### PR TITLE
feat: Add JSON format support and enhance policy templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to OSPAC (Open Source Policy as Code) will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.3] - 2025-11-10
+
+### Added
+
+**Policy Format Support**
+- Added `--format` option to `ospac policy init` command supporting both YAML and JSON output
+- Default output filename now automatically uses selected format extension
+- JSON policy format fully supported for all policy operations and evaluations
+
+### Changed
+
+**Policy Templates - Enhanced Copyleft Restrictions**
+- Updated all policy templates with more consistent and strict copyleft handling
+- Strong copyleft licenses (GPL, AGPL) now set to `deny` across all templates
+- Weak copyleft licenses (LGPL) handling improved:
+  - Mobile template: LGPL now `deny` (app store compliance)
+  - Embedded template: LGPL now `deny` (device distribution complexity)
+  - Web template: LGPL changed from `review` to `deny` (compliance simplification)
+  - Library template: LGPL changed from `review` to `deny` (user restriction prevention)
+  - Desktop template: LGPL remains `review` (dynamic linking flexibility)
+  - Server template: LGPL remains `review` (backend service flexibility)
+- Permissive licenses (MIT, Apache-2.0, BSD) remain `approve` in all templates
+- Added comprehensive remediation messages for all denied licenses
+
+**Policy Command Improvements**
+- Policy init command now generates format-appropriate output files
+- Enhanced validation to work seamlessly with both YAML and JSON formats
+- Improved consistency across all policy template rules
+
 ## [1.2.2] - 2025-11-07
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ospac"
-version = "1.2.2"
+version = "1.2.3"
 description = "Open Source Policy as Code - License compliance policy engine"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
## Summary

This PR adds JSON format support to the policy init command and enhances all policy templates with more consistent and stricter copyleft handling.

## Changes

### Policy Format Support
- Added `--format` option to `ospac policy init` command supporting both YAML and JSON output formats
- Default output filename now automatically uses the selected format extension (`.yaml` or `.json`)
- JSON policy format is fully supported for all policy operations and evaluations
- Both formats work identically with policy validation and evaluation commands

### Policy Template Enhancements
Updated all policy templates with improved copyleft license handling:

**Strong Copyleft (GPL, AGPL)**
- Now set to `deny` with error severity across all templates
- Added comprehensive remediation messages

**Weak Copyleft (LGPL)**
- Mobile template: Changed to `deny` (app store compliance requirements)
- Embedded template: Changed to `deny` (device distribution complexity)
- Web template: Changed from `review` to `deny` (compliance simplification)
- Library template: Changed from `review` to `deny` (prevents user restrictions)
- Desktop template: Remains `review` (dynamic linking flexibility)
- Server template: Remains `review` (backend service flexibility)

**Permissive Licenses (MIT, Apache-2.0, BSD)**
- Remain `approve` in all templates

### Other Changes
- Bumped version to 1.2.3
- Updated CHANGELOG.md with detailed release notes
- Enhanced consistency across all policy template rules

## Testing
- ✅ Generated policies in both JSON and YAML formats
- ✅ Validated both formats work with `ospac policy validate`
- ✅ Verified all templates generate correct rules
- ✅ Confirmed policy evaluation works identically with both formats

## Breaking Changes
None - This is a backward compatible enhancement.