### PR TITLE
chore: release v1.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to OSPAC (Open Source Policy as Code) will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.6] - 2026-01-28
+
+### Fixed
+
+**License Data Lookup**
+- Fixed incorrect file path in `PolicyRuntime.lookup_license_data()` method
+- License JSON files are now correctly loaded from `./data/licenses/json/` directory
+- Resolves issue where license data lookups were failing due to incorrect path construction
+- Aligns runtime engine with the actual directory structure used throughout the codebase
+
 ## [1.2.5] - 2026-01-15
 
 ### Security

--- a/ospac/__init__.py
+++ b/ospac/__init__.py
@@ -4,7 +4,7 @@ OSPAC - Open Source Policy as Code
 A comprehensive policy engine for automated OSS license compliance.
 """
 
-__version__ = "1.2.5"
+__version__ = "1.2.6"
 
 from ospac.runtime.engine import PolicyRuntime
 from ospac.models.license import License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ospac"
-version = "1.2.5"
+version = "1.2.6"
 description = "Open Source Policy as Code - License compliance policy engine"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Release v1.2.6

This PR bumps the version to 1.2.6 and prepares for the next patch release.

### Changes Included

**Fixed in this release:**
- License data lookup path correction (PR #26)
  - Fixed `PolicyRuntime.lookup_license_data()` to use correct path `./data/licenses/json/`
  - Resolves license lookup failures due to incorrect directory structure
  - Aligns with codebase-wide path conventions

### Files Modified
- `pyproject.toml` - Version bump to 1.2.6
- `ospac/__init__.py` - Version bump to 1.2.6  
- `CHANGELOG.md` - Added v1.2.6 release notes

### Release Checklist
- [x] Version bumped in all required files
- [x] CHANGELOG updated with release notes
- [x] All security controls maintained from v1.2.5
- [ ] CI/CD tests passing
- [ ] Ready for PyPI release

cc @ovalenzuela