### PR TITLE
feat: implement dual licensing for code and dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to OSPAC (Open Source Policy as Code) will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2025-11-05
+
+### Added
+
+**Dual Licensing Implementation**
+- Introduced dual licensing structure for the project
+- Added CC BY-NC-SA 4.0 license for the OSPAC license database
+- Created DATA_LICENSE file with full Creative Commons license text
+- Added LICENSE file to ospac/data/ directory for clarity
+
+### Changed
+
+**License Structure**
+- Software code remains under Apache-2.0 license
+- License database now protected under CC BY-NC-SA 4.0 for non-commercial use only
+- Updated README with comprehensive dual licensing explanation
+- Clear separation between software and data licensing terms
+
+### Documentation
+- Enhanced README license section with detailed breakdown of dual licensing
+- Added guidance for commercial vs non-commercial usage
+- Clarified attribution and share-alike requirements for database usage
+
 ## [1.0.4] - 2025-11-04
 
 ### Fixed
@@ -144,6 +167,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 13 SPDX licenses return 404 from API (fallback data provided)
 - LLM analysis optional but recommended for enhanced accuracy
 
+[1.1.0]: https://github.com/SemClone/ospac/releases/tag/v1.1.0
+[1.0.4]: https://github.com/SemClone/ospac/releases/tag/v1.0.4
 [1.0.3]: https://github.com/SemClone/ospac/releases/tag/v1.0.3
 [1.0.2]: https://github.com/SemClone/ospac/releases/tag/v1.0.2
 [1.0.1]: https://github.com/SemClone/ospac/releases/tag/v1.0.1

--- a/DATA_LICENSE
+++ b/DATA_LICENSE
@@ -1,0 +1,42 @@
+Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
+
+This work is licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
+
+To view a copy of this license, visit:
+http://creativecommons.org/licenses/by-nc-sa/4.0/
+
+or send a letter to:
+Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
+
+=======================================================================
+
+You are free to:
+
+    Share — copy and redistribute the material in any medium or format
+    Adapt — remix, transform, and build upon the material
+
+The licensor cannot revoke these freedoms as long as you follow the license terms.
+
+Under the following terms:
+
+    Attribution — You must give appropriate credit, provide a link to the license,
+    and indicate if changes were made. You may do so in any reasonable manner,
+    but not in any way that suggests the licensor endorses you or your use.
+
+    NonCommercial — You may not use the material for commercial purposes.
+
+    ShareAlike — If you remix, transform, or build upon the material, you must
+    distribute your contributions under the same license as the original.
+
+    No additional restrictions — You may not apply legal terms or technological
+    measures that legally restrict others from doing anything the license permits.
+
+Notices:
+
+    You do not have to comply with the license for elements of the material in
+    the public domain or where your use is permitted by an applicable exception
+    or limitation.
+
+    No warranties are given. The license may not give you all of the permissions
+    necessary for your intended use. For example, other rights such as publicity,
+    privacy, or moral rights may limit how you use the material.

--- a/README.md
+++ b/README.md
@@ -196,7 +196,24 @@ For support, please:
 
 ## License
 
-Apache-2.0 - See [LICENSE](LICENSE) for details.
+This project uses dual licensing:
+
+- **Software Code**: Apache-2.0 - See [LICENSE](LICENSE) for details
+- **License Database**: CC BY-NC-SA 4.0 - See [DATA_LICENSE](DATA_LICENSE) for details
+
+### Software License (Apache-2.0)
+
+All source code in this repository (Python files, scripts, configuration) is licensed under the Apache License, Version 2.0. This allows for commercial use, modification, and distribution of the software.
+
+### Dataset License (CC BY-NC-SA 4.0)
+
+The OSPAC license database located in `ospac/data/` is licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License. This means:
+
+- **Non-Commercial Use Only**: The dataset cannot be used for commercial purposes
+- **Attribution Required**: You must give appropriate credit when using the dataset
+- **Share-Alike**: Any derivatives must be shared under the same CC BY-NC-SA 4.0 license
+
+For academic research, open-source projects, or internal non-commercial use, you are free to use the dataset according to the CC BY-NC-SA 4.0 terms.
 
 ## Authors
 

--- a/ospac/data/LICENSE
+++ b/ospac/data/LICENSE
@@ -1,0 +1,19 @@
+# License for OSPAC Database
+
+The OSPAC license database and all data files in this directory are licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License (CC BY-NC-SA 4.0).
+
+To view a copy of this license, visit:
+http://creativecommons.org/licenses/by-nc-sa/4.0/
+
+## Summary
+
+You are free to:
+- **Share** — copy and redistribute the material in any medium or format
+- **Adapt** — remix, transform, and build upon the material
+
+Under the following terms:
+- **Attribution** — You must give appropriate credit, provide a link to the license, and indicate if changes were made
+- **NonCommercial** — You may not use the material for commercial purposes
+- **ShareAlike** — If you remix, transform, or build upon the material, you must distribute your contributions under the same license
+
+For the full license text, see the DATA_LICENSE file in the repository root.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ospac"
-version = "1.0.4"
+version = "1.1.0"
 description = "Open Source Policy as Code - License compliance policy engine"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
## Summary
- Implements dual licensing structure: Apache-2.0 for code, CC BY-NC-SA 4.0 for dataset
- Protects OSPAC license database for non-commercial use only
- Maintains open source nature of the software code

## Changes

### Added
- `DATA_LICENSE` file with full CC BY-NC-SA 4.0 license text
- `ospac/data/LICENSE` file for clarity on data licensing
- Comprehensive dual licensing explanation in README

### Modified
- Updated README.md with dual licensing section
- Bumped version to 1.1.0 in pyproject.toml
- Added v1.1.0 release notes to CHANGELOG.md

## License Structure

**Software (Apache-2.0)**
- All Python code, scripts, and configuration files
- Allows commercial use, modification, and distribution

**Dataset (CC BY-NC-SA 4.0)**  
- OSPAC license database in `ospac/data/`
- Non-commercial use only
- Attribution required
- Share-alike for derivatives

## Test Plan
- [x] Verify DATA_LICENSE file is present and readable
- [x] Confirm ospac/data/LICENSE file exists
- [x] Check README clearly explains dual licensing
- [x] Validate version bump to 1.1.0
- [x] Review CHANGELOG.md for v1.1.0 entry