### PR TITLE
Release v1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to OSPAC (Open Source Policy as Code) will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.4] - 2025-11-04
+
+### Fixed
+
+**CLI Command Improvements**
+- Fixed `ospac obligations` command returning no output
+- Corrected policy loader integration for obligation data retrieval
+- Updated get_obligations method to properly traverse nested policy structure
+- Resolved obligation policy path resolution for CLI commands
+
+**GitHub Actions Workflow**
+- Removed duplicate release workflow causing PyPI publishing conflicts
+- Consolidated to standard python-publish.yml workflow
+- Fixed action errors during release process
+
+### Changed
+
+**Internal Architecture**
+- Improved PolicyRuntime obligation handling for nested policy files
+- Enhanced policy loader to correctly map obligation policies
+- Standardized workflow configuration to prevent CI/CD conflicts
+
 ## [1.0.3] - 2025-11-04
 
 ### Fixed

--- a/ospac/__init__.py
+++ b/ospac/__init__.py
@@ -4,7 +4,7 @@ OSPAC - Open Source Policy as Code
 A comprehensive policy engine for automated OSS license compliance.
 """
 
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 
 from ospac.runtime.engine import PolicyRuntime
 from ospac.models.license import License

--- a/ospac/runtime/engine.py
+++ b/ospac/runtime/engine.py
@@ -118,10 +118,13 @@ class PolicyRuntime:
         """Get all obligations for the given licenses."""
         obligations = {}
 
-        for license_id in licenses:
-            if "obligations" in self.policies:
-                license_obligations = self.policies["obligations"].get(license_id, {})
-                if license_obligations:
-                    obligations[license_id] = license_obligations
+        # Look for obligations in all obligation policy files
+        for policy_name, policy_data in self.policies.items():
+            if policy_name.startswith("obligations/") and "obligations" in policy_data:
+                for license_id in licenses:
+                    if license_id in policy_data["obligations"]:
+                        if license_id not in obligations:
+                            obligations[license_id] = {}
+                        obligations[license_id].update(policy_data["obligations"][license_id])
 
         return obligations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ospac"
-version = "1.0.3"
+version = "1.0.4"
 description = "Open Source Policy as Code - License compliance policy engine"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
## Summary
- Fixed critical CLI `ospac obligations` command functionality
- Resolved GitHub Actions workflow conflicts
- Improved internal architecture for policy handling

## Changes

### Bug Fixes
- **CLI Commands**: Fixed `ospac obligations` command that was returning no output due to incorrect policy structure traversal
- **CI/CD**: Removed duplicate release.yml workflow that was conflicting with standard python-publish.yml, causing PyPI publishing errors
- **Policy Engine**: Updated get_obligations method to properly handle nested policy file structure

### Testing
- [x] Verified `ospac obligations --licenses Apache-2.0,MIT --format checklist` works correctly
- [x] Confirmed all output formats (text, checklist, markdown) function properly  
- [x] Validated GitHub Actions workflow deduplication
- [x] Tested policy loader integration with obligation files

## Release Notes
Version 1.0.4 addresses critical functionality issues in the CLI and build pipeline, ensuring reliable command execution and package publishing.