### PR TITLE
ci: auto-merge data PRs and release on version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - pyproject.toml
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 0
+
+      - name: Read version
+        id: version
+        run: |
+          VERSION=$(python3 -c "
+          import re
+          m = re.search(r'^version = \"(\S+)\"', open('pyproject.toml').read(), re.MULTILINE)
+          print(m.group(1))
+          ")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check tag does not already exist
+        id: tag-check
+        run: |
+          if git ls-remote --tags origin "refs/tags/v${{ steps.version.outputs.version }}" | grep -q .; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build data dump
+        if: steps.tag-check.outputs.exists == 'false'
+        run: |
+          tar -czf "ospac-data-v${{ steps.version.outputs.version }}.tar.gz" \
+            -C ospac data
+
+      - name: Create release
+        if: steps.tag-check.outputs.exists == 'false'
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda  # v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: "v${{ steps.version.outputs.version }}"
+          generate_release_notes: true
+          files: ospac-data-v${{ steps.version.outputs.version }}.tar.gz
+          body: |
+            ## Data dump
+
+            `ospac-data-v${{ steps.version.outputs.version }}.tar.gz` — pre-built OSPAC license dataset (SPDX + LLM analysis). Extract into your project's `ospac/data/` directory to use without running the Python pipeline.
+
+            ## Install
+
+            ```
+            pip install ospac==${{ steps.version.outputs.version }}
+            ```

--- a/.github/workflows/spdx-sync.yml
+++ b/.github/workflows/spdx-sync.yml
@@ -157,6 +157,33 @@ jobs:
               print(f"Validation passed: {len(files)} license files OK")
           EOF
 
+      - name: Bump patch version
+        id: version
+        if: steps.spdx-check.outputs.has_work == 'true' || github.event.inputs.force_reprocess == 'true'
+        run: |
+          python3 - <<'EOF'
+          import re, os
+
+          with open("pyproject.toml", "r") as f:
+              content = f.read()
+
+          m = re.search(r'^version = "(\d+)\.(\d+)\.(\d+)"', content, re.MULTILINE)
+          major, minor, patch = int(m.group(1)), int(m.group(2)), int(m.group(3))
+          new_version = f"{major}.{minor}.{patch + 1}"
+
+          content = re.sub(
+              r'^version = "\d+\.\d+\.\d+"',
+              f'version = "{new_version}"',
+              content, count=1, flags=re.MULTILINE
+          )
+          with open("pyproject.toml", "w") as f:
+              f.write(content)
+
+          print(f"Bumped to {new_version}")
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"new_version={new_version}\n")
+          EOF
+
       - name: Build change summary
         id: summary
         if: always()
@@ -198,9 +225,10 @@ jobs:
       - name: Check for data changes
         id: git-check
         run: |
-          git status --porcelain ospac/data/ | grep -q '.' && echo "changed=true" >> "$GITHUB_OUTPUT" || echo "changed=false" >> "$GITHUB_OUTPUT"
+          git status --porcelain ospac/data/ pyproject.toml | grep -q '.' && echo "changed=true" >> "$GITHUB_OUTPUT" || echo "changed=false" >> "$GITHUB_OUTPUT"
 
       - name: Create pull request
+        id: create-pr
         if: steps.git-check.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676  # v7
         with:
@@ -208,9 +236,15 @@ jobs:
           commit-message: "data: sync SPDX ${{ steps.spdx-check.outputs.spdx_version }} — ${{ steps.spdx-check.outputs.new_count }} new, ${{ steps.spdx-check.outputs.deprecated_flag_count }} deprecated"
           branch: "data/spdx-sync-${{ steps.spdx-check.outputs.spdx_version }}"
           delete-branch: true
-          title: "data: SPDX sync ${{ steps.spdx-check.outputs.spdx_version }} (${{ steps.spdx-check.outputs.new_count }} new licenses)"
+          title: "data: SPDX sync ${{ steps.spdx-check.outputs.spdx_version }} — v${{ steps.version.outputs.new_version }}"
           body: ${{ steps.summary.outputs.pr_body }}
           labels: "data,automated"
+
+      - name: Enable auto-merge
+        if: steps.git-check.outputs.changed == 'true' && steps.create-pr.outputs.pull-request-number != ''
+        run: gh pr merge --auto --squash "${{ steps.create-pr.outputs.pull-request-number }}"
+        env:
+          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
 
       - name: No changes detected
         if: steps.git-check.outputs.changed == 'false'


### PR DESCRIPTION
Two additions to the automation:

**Auto-merge**: spdx-sync now bumps the patch version in `pyproject.toml` as part of the data update commit, then calls `gh pr merge --auto --squash` immediately after creating the data PR. Once CI passes the PR merges itself.

**Release workflow**: new `release.yml` triggers on any push to main that touches `pyproject.toml`. It reads the version, checks the tag doesn't already exist, builds `ospac-data-vX.Y.Z.tar.gz` from `ospac/data/`, creates a GitHub release with it attached, and generates release notes. The existing `python-publish.yml` fires on the release event and handles PyPI.