### PR TITLE
fix: repair v1.2.0 migration leftovers and release 1.3.0

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 [run]
-source = osslili
+source = ospac
 omit =
     */tests/*
     */test_*.py

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.1
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
           body: |
             ## Data dump
 
-            `ospac-data-v${{ steps.version.outputs.new }}.tar.gz` — pre-built OSPAC license dataset (SPDX + LLM analysis). Extract into your project's `ospac/data/` directory to use without running the Python pipeline.
+            `ospac-data-v${{ steps.version.outputs.new }}.tar.gz`: pre-built OSPAC license dataset (SPDX + LLM analysis). Extract into your project's `ospac/data/` directory to use without running the Python pipeline.
 
             ## Install
 

--- a/.github/workflows/spdx-sync.yml
+++ b/.github/workflows/spdx-sync.yml
@@ -194,10 +194,10 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
           token: ${{ secrets.WORKFLOW_PAT }}
-          commit-message: "data: sync SPDX ${{ steps.spdx-check.outputs.spdx_version }} — ${{ steps.spdx-check.outputs.new_count }} new, ${{ steps.spdx-check.outputs.deprecated_flag_count }} deprecated"
+          commit-message: "data: sync SPDX ${{ steps.spdx-check.outputs.spdx_version }}: ${{ steps.spdx-check.outputs.new_count }} new, ${{ steps.spdx-check.outputs.deprecated_flag_count }} deprecated"
           branch: "data/spdx-sync-${{ steps.spdx-check.outputs.spdx_version }}"
           delete-branch: true
-          title: "data: SPDX sync ${{ steps.spdx-check.outputs.spdx_version }} — v${{ steps.version.outputs.new_version }}"
+          title: "data: SPDX sync ${{ steps.spdx-check.outputs.spdx_version }} (v${{ steps.version.outputs.new_version }})"
           body: ${{ steps.summary.outputs.pr_body }}
           labels: "data,automated"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,26 @@ that previously returned `allow` may now correctly return `deny`, so builds that
 - The default-policy notice suggested `ospac init`, which does not exist. It now says
   `ospac policy init`.
 
+**Six LGPL identifiers were classified as strong copyleft**
+- `LGPL-2.0`, `LGPL-2.0+`, `LGPL-2.1`, `LGPL-2.1+`, `LGPL-3.0` and `LGPL-3.0+` were typed
+  `copyleft_strong`, while the modern identifiers they are deprecated aliases of
+  (`LGPL-2.0-only`, `LGPL-2.1-only` and so on) were correctly `copyleft_weak`. An alias must
+  classify identically to the identifier it aliases, so these were wrong.
+- The correction table in the data pipeline already declared LGPL as weak copyleft, but
+  listed only the modern spellings, so the deprecated ones kept the misclassification. Those
+  bare spellings are also the ones that appear most often in real package metadata.
+- Consequence: policy rules matching `license_type: copyleft_strong` denied these
+  identifiers where the modern spelling was only flagged for review. The `desktop` and
+  `server` templates denied `LGPL-2.1` and reviewed `LGPL-3.0-only`, which are the same
+  obligation in practice.
+- This was inert until the `license_type` fix above, because no rule matching on
+  `license_type` ever fired. Fixing evaluation made the data defect start affecting
+  decisions, so both are fixed together.
+- `type` and the derived `key_requirements` are corrected in the six records and in
+  `index.json`, the aliases are added to the pipeline's correction table so regeneration
+  keeps them, and a test asserts the invariant directly against the shipped dataset for
+  every deprecated alias, not just LGPL.
+
 ### Changed
 
 - `__version__` is read from installed package metadata, making `pyproject.toml` the single

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,92 @@ All notable changes to OSPAC (Open Source Policy as Code) will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-08-11
+
+This release repairs a group of defects left behind by the v1.2.0 migration from YAML to
+JSON. That migration updated the dataset layout and the main evaluation paths, but several
+peripheral code paths kept reading the old schema and the old file locations. The most
+serious of them caused policy evaluation to fail open.
+
+Minor rather than patch, because the fail-open fix changes evaluation outcomes: a policy
+that previously returned `allow` may now correctly return `deny`, so builds that passed on
+1.2.11 can legitimately start failing.
+
+### Fixed
+
+**Policy templates matched nothing and approved everything (fail-open)**
+- Policies created by `ospac policy init` match on `license_type`, but `ospac evaluate`
+  never placed `license_type` in the evaluation context. Rules naming an absent context
+  field are skipped, so every generated template matched no rules and returned `allow`.
+- A mobile policy written to deny GPL therefore approved GPL. The result was permissive
+  rather than an error, so nothing surfaced the problem in CI.
+- `evaluate` now resolves each license's type from the dataset, and `license_type` matching
+  accepts any evaluated license, mirroring the existing behaviour of the `license` key.
+  Evaluating several licenses at once involves more than one type, so a single scalar could
+  not express the case.
+- `check_compatibility()` was missing the same context field and can now drive
+  `license_type` rules.
+
+**Crash on `action: review`**
+- The bundled enterprise policy and the desktop and server templates use `action: review`,
+  but `ActionType` defines only `FLAG_FOR_REVIEW`, so `ActionType["REVIEW"]` raised
+  `KeyError` and the CLI exited with `Error: 'REVIEW'`. `review` is now accepted as
+  shorthand for `flag_for_review`. The fail-open bug had prevented those rules from ever
+  firing, which is why the crash was never observed.
+
+**`ospac data validate` could not validate the shipped dataset**
+- It looked only for `licenses/spdx/*.yaml`, the pre-1.2.0 layout, which no longer ships,
+  and always exited with `SPDX directory not found`. It now validates the JSON dataset,
+  defaults to the packaged data directory, and supports `--strict`.
+
+**`ospac data show -f text` printed empty output**
+- The text formatter read `category`, `permissions` and `conditions`, which the JSON schema
+  renamed to `type`, `properties` and `requirements`, so it printed `Category: None` and
+  empty sections. It now shows type, permissions, conditions, limitations, obligations, key
+  requirements and SPDX metadata, marks deprecated identifiers, and renders false booleans
+  visibly instead of omitting them. JSON and YAML output are unchanged.
+
+**`PolicyRuntime.get_obligations()` always returned an empty dict**
+- It read `obligations` from the top level of a record that wraps its contents in a
+  `license` key, so the lookup always missed.
+
+**Obligation enrichment never ran for installed users**
+- `_enhance_result_with_obligations()` resolved a working-directory-relative `data/` path
+  instead of the packaged data directory, so it silently did nothing unless the process
+  happened to run beside a `data/` folder. It now resolves through
+  `PolicyRuntime.resolve_data_dir()`.
+
+**Aggregated requirements were not reproducible**
+- `PolicyResult.aggregate()` deduplicated through a set, so `requirements` came back in a
+  different order on every run, which broke diffing evaluation output and storing it as
+  compliance evidence. Deduplication now preserves first-seen order.
+
+**Incorrect command name in a hint**
+- The default-policy notice suggested `ospac init`, which does not exist. It now says
+  `ospac policy init`.
+
+### Changed
+
+- `__version__` is read from installed package metadata, making `pyproject.toml` the single
+  source of truth. The SPDX sync workflow bumps only `pyproject.toml`, so the previous
+  hardcoded literal fell behind every month, and `ospac --version` and `ospac.__version__`
+  could disagree.
+- License record validation moved into `ospac.utils.data_validation`, shared by the
+  `data validate` command and `scripts/validate_data.py` instead of being duplicated.
+- Coverage configuration pointed at the `osslili` package rather than `ospac`. The dead
+  `[tool.pytest.ini_options]` block in `pyproject.toml`, shadowed by `pytest.ini`, was
+  removed so there is one source of truth.
+- `MANIFEST.in` referenced a nonexistent `ospac/ospac/data` path and an `obligations`
+  directory that does not exist, and omitted the dataset's CC BY-NC-SA notice.
+
+### Added
+
+- `tests/test_cli.py`, the first CLI-level tests in the project. The absence of any test
+  exercising the CLI's own context construction is what allowed the fail-open defect to
+  ship with a green suite: the existing tests hand-build contexts that already contain
+  `license_type`, so nothing covered the code that has to derive it.
+- Documentation site at https://semclone.github.io/ospac/ built from `docs/`.
+
 ## [1.2.6] - 2026-01-28
 
 ### Fixed

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,8 @@
 include README.md
 include LICENSE
-recursive-include ospac/ospac/data *.json *.yaml *.yml *.txt
-recursive-include ospac/ospac/data/licenses *
-recursive-include ospac/ospac/data/compatibility *
-recursive-include ospac/ospac/data/obligations *
-recursive-include ospac/policies *.yaml
+include ospac/data/LICENSE
+recursive-include ospac/data *.json *.yaml *.yml *.txt
+recursive-include ospac/data/licenses *
+recursive-include ospac/data/compatibility *
+recursive-include ospac/defaults *.yaml
+recursive-include policies *.yaml

--- a/README.md
+++ b/README.md
@@ -4,21 +4,21 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![PyPI version](https://img.shields.io/pypi/v/ospac.svg)](https://pypi.org/project/ospac/)
 
-OSPAC answers a narrow question: given a set of licenses and something you intend to do with them, is that allowed? It reads the licenses, applies a policy you keep in Git, and returns an action — approve, deny, or flag for review — along with the obligations you take on if you proceed.
+OSPAC answers a narrow question: given a set of licenses and something you intend to do with them, is that allowed? It reads the licenses, applies a policy you keep in Git, and returns an action (approve, deny, or flag for review) along with the obligations you take on if you proceed.
 
 The answer lives in a policy file, not in OSPAC's code. Compliance rules differ between a mobile app and an internal service, and they change as legal guidance changes, so OSPAC treats those rules as data: versioned, reviewable in a pull request, and testable.
 
-It ships with a complete SPDX license dataset — 729 licenses — so it works offline the moment it is installed. Nothing needs to be generated or downloaded first.
+It ships with the complete SPDX license list, so it works offline the moment it is installed. Nothing needs to be generated or downloaded first.
 
 ## Features
 
-- **Policy as Code** — compliance rules in YAML or JSON, not hardcoded
-- **Complete SPDX dataset** — 729 licenses bundled in the wheel, no setup step
-- **Distribution-aware** — the same licenses can pass for `internal` and fail for `mobile`
-- **Compatibility engine** — per-linking-context rules for static and dynamic linking
-- **Obligation tracking** — derived deterministically from structured license fields
-- **JSON-first output** — every command defaults to JSON for scripting and MCP
-- **Offline** — evaluation makes no network calls and consults no model
+- **Policy as Code**: compliance rules in YAML or JSON, not hardcoded
+- **Complete SPDX dataset**: every SPDX license bundled in the wheel, no setup step
+- **Distribution-aware**: the same licenses can pass for `internal` and fail for `mobile`
+- **Compatibility engine**: per-linking-context rules for static and dynamic linking
+- **Obligation tracking**: derived deterministically from structured license fields
+- **JSON-first output**: every command defaults to JSON for scripting and MCP
+- **Offline**: evaluation makes no network calls and consults no model
 
 ## Installation
 
@@ -54,7 +54,7 @@ ospac obligations -l MIT -f checklist
 ospac policy init --template mobile --output mobile_policy.yaml
 ```
 
-The distribution type is what makes the same input produce different answers — `-d mobile` is stricter than `-d internal` because the policy says so, not because OSPAC hard-codes it.
+The distribution type is what makes the same input produce different answers. `-d mobile` is stricter than `-d internal` because the policy says so, not because OSPAC hard-codes it.
 
 ## How it works
 
@@ -68,7 +68,7 @@ You never run the generation pipeline to use OSPAC. See [The dataset](https://se
 
 ### Two things worth knowing early
 
-**There is always a policy in play.** With no `--policy-dir`, OSPAC loads a bundled default enterprise policy and says so on stderr. That default is opinionated — it denies GPL for commercial distribution and flags LGPL static linking for review. Treat it as a starting point to copy, not as neutral ground.
+**There is always a policy in play.** With no `--policy-dir`, OSPAC loads a bundled default enterprise policy and says so on stderr. That default is opinionated: it denies GPL for commercial distribution and flags LGPL static linking for review. Treat it as a starting point to copy, not as neutral ground.
 
 **Exit codes do not reflect the decision.** `ospac evaluate` and `ospac check` exit 0 even when the answer is deny. Parse the JSON in CI:
 
@@ -108,12 +108,12 @@ Full reference at [Python API](https://semclone.github.io/ospac/api/).
 
 Full documentation is at **[semclone.github.io/ospac](https://semclone.github.io/ospac/)**.
 
-- [Overview](https://semclone.github.io/ospac/) — what OSPAC does, installing, first run
-- [Commands](https://semclone.github.io/ospac/commands/) — every CLI command and flag, with real output
-- [Policies](https://semclone.github.io/ospac/policies/) — rule schema, how matching works, templates
-- [The dataset](https://semclone.github.io/ospac/dataset/) — how license data is shaped, shipped, and regenerated
-- [Python API](https://semclone.github.io/ospac/api/) — using OSPAC as a library
-- [Integration](https://semclone.github.io/ospac/integration/) — CI, the SEMCL.ONE toolchain, MCP
+- [Overview](https://semclone.github.io/ospac/): what OSPAC does, installing, first run
+- [Commands](https://semclone.github.io/ospac/commands/): every CLI command and flag, with real output
+- [Policies](https://semclone.github.io/ospac/policies/): rule schema, how matching works, templates
+- [The dataset](https://semclone.github.io/ospac/dataset/): how license data is shaped, shipped, and regenerated
+- [Python API](https://semclone.github.io/ospac/api/): using OSPAC as a library
+- [Integration](https://semclone.github.io/ospac/integration/): CI, the SEMCL.ONE toolchain, MCP
 
 ## SEMCL.ONE toolchain
 
@@ -148,9 +148,9 @@ See [CONTRIBUTING.md](CONTRIBUTING.md). Documentation sources live in `docs/` an
 
 This project is dual-licensed, and the split matters.
 
-**Software code** — Apache-2.0. All source in this repository (Python, scripts, configuration). Commercial use, modification, and distribution are permitted. See [LICENSE](LICENSE).
+**Software code**: Apache-2.0. All source in this repository (Python, scripts, configuration). Commercial use, modification, and distribution are permitted. See [LICENSE](LICENSE).
 
-**License database** — CC BY-NC-SA 4.0. The dataset in `ospac/data/` is Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International: non-commercial use only, attribution required, derivatives shared alike. See [DATA_LICENSE](DATA_LICENSE).
+**License database**: CC BY-NC-SA 4.0. The dataset in `ospac/data/` is Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International: non-commercial use only, attribution required, derivatives shared alike. See [DATA_LICENSE](DATA_LICENSE).
 
 Installing OSPAC and running it inside a commercial organization to check your own compliance is ordinary internal use. Redistributing the dataset, or building a commercial product on top of it, is what the NonCommercial term restricts. If you are unsure which side of that line you are on, that is a question for your counsel.
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,5 @@
 title: ospac
-description: Open Source Policy as Code — license compliance policy engine
+description: Open Source Policy as Code, a license compliance policy engine
 url: https://semclone.github.io
 baseurl: /ospac
 
@@ -20,7 +20,7 @@ search:
 heading_anchors: true
 
 # Several pages flag known issues (a fail-open in the policy templates, two stale
-# formatters). just-the-docs only styles a callout if it is declared here — otherwise
+# formatters). just-the-docs only styles a callout if it is declared here, otherwise
 # `{: .warning }` renders as an ordinary blockquote and the warning loses its emphasis.
 callouts_level: quiet
 callouts:

--- a/docs/api.md
+++ b/docs/api.md
@@ -29,7 +29,7 @@ runtime = PolicyRuntime(skip_default=True)      # no policy at all
 
 `PolicyRuntime._using_default` tells you whether the default policy was loaded. It is
 underscore-prefixed but it is what the CLI checks to emit its warning, and it is worth
-asserting on in automation — see the fail-open discussion in
+asserting on in automation. See the fail-open discussion in
 [Policies]({{ site.baseurl }}/policies/#nothing-matching-means-allow).
 
 ```python
@@ -138,7 +138,7 @@ Where ospac reads license data from. Pass a path to override.
 > `PolicyRuntime.get_obligations(["MIT"])` returns `{}` for every license. It reads
 > `lookup_license_data()["obligations"]`, but obligations live at
 > `["license"]["obligations"]`, so the lookup always misses. The CLI's `ospac obligations`
-> is unaffected — it uses a separate code path.
+> is unaffected: it uses a separate code path.
 >
 > Read obligations directly until this is fixed:
 >
@@ -187,7 +187,7 @@ Both describe the same duties. Use the dataset's list when you want the same tex
 prints.
 
 `is_compatible_with` is a model-level convenience that reads the license's own
-`compatibility` block. It does not consult your policy — use `runtime.check_compatibility()`
+`compatibility` block. It does not consult your policy. Use `runtime.check_compatibility()`
 when the answer should respect policy.
 
 ## ComplianceResult and PolicyResult
@@ -211,8 +211,8 @@ from ospac import ComplianceResult
 ComplianceResult.from_policy_result(policy_result)   # convert
 ```
 
-`PolicyResult.aggregate([...])` merges several results, taking the most severe action —
-this is what produces the `rule_id: "aggregate"` you see in CLI output.
+`PolicyResult.aggregate([...])` merges several results, taking the most severe action.
+This is what produces the `rule_id: "aggregate"` you see in CLI output.
 
 ## A CI gate
 
@@ -252,5 +252,5 @@ Pair it with a case that must be denied, so the gate is proven to still bite:
 ```python
 gpl = runtime.evaluate({**base_context, "licenses": ["GPL-3.0"],
                         "licenses_found": ["GPL-3.0"]})
-assert gpl.action == ActionType.DENY, "policy stopped denying GPL — rules are inert"
+assert gpl.action == ActionType.DENY, "policy stopped denying GPL, rules are inert"
 ```

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -44,7 +44,7 @@ ospac evaluate -l LICENSES [-d DIST] [-c CONTEXT] [-p DIR] [-o FORMAT]
 The distribution type is what makes the same input produce different answers:
 
 ```bash
-ospac evaluate -l GPL-3.0 -d mobile       # deny — app store terms
+ospac evaluate -l GPL-3.0 -d mobile       # deny, app store terms
 ospac evaluate -l GPL-3.0 -d open_source  # policy-dependent
 ospac evaluate -l MIT -d embedded         # approve
 ```
@@ -74,7 +74,7 @@ $ ospac evaluate -l GPL-3.0 -d mobile
 `action` is one of `approve`, `deny`, or `flag_for_review`. When several rules match, the
 results are aggregated and the most severe action wins, reported under the synthetic
 `rule_id` of `aggregate`. `using_default_policy` tells you whether the decision came from
-your policy or the bundled one — worth asserting on in CI.
+your policy or the bundled one, worth asserting on in CI.
 
 Linking context matters for weak copyleft, where the same license is fine dynamically and
 needs review statically:
@@ -116,7 +116,7 @@ $ ospac check GPL-2.0 Apache-2.0
 }
 ```
 
-GPL-2.0 and Apache-2.0 are the canonical incompatible pair — Apache's patent termination
+GPL-2.0 and Apache-2.0 are the canonical incompatible pair. Apache's patent termination
 clause is an additional restriction GPL-2.0 does not permit. Text output is more readable
 when a human is watching:
 
@@ -158,7 +158,7 @@ MIT:
 ```
 
 The `json` format returns the full license record under `license_data`, not just the
-obligation strings — the same structure documented in
+obligation strings, the same structure documented in
 [The dataset]({{ site.baseurl }}/dataset/). That is the format to consume programmatically,
 because it carries `requirements`, `properties` and `compatibility` alongside the
 human-readable obligation list.
@@ -239,7 +239,7 @@ $ ospac data show MIT -f json
 > `-f text` is currently broken. It reads field names from the pre-1.2.0 schema
 > (`category`, `permissions`, `conditions`), which the JSON dataset no longer uses, so it
 > prints `Category: None` and empty Permissions and Conditions sections. The data is
-> fine — only this formatter is stale. Use `-f json` or `-f yaml`.
+> fine, only this formatter is stale. Use `-f json` or `-f yaml`.
 
 License IDs are validated before use, so a path-traversal attempt in the ID is rejected
 rather than resolved. An unknown ID exits non-zero and lists a sample of valid IDs.
@@ -247,7 +247,7 @@ rather than resolved. An unknown ID exits non-zero and lists a sample of valid I
 ### data generate
 
 Regenerates the license dataset from upstream SPDX. This is a maintainer operation that
-normally runs in CI once a month — you do not need it to use ospac.
+normally runs in CI once a month, you do not need it to use ospac.
 
 ```
 ospac data generate [-o DIR] [--use-llm] [--llm-provider P] [--llm-model M]
@@ -293,5 +293,5 @@ ospac data download-spdx [-o DIR] [--force]
 > python scripts/validate_data.py --data-dir ospac/data
 > ```
 >
-> That script checks all 729 records against the current JSON schema and reports errors
+> That script checks every record against the current JSON schema and reports errors
 > and warnings separately, with a `--strict` flag to fail on warnings.

--- a/docs/dataset.md
+++ b/docs/dataset.md
@@ -10,7 +10,7 @@ description: How the license data is shaped, how it ships with the package, and 
 ospac's decisions are only as good as its license data, so it is worth knowing what that
 data is, where it comes from, and what it does and does not claim.
 
-The short version: 729 SPDX licenses, one JSON file each, bundled inside the installed
+The short version: every license in the SPDX list, one JSON file each, bundled inside the installed
 wheel, regenerated monthly by an automated pipeline that opens a pull request for review.
 
 ## How it ships
@@ -26,7 +26,7 @@ ospac/data/
 ├── LICENSE                       # CC BY-NC-SA 4.0, applies to this directory
 ├── licenses/
 │   └── json/
-│       ├── MIT.json              # one file per license, 729 total
+│       ├── MIT.json              # one file per license
 │       ├── Apache-2.0.json
 │       └── ...
 └── compatibility/
@@ -41,14 +41,14 @@ ospac/data/
 One file per license is deliberate. Looking up a single license reads a single small file
 rather than parsing a multi-megabyte database, which is what makes CLI startup fast.
 `index.json` exists so that listing and category questions can be answered without opening
-729 files:
+every license file:
 
 ```json
 {
   "version": "1.0",
-  "generated": "2026-06-10T20:08:59.408681",
-  "spdx_list_version": "3dfd9aa",
-  "total_licenses": 729,
+  "generated": "2026-08-01T03:04:52.358635",
+  "spdx_list_version": "e4c1f27",
+  "total_licenses": 733,
   "licenses": {
     "MIT": {
       "name": "MIT License",
@@ -67,7 +67,7 @@ dataset is traceable to a specific upstream SPDX commit and a generation timesta
 ### The dataset is licensed separately from the code
 
 ospac is dual-licensed, and this trips people up. The code is Apache-2.0. The dataset in
-`ospac/data/` is **CC BY-NC-SA 4.0** — non-commercial, attribution required, share-alike.
+`ospac/data/` is **CC BY-NC-SA 4.0**: non-commercial, attribution required, share-alike.
 See [`DATA_LICENSE`](https://github.com/SemClone/ospac/blob/main/DATA_LICENSE).
 
 Installing ospac and running it inside a commercial organization to check your own
@@ -128,8 +128,8 @@ the file on disk has the extra nesting level.
       "is_fsf_libre": true,
       "is_deprecated": false
     },
-    "generated": "2026-06-10T20:08:59.287920",
-    "spdx_list_version": "3dfd9aa"
+    "generated": "2026-08-01T03:04:52.211970",
+    "spdx_list_version": "e4c1f27"
   }
 }
 ```
@@ -139,7 +139,7 @@ the file on disk has the extra nesting level.
 | `type` | Family: `permissive`, `copyleft_weak`, `copyleft_strong`, `proprietary`, `public_domain`. Policy rules match on this via `license_type`. |
 | `properties` | What the license lets you do. |
 | `requirements` | Conditions you must satisfy. The booleans here drive `obligations`. |
-| `limitations` | What the license withholds — warranty, liability, trademark grant. |
+| `limitations` | What the license withholds: warranty, liability, trademark grant. |
 | `compatibility` | Per-linking-context rules. `category:any` means compatible with every family. |
 | `contamination_effect` | How far copyleft reaches: `none`, `file`, `library`, `project`. |
 | `obligations` | Human-readable duties, derived from `requirements`. |
@@ -150,14 +150,14 @@ the file on disk has the extra nesting level.
 > `ospac_license_database.json` with `category`, `permissions` and `conditions` fields, that
 > describes the pre-1.2.0 layout and no longer applies. The fields are now `type`,
 > `properties` and `requirements`, and the data is split per license. Two CLI formatters
-> still read the old names — see the warnings in
+> still read the old names. See the warnings in
 > [Commands]({{ site.baseurl }}/commands/#data-show).
 
 ### Compatibility is stored sparsely
 
 `compatibility/metadata.json` records `"format": "sparse"` and
-`"default_status": "unknown"`. Pairs are not enumerated — 729 licenses would mean over
-265,000 pairs. Instead, licenses are grouped into families in `categories.json`, and only
+`"default_status": "unknown"`. Pairs are not enumerated, since the full list would mean over
+250,000 pairs. Instead, licenses are grouped into families in `categories.json`, and only
 the rules *between* families are stored, in `relationships/`. A lookup resolves each
 license to its family and consults that rule.
 
@@ -167,7 +167,7 @@ to compatible. Absence of a recorded conflict is not evidence of compatibility.
 ## How it is regenerated
 
 The dataset is rebuilt from upstream SPDX by `ospac data generate`, implemented in
-`ospac/pipeline/data_generator.py`. In normal operation you never run this — CI does, and
+`ospac/pipeline/data_generator.py`. In normal operation you never run this. CI does, and
 the result reaches you as a released version.
 
 ### The monthly pipeline
@@ -188,8 +188,8 @@ be triggered manually with `workflow_dispatch`. It does this:
 5. **Open a pull request** labelled `data,automated`, with a body summarising the SPDX
    version, new license IDs, and deprecation flags changed, then enable auto-merge.
 
-So dataset changes arrive as reviewable pull requests with a diff you can read — the commit
-history shows them as `data: sync SPDX <version> — N new, M deprecated`. Deprecation
+So dataset changes arrive as reviewable pull requests with a diff you can read. The commit
+history shows them as `data: sync SPDX <version>, N new, M deprecated`. Deprecation
 flagging (step 1b) happens without an LLM, since it only copies an upstream boolean.
 
 ### Where the LLM fits, and where it does not
@@ -197,7 +197,7 @@ flagging (step 1b) happens without an LLM, since it only copies an upstream bool
 An LLM reads license texts during generation to classify a license's family, permissions and
 conditions. Providers are OpenAI, Anthropic Claude, and local Ollama
 (`ospac/pipeline/llm_providers.py`); CI uses OpenAI. This is a maintainer-time step. The
-installed tool never calls a model, and `pip install ospac` does not pull an LLM SDK — that
+installed tool never calls a model, and `pip install ospac` does not pull an LLM SDK. That
 is what the `[llm]` extra is for.
 
 Two mechanisms exist because raw LLM output was not trustworthy enough:
@@ -206,7 +206,7 @@ Two mechanisms exist because raw LLM output was not trustworthy enough:
 computed deterministically from the `requirements` and `properties` booleans, because
 LLM-written prose for these fields came back uniformly generic. `disclose_source: true`
 always produces "Provide or offer access to complete source code", for every license, with
-identical wording. So obligation text is a mechanical function of the structured fields — if
+identical wording. So obligation text is a mechanical function of the structured fields. If
 an obligation looks wrong, the underlying boolean is wrong.
 
 **Known misclassifications are overridden.** A correction table pins fields that LLMs
@@ -215,7 +215,7 @@ classified as copyleft with `same_license` and `disclose_source` set, which is s
 and would have denied Apache-2.0 across copyleft policy rules. The table also covers
 MPL-2.0 and CC0-1.0.
 
-The design assumption is that the LLM is a useful first pass over 729 license texts and not
+The design assumption is that the LLM is a useful first pass over hundreds of license texts and not
 an authority. Validation, deterministic derivation, human PR review, and the correction
 table all exist to catch it being wrong.
 
@@ -240,7 +240,7 @@ Point ospac at your own dataset with `--data-dir`, which `obligations` accepts:
 ospac obligations -l MIT -d ./data
 ```
 
-Notes on cost and correctness. `--force-reprocess` reanalyzes all 729 licenses and is the
+Notes on cost and correctness. `--force-reprocess` reanalyzes every license and is the
 expensive path; without it, generation is a delta over what already exists, and progress is
 tracked so an interrupted run resumes. `--limit` bounds a trial run. Regenerating a record
 does not preserve manual edits, so corrections belong in the correction table rather than in
@@ -253,8 +253,8 @@ the output files.
 ```bash
 $ python scripts/validate_data.py --data-dir ospac/data
 ────────────────────────────────────────────────────────────
-  Total files  : 729
-  Clean        : 728
+  Total files  : 733
+  Clean        : 732
   Warnings     : 1
   Errors       : 0
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ permalink: /
 
 ospac answers a narrow question: given a set of licenses and something you intend to do
 with them, is that allowed? It reads the licenses, applies a policy you can keep in Git,
-and returns an action — approve, deny, or flag for review — along with the obligations
+and returns an action (approve, deny, or flag for review) along with the obligations
 you take on if you proceed.
 
 The point is that the answer lives in a policy file, not in ospac's code. Compliance
@@ -72,8 +72,8 @@ Requirements:
   • Include MIT license text
 ```
 
-The same licenses can produce a different answer under a different distribution type —
-that is the whole idea. `-d mobile` is stricter than `-d internal`, because the policy
+The same licenses can produce a different answer under a different distribution type.
+That is the whole idea. `-d mobile` is stricter than `-d internal`, because the policy
 says so, not because ospac hard-codes it.
 
 And ask what you owe if you do ship something:
@@ -90,12 +90,12 @@ MIT:
 ## Two things worth knowing early
 
 **There is always a policy in play.** With no `--policy-dir`, ospac loads a bundled
-default enterprise policy and says so on stderr. That default is opinionated — it denies
+default enterprise policy and says so on stderr. That default is opinionated: it denies
 GPL for commercial distribution and flags LGPL static linking for review. Treat it as a
 starting point to copy, not as neutral ground. `ospac policy init` writes one you own.
 
 **ospac is offline.** Evaluation reads the bundled dataset and your policy files; it makes
-no network calls and consults no model. LLMs appear in exactly one place — regenerating the
+no network calls and consults no model. LLMs appear in exactly one place, regenerating the
 dataset, a maintainer task described in [The dataset]({{ site.baseurl }}/dataset/). The tool
 you install does not use them.
 

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -33,7 +33,7 @@ ACTION=$(ospac evaluate -l "$LICENSES" -d mobile | jq -r '.result.action')
 [ "$ACTION" = "deny" ] && { echo "blocked"; exit 1; }
 ```
 
-Non-zero exits are reserved for real failures — an unknown license ID, an unreadable
+Non-zero exits are reserved for real failures: an unknown license ID, an unreadable
 policy, a malformed dataset.
 
 ## A CI gate that cannot pass by accident
@@ -93,14 +93,14 @@ jobs:
           ACTION=$(ospac evaluate -l GPL-3.0 -d mobile -p ./compliance-policy.yaml \
             | jq -r '.result.action')
           if [ "$ACTION" != "deny" ]; then
-            echo "::error::GPL-3.0 was not denied — policy rules are not matching"
+            echo "::error::GPL-3.0 was not denied, policy rules are not matching"
             exit 1
           fi
 ```
 
 That last step is the one people leave out. Because unmatched rules produce `allow`, a
 policy that stops matching looks identical to a clean codebase. See
-[Policies]({{ site.baseurl }}/policies/) for why rules go inert — most often a `when` clause
+[Policies]({{ site.baseurl }}/policies/) for why rules go inert. Most often a `when` clause
 naming a context field that is not populated.
 
 ### Reporting into a pull request
@@ -154,7 +154,7 @@ ospac evaluate -l "$LICENSES" -d mobile
 }
 ```
 
-Note that `approve` still carries `requirements` — permission to ship is not the same as
+Note that `approve` still carries `requirements`. Permission to ship is not the same as
 having nothing to do. Feed those into your NOTICE file.
 
 {: .warning }
@@ -169,7 +169,7 @@ having nothing to do. Feed those into your NOTICE file.
 > ```
 >
 > The contents are stable; only the order moves. Do not diff this array between runs or
-> commit it as evidence unchanged — sort it first (`jq '.result.requirements | sort'`), or
+> commit it as evidence unchanged. Sort it first (`jq '.result.requirements | sort'`), or
 > compare as a set.
 
 Install the neighbours with the extra:
@@ -196,7 +196,7 @@ check rather than guess at licence rules. The ospac-backed tools include:
 | `get_license_details` | Full dataset record |
 | `generate_legal_notices` | NOTICE file content |
 
-JSON-first output is what makes this work — the same structures documented here are what
+JSON-first output is what makes this work: the same structures documented here are what
 the agent receives.
 
 ## Docker
@@ -216,8 +216,8 @@ docker run --rm ospac evaluate -l "MIT,GPL-3.0" -d mobile -p /policy.yaml
 ```
 
 Pin the version when the answer needs to be reproducible. Dataset changes ship in patch
-releases — see [The dataset]({{ site.baseurl }}/dataset/#the-monthly-pipeline) — so
-`ospac==1.2.10` fixes both the code and the licence data behind a decision, which matters if
+releases (see [The dataset]({{ site.baseurl }}/dataset/#the-monthly-pipeline)), so
+`ospac==1.3.0` fixes both the code and the licence data behind a decision, which matters if
 you are keeping compliance evidence.
 
 ## Pre-commit
@@ -260,6 +260,6 @@ case "$(echo "$RESULT" | jq -r '.result.action')" in
   deny)            echo "blocked"; exit 1 ;;
   flag_for_review) echo "needs review" ;;
   approve)         echo "ok" ;;
-  allow)           echo "no rule matched — check the policy covers $DIST"; exit 1 ;;
+  allow)           echo "no rule matched, check the policy covers $DIST"; exit 1 ;;
 esac
 ```

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -51,8 +51,8 @@ policy in it is loaded and all rules are pooled together.
 Three things govern the outcome, and all three surprise people at least once.
 
 **Every key in `when` must match.** Conditions are ANDed. A rule with both
-`distribution_type` and `license` fires only when both hold. To express OR, use a list —
-`distribution_type: ["mobile", "web"]` matches either — or write separate rules.
+`distribution_type` and `license` fires only when both hold. To express OR, use a list.
+`distribution_type: ["mobile", "web"]` matches either, or write separate rules.
 
 **A missing context field never matches.** If `when` names a field that is not in the
 evaluation context, the rule is skipped. It does not match loosely and it does not error;
@@ -100,7 +100,7 @@ values are conventionally more important.
 > open, so it will not draw attention to itself in CI.
 >
 > Until this is fixed, match on `license` with explicit SPDX IDs instead of on
-> `license_type`. That path works — it is what the bundled default enterprise policy uses,
+> `license_type`. That path works: it is what the bundled default enterprise policy uses,
 > and why the default policy produces correct answers while the templates do not.
 
 Rewriting the example above to match on `license` makes it fire:
@@ -125,7 +125,7 @@ $ ospac evaluate -l GPL-3.0 -d mobile -p mobile_policy.yaml
     "remediation": "Use an MIT or Apache-2.0 alternative"
 ```
 
-The cost of this approach is that ID lists need maintaining — a license family has many
+The cost of this approach is that ID lists need maintaining, since a license family has many
 spellings (`GPL-3.0`, `GPL-3.0-only`, `GPL-3.0-or-later`, `GPL-3.0+`), and a missing
 variant is a rule that quietly does not cover it. Enumerate the variants you actually
 encounter, and read `ospac/data/compatibility/categories.json` for the full membership of
@@ -175,7 +175,7 @@ Editing that file gives you a policy that already matches on `license`, which si
 ## Templates
 
 `ospac policy init -t NAME` writes one of `mobile`, `desktop`, `web`, `server`, `embedded`,
-`library`, or `custom`. They differ mainly in copyleft treatment — `mobile` denies both
+`library`, or `custom`. They differ mainly in copyleft treatment: `mobile` denies both
 strong and weak copyleft, `library` and `server` are laxer.
 
 Given the `license_type` issue above, treat these as a sketch of intent to be rewritten
@@ -188,6 +188,6 @@ ospac policy validate ./policy.yaml
 ```
 
 Run this in CI on every policy change. A policy that fails to load falls back to the
-default, so a typo replaces your rules with the bundled ones — and because the fallback
+default, so a typo replaces your rules with the bundled ones, and because the fallback
 still returns plausible answers, nothing looks broken. Pair validation with the
 `using_default_policy` assertion above.

--- a/ospac/__init__.py
+++ b/ospac/__init__.py
@@ -4,7 +4,15 @@ OSPAC - Open Source Policy as Code
 A comprehensive policy engine for automated OSS license compliance.
 """
 
-__version__ = "1.2.10"
+from importlib.metadata import PackageNotFoundError, version as _installed_version
+
+# Read the version from installed package metadata so pyproject.toml stays the single
+# source of truth. The SPDX sync workflow bumps the patch version there on every dataset
+# release, and a hardcoded literal here drifted behind it every month.
+try:
+    __version__ = _installed_version("ospac")
+except PackageNotFoundError:  # running from a source tree that was never installed
+    __version__ = "0.0.0.dev0"
 
 from ospac.runtime.engine import PolicyRuntime
 from ospac.models.license import License

--- a/ospac/cli/commands.py
+++ b/ospac/cli/commands.py
@@ -87,9 +87,23 @@ def evaluate(policy_dir: str, licenses: str, context: str,
 
         license_list = [l.strip() for l in licenses.split(",")]
 
+        # Resolve license types from the dataset so rules matching on
+        # license_type (e.g. copyleft_strong) can fire. Licenses missing
+        # from the dataset simply contribute no type.
+        license_types = []
+        for license_id in license_list:
+            try:
+                license_data = runtime.lookup_license_data(license_id)
+            except ValueError:
+                continue
+            license_type = (license_data or {}).get("license", {}).get("type")
+            if license_type and license_type not in license_types:
+                license_types.append(license_type)
+
         eval_context = {
             "licenses_found": license_list,
             "licenses": license_list,  # Support both keys
+            "license_type": license_types,
             "context": context,
             "distribution": distribution,
             "distribution_type": distribution,  # Support both keys

--- a/ospac/cli/commands.py
+++ b/ospac/cli/commands.py
@@ -16,6 +16,7 @@ from ospac.models.compliance import ComplianceStatus
 from ospac.pipeline.spdx_processor import SPDXProcessor
 from ospac.pipeline.data_generator import PolicyDataGenerator
 from ospac.utils.validation import validate_license_id
+from ospac.utils.data_validation import validate_license
 
 # Initialize colorama
 init(autoreset=True)
@@ -83,7 +84,7 @@ def evaluate(policy_dir: str, licenses: str, context: str,
         runtime = PolicyRuntime(policy_dir)
 
         if runtime._using_default and output == "text":
-            click.secho("Using default enterprise policy. Create a custom policy with 'ospac init' to customize.", fg="yellow")
+            click.secho("Using default enterprise policy. Create a custom policy with 'ospac policy init' to customize.", fg="yellow")
 
         license_list = [l.strip() for l in licenses.split(",")]
 
@@ -113,7 +114,7 @@ def evaluate(policy_dir: str, licenses: str, context: str,
         result = runtime.evaluate(eval_context)
 
         # Add license obligations to requirements regardless of policy decision
-        _enhance_result_with_obligations(result, license_list)
+        _enhance_result_with_obligations(result, license_list, runtime)
 
         if output == "json":
             # Convert result to JSON-serializable format
@@ -163,7 +164,7 @@ def check(license1: str, license2: str, context: str, policy_dir: str, output: s
         runtime = PolicyRuntime(policy_dir)
 
         if runtime._using_default and output == "text":
-            click.secho("Using default enterprise policy. Create a custom policy with 'ospac init' to customize.", fg="yellow")
+            click.secho("Using default enterprise policy. Create a custom policy with 'ospac policy init' to customize.", fg="yellow")
 
         result = runtime.check_compatibility(license1, license2, context)
 
@@ -425,29 +426,21 @@ def show(license_id: str, format: str):
         # Load from JSON file (preferred format)
         json_file = data_dir / "licenses" / "json" / f"{license_id}.json"
 
-        if json_file.exists():
-            with open(json_file) as f:
-                data = json.load(f)
-            license_data = data.get("license", {})
-        else:
-            # Fallback to YAML file
-            yaml_file = data_dir / "licenses" / "spdx" / f"{license_id}.yaml"
+        if not json_file.exists():
+            click.secho(f"License {license_id} not found", fg="red")
 
-            if not yaml_file.exists():
-                click.secho(f"License {license_id} not found", fg="red")
+            # Show available licenses
+            json_dir = data_dir / "licenses" / "json"
+            if json_dir.exists():
+                available = [f.stem for f in json_dir.glob("*.json")][:10]
+                click.echo("\nAvailable licenses (first 10):")
+                for lid in available:
+                    click.echo(f"  - {lid}")
+            sys.exit(1)
 
-                # Show available licenses
-                json_dir = data_dir / "licenses" / "json"
-                if json_dir.exists():
-                    available = [f.stem for f in json_dir.glob("*.json")][:10]
-                    click.echo("\nAvailable licenses (first 10):")
-                    for lid in available:
-                        click.echo(f"  - {lid}")
-                sys.exit(1)
-
-            with open(yaml_file) as f:
-                data = yaml.safe_load(f)
-            license_data = data.get("license", {})
+        with open(json_file) as f:
+            data = json.load(f)
+        license_data = data.get("license", {})
 
         if format == "json":
             click.echo(json.dumps(license_data, indent=2))
@@ -456,22 +449,50 @@ def show(license_id: str, format: str):
         else:
             # Text format
             click.secho(f"License: {license_id}", fg="cyan", bold=True)
-            click.echo(f"Category: {license_data.get('category')}")
             click.echo(f"Name: {license_data.get('name')}")
+            click.echo(f"Type: {license_data.get('type')}")
 
-            click.echo("\nPermissions:")
-            for perm, value in license_data.get("permissions", {}).items():
-                symbol = "✓" if value else "✗"
-                click.echo(f"  {symbol} {perm}")
+            spdx_metadata = license_data.get("spdx_metadata", {})
+            if spdx_metadata.get("is_deprecated"):
+                click.secho("⚠ This license identifier is DEPRECATED", fg="yellow")
 
-            click.echo("\nConditions:")
-            for cond, value in license_data.get("conditions", {}).items():
-                if value:
-                    click.echo(f"  • {cond}")
+            def bool_mark(value):
+                return "✓" if value else "✗"
 
-            click.echo("\nObligations:")
-            for obligation in license_data.get("obligations", []):
-                click.echo(f"  • {obligation}")
+            permissions = license_data.get("properties", {})
+            if permissions:
+                click.echo("\nPermissions:")
+                for perm, value in permissions.items():
+                    click.echo(f"  {bool_mark(value)} {perm}")
+
+            conditions = license_data.get("requirements", {})
+            if conditions:
+                click.echo("\nConditions:")
+                for cond, value in conditions.items():
+                    click.echo(f"  {bool_mark(value)} {cond}")
+
+            limitations = license_data.get("limitations", {})
+            if limitations:
+                click.echo("\nLimitations:")
+                for limitation, value in limitations.items():
+                    click.echo(f"  {bool_mark(value)} {limitation}")
+
+            obligations_list = license_data.get("obligations", [])
+            if obligations_list:
+                click.echo("\nObligations:")
+                for obligation in obligations_list:
+                    click.echo(f"  • {obligation}")
+
+            key_requirements = license_data.get("key_requirements", [])
+            if key_requirements:
+                click.echo("\nKey requirements:")
+                for req in key_requirements:
+                    click.echo(f"  • {req}")
+
+            if spdx_metadata:
+                click.echo("\nSPDX metadata:")
+                for key, value in spdx_metadata.items():
+                    click.echo(f"  {bool_mark(value)} {key}")
 
     except Exception as e:
         click.secho(f"Error: {e}", fg="red", err=True)
@@ -480,61 +501,79 @@ def show(license_id: str, format: str):
 
 @data.command()
 @click.option("--data-dir", "-d", type=click.Path(exists=True),
-              default=None, help="Directory containing generated data")
-def validate(data_dir: Optional[str]):
-    """Validate SPDX license data."""
-    import yaml
+              default=None, help="Directory containing generated data (defaults to packaged data)")
+@click.option("--strict", is_flag=True,
+              help="Treat warnings as errors")
+def validate(data_dir: Optional[str], strict: bool):
+    """Validate the license JSON dataset."""
     try:
         # Use package data directory if not specified
         if data_dir is None:
             data_dir = str(Path(__file__).parent.parent / "data")
 
-        data_path = Path(data_dir)
-
-        # Check SPDX directory exists
-        spdx_dir = data_path / "licenses" / "spdx"
-        if not spdx_dir.exists():
-            click.secho(f"✗ SPDX directory not found: {spdx_dir}", fg="red")
+        licenses_dir = Path(data_dir) / "licenses" / "json"
+        if not licenses_dir.exists():
+            click.secho(f"✗ License JSON directory not found: {licenses_dir}", fg="red")
             sys.exit(1)
 
-        # Count and validate SPDX files
-        yaml_files = list(spdx_dir.glob("*.yaml"))
-        total = len(yaml_files)
+        json_files = sorted(licenses_dir.glob("*.json"))
+        total = len(json_files)
 
         if total == 0:
-            click.secho(f"✗ No SPDX YAML files found in {spdx_dir}", fg="red")
+            click.secho(f"✗ No license JSON files found in {licenses_dir}", fg="red")
             sys.exit(1)
 
-        click.echo(f"Validating {total} SPDX licenses...")
+        click.echo(f"Validating {total} license JSON files...")
 
-        issues = []
-        required_fields = {"id", "name", "type", "properties", "requirements", "limitations", "obligations"}
+        all_errors = {}
+        all_warnings = {}
 
-        for yaml_file in yaml_files:
+        for json_file in json_files:
+            license_id = json_file.stem
             try:
-                with open(yaml_file) as f:
-                    data = yaml.safe_load(f)
+                with open(json_file) as f:
+                    raw = json.load(f)
+            except json.JSONDecodeError as e:
+                all_errors[license_id] = [f"invalid JSON: {e}"]
+                continue
 
-                if "license" not in data:
-                    issues.append(f"{yaml_file.name}: Missing 'license' section")
-                    continue
+            license_record = raw.get("license", {})
+            if not license_record:
+                all_errors[license_id] = ["top-level 'license' key missing or empty"]
+                continue
 
-                license_data = data["license"]
-                missing_fields = required_fields - set(license_data.keys())
-                if missing_fields:
-                    issues.append(f"{yaml_file.name}: Missing fields: {missing_fields}")
+            errors, warnings = validate_license(license_id, license_record)
+            if errors:
+                all_errors[license_id] = errors
+            if warnings:
+                all_warnings[license_id] = warnings
 
-            except Exception as e:
-                issues.append(f"{yaml_file.name}: Parse error - {e}")
+        clean = total - len(set(all_errors) | set(all_warnings))
 
-        if issues:
-            click.secho(f"⚠ Found {len(issues)} validation issues:", fg="yellow")
-            for issue in issues[:10]:  # Show first 10
-                click.echo(f"  - {issue}")
-        else:
-            click.secho(f"✓ All {total} licenses validated successfully", fg="green")
+        if all_errors:
+            click.secho(f"\n✗ Errors in {len(all_errors)} files:", fg="red")
+            for license_id, messages in sorted(all_errors.items())[:10]:
+                for message in messages:
+                    click.echo(f"  - {license_id}: {message}")
+            if len(all_errors) > 10:
+                click.echo(f"  ... and {len(all_errors) - 10} more files with errors")
 
-        click.echo(f"\nData summary: {total} SPDX license files validated")
+        if all_warnings:
+            click.secho(f"\n⚠ Warnings in {len(all_warnings)} files:", fg="yellow")
+            for license_id, messages in sorted(all_warnings.items())[:10]:
+                for message in messages:
+                    click.echo(f"  - {license_id}: {message}")
+            if len(all_warnings) > 10:
+                click.echo(f"  ... and {len(all_warnings) - 10} more files with warnings")
+
+        click.echo(f"\nData summary: {total} files, {clean} clean, "
+                   f"{len(all_warnings)} with warnings, {len(all_errors)} with errors")
+
+        if all_errors or (strict and all_warnings):
+            click.secho("✗ Validation failed", fg="red")
+            sys.exit(1)
+
+        click.secho(f"✓ All {total} licenses validated successfully", fg="green")
 
     except Exception as e:
         click.secho(f"Error: {e}", fg="red", err=True)
@@ -940,12 +979,16 @@ def _get_license_data_directly(licenses: list, data_dir: Optional[str] = None) -
     return license_data_result
 
 
-def _enhance_result_with_obligations(result, license_list: list):
-    """Add license obligations to policy result requirements."""
-    import json
-    from pathlib import Path
+def _enhance_result_with_obligations(result, license_list: list, runtime: PolicyRuntime,
+                                     data_dir: Optional[str] = None):
+    """Add license obligations to policy result requirements.
 
-    # Get license obligations from JSON files (preferred) or YAML files
+    Loads obligations from the packaged license JSON dataset (or an explicit
+    data_dir override) so enrichment works regardless of the current working
+    directory. The legacy YAML layout no longer ships, so there is no fallback.
+    """
+    json_dir = Path(runtime.resolve_data_dir(data_dir)) / "licenses" / "json"
+
     all_obligations = []
 
     for license_id in license_list:
@@ -956,9 +999,7 @@ def _enhance_result_with_obligations(result, license_list: list):
             # Skip invalid license IDs
             continue
 
-        # Try JSON first, then fallback to YAML
-        json_file = Path("data") / "licenses" / "json" / f"{license_id}.json"
-        yaml_file = Path("data") / "licenses" / "spdx" / f"{license_id}.yaml"
+        json_file = json_dir / f"{license_id}.json"
 
         spdx_data = None
 
@@ -966,14 +1007,6 @@ def _enhance_result_with_obligations(result, license_list: list):
             try:
                 with open(json_file) as f:
                     spdx_data = json.load(f)
-            except Exception:
-                pass
-
-        if spdx_data is None and yaml_file.exists():
-            try:
-                import yaml
-                with open(yaml_file) as f:
-                    spdx_data = yaml.safe_load(f)
             except Exception:
                 pass
 

--- a/ospac/data/index.json
+++ b/ospac/data/index.json
@@ -2603,7 +2603,7 @@
     },
     "LGPL-2.0+": {
       "name": "GNU Library General Public License v2 or later",
-      "category": "copyleft_strong",
+      "category": "copyleft_weak",
       "file": "licenses/json/LGPL-2.0+.json",
       "is_deprecated": true,
       "obligations_count": 4
@@ -2624,14 +2624,14 @@
     },
     "LGPL-2.0": {
       "name": "GNU Library General Public License v2 only",
-      "category": "copyleft_strong",
+      "category": "copyleft_weak",
       "file": "licenses/json/LGPL-2.0.json",
       "is_deprecated": true,
       "obligations_count": 4
     },
     "LGPL-2.1+": {
       "name": "GNU Lesser General Public License v2.1 or later",
-      "category": "copyleft_strong",
+      "category": "copyleft_weak",
       "file": "licenses/json/LGPL-2.1+.json",
       "is_deprecated": true,
       "obligations_count": 4
@@ -2652,14 +2652,14 @@
     },
     "LGPL-2.1": {
       "name": "GNU Lesser General Public License v2.1 only",
-      "category": "copyleft_strong",
+      "category": "copyleft_weak",
       "file": "licenses/json/LGPL-2.1.json",
       "is_deprecated": true,
       "obligations_count": 4
     },
     "LGPL-3.0+": {
       "name": "GNU Lesser General Public License v3.0 or later",
-      "category": "copyleft_strong",
+      "category": "copyleft_weak",
       "file": "licenses/json/LGPL-3.0+.json",
       "is_deprecated": true,
       "obligations_count": 4
@@ -2680,7 +2680,7 @@
     },
     "LGPL-3.0": {
       "name": "GNU Lesser General Public License v3.0 only",
-      "category": "copyleft_strong",
+      "category": "copyleft_weak",
       "file": "licenses/json/LGPL-3.0.json",
       "is_deprecated": true,
       "obligations_count": 4

--- a/ospac/data/licenses/json/LGPL-2.0+.json
+++ b/ospac/data/licenses/json/LGPL-2.0+.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "LGPL-2.0+",
     "name": "GNU Library General Public License v2 or later",
-    "type": "copyleft_strong",
+    "type": "copyleft_weak",
     "spdx_id": "LGPL-2.0+",
     "properties": {
       "commercial_use": true,
@@ -59,7 +59,7 @@
     ],
     "key_requirements": [
       "Attribution required",
-      "Combined works must be released under the same license"
+      "Modifications to covered files must stay open-source"
     ],
     "spdx_metadata": {
       "is_osi_approved": true,

--- a/ospac/data/licenses/json/LGPL-2.0.json
+++ b/ospac/data/licenses/json/LGPL-2.0.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "LGPL-2.0",
     "name": "GNU Library General Public License v2 only",
-    "type": "copyleft_strong",
+    "type": "copyleft_weak",
     "spdx_id": "LGPL-2.0",
     "properties": {
       "commercial_use": true,
@@ -59,7 +59,7 @@
     ],
     "key_requirements": [
       "Attribution required",
-      "Combined works must be released under the same license"
+      "Modifications to covered files must stay open-source"
     ],
     "spdx_metadata": {
       "is_osi_approved": true,

--- a/ospac/data/licenses/json/LGPL-2.1+.json
+++ b/ospac/data/licenses/json/LGPL-2.1+.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "LGPL-2.1+",
     "name": "GNU Lesser General Public License v2.1 or later",
-    "type": "copyleft_strong",
+    "type": "copyleft_weak",
     "spdx_id": "LGPL-2.1+",
     "properties": {
       "commercial_use": true,
@@ -59,7 +59,7 @@
     ],
     "key_requirements": [
       "Attribution required",
-      "Combined works must be released under the same license"
+      "Modifications to covered files must stay open-source"
     ],
     "spdx_metadata": {
       "is_osi_approved": true,

--- a/ospac/data/licenses/json/LGPL-2.1.json
+++ b/ospac/data/licenses/json/LGPL-2.1.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "LGPL-2.1",
     "name": "GNU Lesser General Public License v2.1 only",
-    "type": "copyleft_strong",
+    "type": "copyleft_weak",
     "spdx_id": "LGPL-2.1",
     "properties": {
       "commercial_use": true,
@@ -59,7 +59,7 @@
     ],
     "key_requirements": [
       "Attribution required",
-      "Combined works must be released under the same license"
+      "Modifications to covered files must stay open-source"
     ],
     "spdx_metadata": {
       "is_osi_approved": true,

--- a/ospac/data/licenses/json/LGPL-3.0+.json
+++ b/ospac/data/licenses/json/LGPL-3.0+.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "LGPL-3.0+",
     "name": "GNU Lesser General Public License v3.0 or later",
-    "type": "copyleft_strong",
+    "type": "copyleft_weak",
     "spdx_id": "LGPL-3.0+",
     "properties": {
       "commercial_use": true,
@@ -59,7 +59,7 @@
     ],
     "key_requirements": [
       "Attribution required",
-      "Combined works must be released under the same license"
+      "Modifications to covered files must stay open-source"
     ],
     "spdx_metadata": {
       "is_osi_approved": true,

--- a/ospac/data/licenses/json/LGPL-3.0.json
+++ b/ospac/data/licenses/json/LGPL-3.0.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "LGPL-3.0",
     "name": "GNU Lesser General Public License v3.0 only",
-    "type": "copyleft_strong",
+    "type": "copyleft_weak",
     "spdx_id": "LGPL-3.0",
     "properties": {
       "commercial_use": true,
@@ -59,7 +59,7 @@
     ],
     "key_requirements": [
       "Attribution required",
-      "Combined works must be released under the same license"
+      "Modifications to covered files must stay open-source"
     ],
     "spdx_metadata": {
       "is_osi_approved": true,

--- a/ospac/models/compliance.py
+++ b/ospac/models/compliance.py
@@ -74,7 +74,7 @@ class PolicyResult:
             action=most_restrictive.action,
             severity=highest_severity.severity,
             message=f"Evaluated {len(results)} rules",
-            requirements=list(set(all_requirements)),
+            requirements=list(dict.fromkeys(all_requirements)),
             remediation=most_restrictive.remediation,
         )
 

--- a/ospac/pipeline/data_generator.py
+++ b/ospac/pipeline/data_generator.py
@@ -27,6 +27,16 @@ _KNOWN_OVERRIDES: Dict[str, Dict] = {
     "LGPL-2.1-or-later": {"category": "copyleft_weak"},
     "LGPL-3.0-only":     {"category": "copyleft_weak"},
     "LGPL-3.0-or-later": {"category": "copyleft_weak"},
+    # The deprecated bare and "+" spellings are aliases of the identifiers above, so they
+    # must classify identically. They were missing here, so the LLM kept marking them
+    # strong while their modern equivalents were corrected to weak. These are also the
+    # spellings that appear most often in real package metadata.
+    "LGPL-2.0":          {"category": "copyleft_weak"},
+    "LGPL-2.0+":         {"category": "copyleft_weak"},
+    "LGPL-2.1":          {"category": "copyleft_weak"},
+    "LGPL-2.1+":         {"category": "copyleft_weak"},
+    "LGPL-3.0":          {"category": "copyleft_weak"},
+    "LGPL-3.0+":         {"category": "copyleft_weak"},
     # MPL-2.0: file-level (weak) copyleft, modified files must stay MPL and source disclosed
     "MPL-2.0": {
         "category": "copyleft_weak",

--- a/ospac/pipeline/data_generator.py
+++ b/ospac/pipeline/data_generator.py
@@ -20,14 +20,14 @@ logger = logging.getLogger(__name__)
 # "category" maps to the `category` field (license type).
 # "conditions" are merged into the `conditions` dict (any key overrides the LLM value).
 _KNOWN_OVERRIDES: Dict[str, Dict] = {
-    # LGPL permits linking from proprietary code — it is weak copyleft, not strong
+    # LGPL permits linking from proprietary code, so it is weak copyleft, not strong
     "LGPL-2.0-only":     {"category": "copyleft_weak"},
     "LGPL-2.0-or-later": {"category": "copyleft_weak"},
     "LGPL-2.1-only":     {"category": "copyleft_weak"},
     "LGPL-2.1-or-later": {"category": "copyleft_weak"},
     "LGPL-3.0-only":     {"category": "copyleft_weak"},
     "LGPL-3.0-or-later": {"category": "copyleft_weak"},
-    # MPL-2.0: file-level (weak) copyleft — modified files must stay MPL and source disclosed
+    # MPL-2.0: file-level (weak) copyleft, modified files must stay MPL and source disclosed
     "MPL-2.0": {
         "category": "copyleft_weak",
         "conditions": {"disclose_source": True, "same_license": True},
@@ -41,7 +41,7 @@ _KNOWN_OVERRIDES: Dict[str, Dict] = {
     "AGPL-3.0-or-later": {"conditions": {"network_use_disclosure": True}},
     # Apache-2.0 requires documenting changes made to original files
     "Apache-2.0": {"conditions": {"state_changes": True}},
-    # CC0 is a full public domain waiver — no copyright or license text requirements
+    # CC0 is a full public domain waiver, with no copyright or license text requirements
     "CC0-1.0": {"conditions": {"include_copyright": False, "include_license": False}},
 }
 
@@ -270,7 +270,7 @@ class PolicyDataGenerator:
                                 "Network use triggers source-disclosure obligation"],
             "public_domain":   ["No restrictions"],
             "source_available":["Source visible but redistribution restricted"],
-            "proprietary":     ["All rights reserved — no redistribution"],
+            "proprietary":     ["All rights reserved, no redistribution"],
             "unknown":         ["Review license terms before use"],
         }
         key_reqs = list(_CATEGORY_KEY.get(category, ["Review license terms before use"]))
@@ -569,7 +569,7 @@ class PolicyDataGenerator:
                 if entry == f"category:{cat2}":
                     return "incompatible"
 
-            return None  # not specified — fall through to category logic
+            return None  # not specified, fall through to category logic
 
         static = resolve("static_linking")
         dynamic = resolve("dynamic_linking")
@@ -860,7 +860,7 @@ class PolicyDataGenerator:
                 json.dump(license_file_data, f, indent=2)
 
         logger.info(f"Wrote {len(licenses)} license files to {licenses_json_dir}")
-        # Index is rebuilt from ALL files after the delta — see _rebuild_index_from_files
+        # Index is rebuilt from ALL files after the delta, see _rebuild_index_from_files
 
     def _rebuild_index_from_files(self, spdx_version: str = "") -> None:
         """Build index.json from ALL license JSON files on disk, not just the current batch."""

--- a/ospac/pipeline/llm_providers.py
+++ b/ospac/pipeline/llm_providers.py
@@ -49,7 +49,7 @@ machine-readable license metadata that will be used for automated compliance che
 Ground-truth reference: cross-check your answers against the TLDR Legal summaries at tldrlegal.com and
 the SPDX license list at spdx.org/licenses before responding.
 
-Critical accuracy requirements — common mistakes to avoid:
+Critical accuracy requirements, common mistakes to avoid:
 - Apache-2.0 GRANTS explicit patent rights (patent_grant=true) and does NOT require same-license or source disclosure
 - GPL-2.0 is NOT compatible with Apache-2.0 upstream (GPL-3.0 is compatible as downstream)
 - LGPL allows dynamic linking from proprietary code without triggering copyleft
@@ -57,7 +57,7 @@ Critical accuracy requirements — common mistakes to avoid:
 - Public domain (CC0, Unlicense) has no obligations at all
 - "liability: true" in limitations means the license DISCLAIMS liability (standard for OSS)
 
-Always respond with valid JSON only — no prose, no markdown fences, no trailing commas."""
+Always respond with valid JSON only: no prose, no markdown fences, no trailing commas."""
 
     def _get_analysis_prompt(self, license_id: str, license_text: str) -> str:
         """Get the analysis prompt for a specific license."""

--- a/ospac/runtime/engine.py
+++ b/ospac/runtime/engine.py
@@ -76,9 +76,13 @@ class PolicyRuntime:
         for rule in applicable_rules:
             result = self.evaluator.evaluate_rule(rule, context)
             # Convert dict result to PolicyResult
+            action_name = result.get("action", "allow").lower()
+            if action_name == "review":
+                # Policies may use "review" as shorthand for flag_for_review
+                action_name = "flag_for_review"
             policy_result = PolicyResult(
                 rule_id=result.get("rule_id", "unknown"),
-                action=ActionType[result.get("action", "allow").upper()],
+                action=ActionType[action_name.upper()],
                 severity=result.get("severity", "info"),
                 message=result.get("message"),
                 requirements=result.get("requirements", []),
@@ -141,6 +145,28 @@ class PolicyRuntime:
                         return False
                 else:
                     if value not in licenses_to_check:
+                        return False
+            elif key == "license_type":
+                # Multiple licenses may be evaluated at once, so the context
+                # value can be a scalar or a list of types. The rule matches
+                # if any evaluated license's type matches the rule value.
+                types_to_check = []
+
+                if isinstance(context_value, str):
+                    types_to_check.append(context_value)
+                elif isinstance(context_value, list):
+                    types_to_check.extend(context_value)
+
+                # If no license types are available in context, no match
+                if not types_to_check:
+                    return False
+
+                if isinstance(value, list):
+                    # Check if any type in context matches any in the rule
+                    if not any(lic_type in value for lic_type in types_to_check):
+                        return False
+                else:
+                    if value not in types_to_check:
                         return False
             else:
                 # Normal field checking

--- a/ospac/runtime/engine.py
+++ b/ospac/runtime/engine.py
@@ -184,9 +184,23 @@ class PolicyRuntime:
     def check_compatibility(self, license1: str, license2: str,
                            context: str = "general") -> ComplianceResult:
         """Check if two licenses are compatible."""
+        # Resolve license types from the dataset so rules matching on
+        # license_type (e.g. copyleft_strong) can fire. Licenses missing
+        # from the dataset simply contribute no type.
+        license_types = []
+        for license_id in (license1, license2):
+            try:
+                license_data = self.lookup_license_data(license_id)
+            except ValueError:
+                continue
+            license_type = (license_data or {}).get("license", {}).get("type")
+            if license_type and license_type not in license_types:
+                license_types.append(license_type)
+
         eval_context = {
             "license1": license1,
             "license2": license2,
+            "license_type": license_types,
             "compatibility_context": context
         }
 
@@ -194,7 +208,19 @@ class PolicyRuntime:
         return ComplianceResult.from_policy_result(result)
 
     def get_obligations(self, licenses: List[str], data_dir: Optional[str] = None) -> Dict[str, Any]:
-        """Get all obligations for the given licenses."""
+        """
+        Get all obligations for the given licenses.
+
+        Args:
+            licenses: List of SPDX license identifiers
+            data_dir: Optional data directory path
+
+        Returns:
+            Dictionary keyed by license id. Each value is a dictionary that
+            contains an "obligations" list from the license dataset, merged
+            with any entries from obligations/ policy files. Licenses with
+            no known obligations are omitted.
+        """
         # Use package data directory if not specified
         data_dir = self.resolve_data_dir(data_dir)
 
@@ -214,7 +240,9 @@ class PolicyRuntime:
         if licenses_dir.exists():
             for license_id in licenses:
                 license_data = self.lookup_license_data(license_id, data_dir) or {}
-                license_obligations = license_data.get("obligations", [])
+                # Per-license JSON files wrap the record in a "license" key
+                license_record = license_data.get("license", license_data)
+                license_obligations = license_record.get("obligations", [])
                 if license_obligations:
                     if license_id not in obligations:
                         obligations[license_id] = {}

--- a/ospac/utils/__init__.py
+++ b/ospac/utils/__init__.py
@@ -2,6 +2,7 @@
 OSPAC utility functions.
 """
 
+from ospac.utils.data_validation import KNOWN_LICENSES, validate_license
 from ospac.utils.validation import validate_license_id, validate_license_path
 
-__all__ = ["validate_license_id", "validate_license_path"]
+__all__ = ["KNOWN_LICENSES", "validate_license", "validate_license_id", "validate_license_path"]

--- a/ospac/utils/data_validation.py
+++ b/ospac/utils/data_validation.py
@@ -1,0 +1,198 @@
+"""
+Shared validation rules for the license JSON dataset.
+
+This module is the single source of truth for the dataset validation rules.
+It is used by two callers:
+
+- the ``ospac data validate`` CLI command (``ospac/cli/commands.py``), which
+  must work from an installed package, and
+- the maintainer script ``scripts/validate_data.py``, which is only present
+  in a source checkout (packaging ships ``ospac*`` only).
+
+Keep all rule changes here so both callers stay in sync automatically.
+
+"""
+
+# Known-correct values for well-known licenses, used as spot checks.
+KNOWN_LICENSES = {
+    "Apache-2.0": {
+        "type": "permissive",
+        "properties": {"patent_grant": True},
+        "requirements": {"disclose_source": False, "same_license": False},
+        "spdx_metadata": {"is_osi_approved": True},
+    },
+    "MIT": {
+        "type": "permissive",
+        "requirements": {"disclose_source": False, "same_license": False},
+        "spdx_metadata": {"is_osi_approved": True},
+    },
+    "GPL-3.0-only": {
+        "type": "copyleft_strong",
+        "requirements": {"disclose_source": True, "same_license": True},
+        "spdx_metadata": {"is_osi_approved": True},
+    },
+    "GPL-2.0-only": {
+        "type": "copyleft_strong",
+        "requirements": {"disclose_source": True, "same_license": True},
+        "spdx_metadata": {"is_osi_approved": True},
+    },
+    "LGPL-2.1-only": {
+        "type": "copyleft_weak",
+        "requirements": {"disclose_source": True},
+        "spdx_metadata": {"is_osi_approved": True},
+    },
+    "LGPL-3.0-only": {
+        "type": "copyleft_weak",
+        "requirements": {"disclose_source": True},
+        "spdx_metadata": {"is_osi_approved": True},
+    },
+    "AGPL-3.0-only": {
+        "type": "copyleft_strong",
+        "requirements": {"disclose_source": True, "same_license": True, "network_use_disclosure": True},
+        "spdx_metadata": {"is_osi_approved": True},
+    },
+    "BSD-2-Clause": {
+        "type": "permissive",
+        "requirements": {"disclose_source": False, "same_license": False},
+        "spdx_metadata": {"is_osi_approved": True},
+    },
+    "BSD-3-Clause": {
+        "type": "permissive",
+        "requirements": {"disclose_source": False, "same_license": False},
+        "spdx_metadata": {"is_osi_approved": True},
+    },
+    "CC0-1.0": {
+        "type": "public_domain",
+        "requirements": {"disclose_source": False, "same_license": False},
+    },
+    "ISC": {
+        "type": "permissive",
+        "spdx_metadata": {"is_osi_approved": True},
+    },
+    "MPL-2.0": {
+        "type": "copyleft_weak",
+        "spdx_metadata": {"is_osi_approved": True},
+    },
+}
+
+REQUIRED_TOP_FIELDS = {"id", "name", "type", "spdx_id", "properties", "requirements",
+                        "limitations", "compatibility", "obligations", "key_requirements",
+                        "spdx_metadata"}
+
+REQUIRED_PROPERTIES = {"commercial_use", "distribution", "modification", "patent_grant", "private_use"}
+REQUIRED_REQUIREMENTS = {"disclose_source", "include_license", "include_copyright",
+                          "same_license", "network_use_disclosure", "state_changes"}
+REQUIRED_LIMITATIONS = {"liability", "warranty", "trademark_use"}
+REQUIRED_COMPAT_KEYS = {"static_linking", "dynamic_linking", "contamination_effect"}
+REQUIRED_COMPAT_LINK_KEYS = {"compatible_with", "incompatible_with", "requires_review"}
+
+VALID_TYPES = {"permissive", "copyleft_strong", "copyleft_weak", "public_domain",
+               "network_copyleft", "source_available", "proprietary", "unknown"}
+# 'derivative' is valid for share-alike licenses (CC-BY-SA etc.) where only derivative
+# works must use the same license, not the whole combined work.
+VALID_CONTAMINATION = {"none", "module", "full", "derivative", "unknown"}
+
+
+def validate_license(lid: str, lic: dict) -> tuple[list, list]:
+    """Return (errors, warnings) for one unwrapped license record."""
+    errors = []
+    warnings = []
+
+    def err(msg): errors.append(msg)
+    def warn(msg): warnings.append(msg)
+
+    # Top-level fields
+    missing_top = REQUIRED_TOP_FIELDS - set(lic.keys())
+    for f in sorted(missing_top):
+        err(f"missing top-level field '{f}'")
+
+    # id / name / type
+    if lic.get("id") != lid:
+        err(f"id field '{lic.get('id')}' does not match filename '{lid}'")
+    if lic.get("name", "") == lid:
+        warn("name is same as id, should be human-readable (e.g. 'MIT License')")
+    lic_type_raw = lic.get("type", "")
+    if lic_type_raw and lic_type_raw not in VALID_TYPES:
+        if "|" in lic_type_raw:
+            # Ambiguous type on a genuinely grey license: warn, don't fail
+            warn(f"ambiguous type '{lic_type_raw}', resolve to one of {VALID_TYPES}")
+        else:
+            err(f"invalid type '{lic_type_raw}', must be one of {VALID_TYPES}")
+
+    # properties
+    props = lic.get("properties", {})
+    for f in REQUIRED_PROPERTIES - set(props.keys()):
+        err(f"properties.{f} missing")
+    for f, v in props.items():
+        if not isinstance(v, bool):
+            err(f"properties.{f} must be bool, got {type(v).__name__}")
+
+    # requirements
+    reqs = lic.get("requirements", {})
+    for f in REQUIRED_REQUIREMENTS - set(reqs.keys()):
+        warn(f"requirements.{f} missing")
+    for f, v in reqs.items():
+        if not isinstance(v, bool):
+            err(f"requirements.{f} must be bool, got {type(v).__name__}")
+
+    # limitations
+    lims = lic.get("limitations", {})
+    for f in REQUIRED_LIMITATIONS - set(lims.keys()):
+        warn(f"limitations.{f} missing")
+
+    # compatibility
+    compat = lic.get("compatibility", {})
+    for f in REQUIRED_COMPAT_KEYS - set(compat.keys()):
+        err(f"compatibility.{f} missing")
+
+    for link in ("static_linking", "dynamic_linking"):
+        section = compat.get(link, {})
+        if not isinstance(section, dict):
+            err(f"compatibility.{link} must be a dict")
+            continue
+        for f in REQUIRED_COMPAT_LINK_KEYS - set(section.keys()):
+            warn(f"compatibility.{link}.{f} missing")
+        # At least some entries should be non-empty
+        if (isinstance(section.get("compatible_with"), list) and
+                isinstance(section.get("incompatible_with"), list) and
+                not section["compatible_with"] and not section["incompatible_with"]):
+            warn(f"compatibility.{link} has empty compatible_with AND incompatible_with")
+
+    contamination = compat.get("contamination_effect", "")
+    if contamination and contamination not in VALID_CONTAMINATION:
+        err(f"compatibility.contamination_effect '{contamination}' not in {VALID_CONTAMINATION}")
+
+    # obligations / key_requirements
+    obligs = lic.get("obligations", [])
+    lic_type = lic.get("type", "")
+    if not obligs and lic_type not in ("public_domain",):
+        warn("obligations list is empty")
+    if not isinstance(obligs, list):
+        err(f"obligations must be a list, got {type(obligs).__name__}")
+
+    krs = lic.get("key_requirements", [])
+    if not isinstance(krs, list):
+        err(f"key_requirements must be a list, got {type(krs).__name__}")
+
+    # spdx_metadata
+    meta = lic.get("spdx_metadata", {})
+    for f in ("is_osi_approved", "is_fsf_libre", "is_deprecated"):
+        if f not in meta:
+            warn(f"spdx_metadata.{f} missing")
+        elif not isinstance(meta[f], bool):
+            err(f"spdx_metadata.{f} must be bool, got {type(meta[f]).__name__}")
+
+    # Known-license spot checks
+    if lid in KNOWN_LICENSES:
+        spec = KNOWN_LICENSES[lid]
+        if "type" in spec and lic.get("type") != spec["type"]:
+            err(f"known-license: type should be '{spec['type']}', got '{lic.get('type')}'")
+        for section, expected in spec.items():
+            if section == "type":
+                continue
+            actual = lic.get(section, {})
+            for k, v in expected.items():
+                if actual.get(k) != v:
+                    err(f"known-license: {section}.{k} should be {v}, got {actual.get(k)!r}")
+
+    return errors, warnings

--- a/ospac/utils/data_validation.py
+++ b/ospac/utils/data_validation.py
@@ -46,6 +46,17 @@ KNOWN_LICENSES = {
         "requirements": {"disclose_source": True},
         "spdx_metadata": {"is_osi_approved": True},
     },
+    # Deprecated aliases of the LGPL identifiers above. Spot checked explicitly because
+    # they were classified copyleft_strong while their modern equivalents were weak, and
+    # nothing here caught the disagreement.
+    "LGPL-2.1": {
+        "type": "copyleft_weak",
+        "requirements": {"disclose_source": True},
+    },
+    "LGPL-3.0": {
+        "type": "copyleft_weak",
+        "requirements": {"disclose_source": True},
+    },
     "AGPL-3.0-only": {
         "type": "copyleft_strong",
         "requirements": {"disclose_source": True, "same_license": True, "network_use_disclosure": True},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,13 +134,8 @@ warn_unused_configs = true
 disallow_untyped_defs = false
 ignore_missing_imports = true
 
-[tool.pytest.ini_options]
-testpaths = ["tests"]
-python_files = ["test_*.py", "*_test.py"]
-addopts = "-v --cov=osslili --cov-report=term-missing"
-
 [tool.coverage.run]
-source = ["osslili"]
+source = ["ospac"]
 omit = ["*/tests/*", "*/test_*.py"]
 
 [tool.coverage.report]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ospac"
-version = "1.2.11"
+version = "1.3.0"
 description = "Open Source Policy as Code - License compliance policy engine"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/validate_data.py
+++ b/scripts/validate_data.py
@@ -17,189 +17,15 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
-# ── Known-correct values for well-known licenses ─────────────────────────────
-KNOWN_LICENSES = {
-    "Apache-2.0": {
-        "type": "permissive",
-        "properties": {"patent_grant": True},
-        "requirements": {"disclose_source": False, "same_license": False},
-        "spdx_metadata": {"is_osi_approved": True},
-    },
-    "MIT": {
-        "type": "permissive",
-        "requirements": {"disclose_source": False, "same_license": False},
-        "spdx_metadata": {"is_osi_approved": True},
-    },
-    "GPL-3.0-only": {
-        "type": "copyleft_strong",
-        "requirements": {"disclose_source": True, "same_license": True},
-        "spdx_metadata": {"is_osi_approved": True},
-    },
-    "GPL-2.0-only": {
-        "type": "copyleft_strong",
-        "requirements": {"disclose_source": True, "same_license": True},
-        "spdx_metadata": {"is_osi_approved": True},
-    },
-    "LGPL-2.1-only": {
-        "type": "copyleft_weak",
-        "requirements": {"disclose_source": True},
-        "spdx_metadata": {"is_osi_approved": True},
-    },
-    "LGPL-3.0-only": {
-        "type": "copyleft_weak",
-        "requirements": {"disclose_source": True},
-        "spdx_metadata": {"is_osi_approved": True},
-    },
-    "AGPL-3.0-only": {
-        "type": "copyleft_strong",
-        "requirements": {"disclose_source": True, "same_license": True, "network_use_disclosure": True},
-        "spdx_metadata": {"is_osi_approved": True},
-    },
-    "BSD-2-Clause": {
-        "type": "permissive",
-        "requirements": {"disclose_source": False, "same_license": False},
-        "spdx_metadata": {"is_osi_approved": True},
-    },
-    "BSD-3-Clause": {
-        "type": "permissive",
-        "requirements": {"disclose_source": False, "same_license": False},
-        "spdx_metadata": {"is_osi_approved": True},
-    },
-    "CC0-1.0": {
-        "type": "public_domain",
-        "requirements": {"disclose_source": False, "same_license": False},
-    },
-    "ISC": {
-        "type": "permissive",
-        "spdx_metadata": {"is_osi_approved": True},
-    },
-    "MPL-2.0": {
-        "type": "copyleft_weak",
-        "spdx_metadata": {"is_osi_approved": True},
-    },
-}
+# Make the source checkout importable when the script is run directly,
+# e.g. `python scripts/validate_data.py` without PYTHONPATH set.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
-REQUIRED_TOP_FIELDS = {"id", "name", "type", "spdx_id", "properties", "requirements",
-                        "limitations", "compatibility", "obligations", "key_requirements",
-                        "spdx_metadata"}
-
-REQUIRED_PROPERTIES = {"commercial_use", "distribution", "modification", "patent_grant", "private_use"}
-REQUIRED_REQUIREMENTS = {"disclose_source", "include_license", "include_copyright",
-                          "same_license", "network_use_disclosure", "state_changes"}
-REQUIRED_LIMITATIONS = {"liability", "warranty", "trademark_use"}
-REQUIRED_COMPAT_KEYS = {"static_linking", "dynamic_linking", "contamination_effect"}
-REQUIRED_COMPAT_LINK_KEYS = {"compatible_with", "incompatible_with", "requires_review"}
-
-VALID_TYPES = {"permissive", "copyleft_strong", "copyleft_weak", "public_domain",
-               "network_copyleft", "source_available", "proprietary", "unknown"}
-# 'derivative' is valid for share-alike licenses (CC-BY-SA etc.) where only derivative
-# works must use the same license, not the whole combined work.
-VALID_CONTAMINATION = {"none", "module", "full", "derivative", "unknown"}
-
-
-def validate_license(lid: str, lic: dict) -> tuple[list, list]:
-    """Return (errors, warnings) for one license dict."""
-    errors = []
-    warnings = []
-
-    def err(msg): errors.append(msg)
-    def warn(msg): warnings.append(msg)
-
-    # ── Top-level fields ──────────────────────────────────────────────────────
-    missing_top = REQUIRED_TOP_FIELDS - set(lic.keys())
-    for f in sorted(missing_top):
-        err(f"missing top-level field '{f}'")
-
-    # ── id / name / type ──────────────────────────────────────────────────────
-    if lic.get("id") != lid:
-        err(f"id field '{lic.get('id')}' does not match filename '{lid}'")
-    if lic.get("name", "") == lid:
-        warn("name is same as id — should be human-readable (e.g. 'MIT License')")
-    lic_type_raw = lic.get("type", "")
-    if lic_type_raw and lic_type_raw not in VALID_TYPES:
-        if "|" in lic_type_raw:
-            # LLM returned ambiguous type for a genuinely grey license — warn, don't fail
-            warn(f"ambiguous type '{lic_type_raw}' — resolve to one of {VALID_TYPES}")
-        else:
-            err(f"invalid type '{lic_type_raw}' — must be one of {VALID_TYPES}")
-
-    # ── properties ────────────────────────────────────────────────────────────
-    props = lic.get("properties", {})
-    for f in REQUIRED_PROPERTIES - set(props.keys()):
-        err(f"properties.{f} missing")
-    for f, v in props.items():
-        if not isinstance(v, bool):
-            err(f"properties.{f} must be bool, got {type(v).__name__}")
-
-    # ── requirements ──────────────────────────────────────────────────────────
-    reqs = lic.get("requirements", {})
-    for f in REQUIRED_REQUIREMENTS - set(reqs.keys()):
-        warn(f"requirements.{f} missing")
-    for f, v in reqs.items():
-        if not isinstance(v, bool):
-            err(f"requirements.{f} must be bool, got {type(v).__name__}")
-
-    # ── limitations ───────────────────────────────────────────────────────────
-    lims = lic.get("limitations", {})
-    for f in REQUIRED_LIMITATIONS - set(lims.keys()):
-        warn(f"limitations.{f} missing")
-
-    # ── compatibility ─────────────────────────────────────────────────────────
-    compat = lic.get("compatibility", {})
-    for f in REQUIRED_COMPAT_KEYS - set(compat.keys()):
-        err(f"compatibility.{f} missing")
-
-    for link in ("static_linking", "dynamic_linking"):
-        section = compat.get(link, {})
-        if not isinstance(section, dict):
-            err(f"compatibility.{link} must be a dict")
-            continue
-        for f in REQUIRED_COMPAT_LINK_KEYS - set(section.keys()):
-            warn(f"compatibility.{link}.{f} missing")
-        # At least some entries should be non-empty
-        if (isinstance(section.get("compatible_with"), list) and
-                isinstance(section.get("incompatible_with"), list) and
-                not section["compatible_with"] and not section["incompatible_with"]):
-            warn(f"compatibility.{link} has empty compatible_with AND incompatible_with")
-
-    contamination = compat.get("contamination_effect", "")
-    if contamination and contamination not in VALID_CONTAMINATION:
-        err(f"compatibility.contamination_effect '{contamination}' not in {VALID_CONTAMINATION}")
-
-    # ── obligations / key_requirements ────────────────────────────────────────
-    obligs = lic.get("obligations", [])
-    lic_type = lic.get("type", "")
-    if not obligs and lic_type not in ("public_domain",):
-        warn("obligations list is empty")
-    if not isinstance(obligs, list):
-        err(f"obligations must be a list, got {type(obligs).__name__}")
-
-    krs = lic.get("key_requirements", [])
-    if not isinstance(krs, list):
-        err(f"key_requirements must be a list, got {type(krs).__name__}")
-
-    # ── spdx_metadata ─────────────────────────────────────────────────────────
-    meta = lic.get("spdx_metadata", {})
-    for f in ("is_osi_approved", "is_fsf_libre", "is_deprecated"):
-        if f not in meta:
-            warn(f"spdx_metadata.{f} missing")
-        elif not isinstance(meta[f], bool):
-            err(f"spdx_metadata.{f} must be bool, got {type(meta[f]).__name__}")
-
-    # ── Known-license spot checks ─────────────────────────────────────────────
-    if lid in KNOWN_LICENSES:
-        spec = KNOWN_LICENSES[lid]
-        if "type" in spec and lic.get("type") != spec["type"]:
-            err(f"known-license: type should be '{spec['type']}', got '{lic.get('type')}'")
-        for section, expected in spec.items():
-            if section == "type":
-                continue
-            actual = lic.get(section, {})
-            for k, v in expected.items():
-                if actual.get(k) != v:
-                    err(f"known-license: {section}.{k} should be {v}, got {actual.get(k)!r}")
-
-    return errors, warnings
+# Single source of truth for the validation rules, shared with the
+# `ospac data validate` CLI command.
+from ospac.utils.data_validation import validate_license  # noqa: E402
 
 
 def run(data_dir: Path, strict: bool, as_json: bool) -> int:
@@ -222,7 +48,7 @@ def run(data_dir: Path, strict: bool, as_json: bool) -> int:
         try:
             raw = json.loads(p.read_text())
         except json.JSONDecodeError as e:
-            parse_failures.append(f"{lid}: invalid JSON — {e}")
+            parse_failures.append(f"{lid}: invalid JSON: {e}")
             continue
 
         lic = raw.get("license", {})
@@ -246,11 +72,11 @@ def run(data_dir: Path, strict: bool, as_json: bool) -> int:
     warning_categories: dict[str, int] = defaultdict(int)
     for msgs in all_errors.values():
         for m in msgs:
-            key = m.split("'")[0].strip().rstrip(" —").split(":")[0]
+            key = m.split("'")[0].strip().rstrip(" ,").split(":")[0]
             error_categories[key] += 1
     for msgs in all_warnings.values():
         for m in msgs:
-            key = m.split("'")[0].strip().rstrip(" —").split(":")[0]
+            key = m.split("'")[0].strip().rstrip(" ,").split(":")[0]
             warning_categories[key] += 1
 
     if as_json:
@@ -278,14 +104,14 @@ def run(data_dir: Path, strict: bool, as_json: bool) -> int:
             print(f"  ✗ {m}")
 
     if all_errors:
-        print(f"\n{E}ERRORS — {n_err} files affected{RESET}")
+        print(f"\n{E}ERRORS: {n_err} files affected{RESET}")
         for lid, msgs in sorted(all_errors.items()):
             print(f"  {lid}:")
             for m in msgs:
                 print(f"    ✗ {m}")
 
     if all_warnings:
-        print(f"\n{W}WARNINGS — {n_warn} files affected{RESET}")
+        print(f"\n{W}WARNINGS: {n_warn} files affected{RESET}")
         # Group by category to avoid flooding output
         for cat, count in sorted(warning_categories.items(), key=lambda x: -x[1])[:15]:
             print(f"  [{count:4d} files]  {cat}…")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,7 @@ would never catch a CLI that forgets to populate it.
 """
 
 import json
+from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
@@ -159,3 +160,112 @@ class TestEvaluateDefaultPolicy:
 
         assert output["using_default_policy"] is True
         assert output["result"]["action"] != "deny"
+
+    def test_default_policy_hint_names_a_real_command(self, runner):
+        result = runner.invoke(cli, ["evaluate", "-l", "MIT", "-o", "text"])
+
+        assert result.exit_code == 0, result.output
+        assert "ospac policy init" in result.output
+        assert "'ospac init'" not in result.output, (
+            "There is no 'ospac init' command; the hint must say "
+            "'ospac policy init'"
+        )
+
+
+class TestDataShow:
+    """`data show` must read the migrated JSON schema, not pre-v1.2.0 fields."""
+
+    def test_text_output_uses_migrated_fields(self, runner):
+        result = runner.invoke(cli, ["data", "show", "MIT", "-f", "text"])
+
+        assert result.exit_code == 0, result.output
+        assert "Type: permissive" in result.output
+        assert "Category: None" not in result.output, (
+            "'category' is a pre-migration field; the dataset uses 'type'"
+        )
+        # Permissions come from 'properties', conditions from 'requirements'
+        assert "commercial_use" in result.output
+        assert "include_license" in result.output
+        # False values must be shown explicitly, not silently omitted
+        assert "✗ disclose_source" in result.output
+        assert "✗ warranty" in result.output
+        assert "is_osi_approved" in result.output
+
+    def test_json_output_shape_is_unchanged(self, runner):
+        result = runner.invoke(cli, ["data", "show", "MIT", "-f", "json"])
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["id"] == "MIT"
+        assert data["type"] == "permissive"
+        assert data["properties"]["commercial_use"] is True
+        assert data["requirements"]["include_license"] is True
+        assert data["spdx_metadata"]["is_osi_approved"] is True
+        assert data["obligations"] == [
+            "Retain copyright notices",
+            "Include license text",
+        ]
+
+
+class TestDataValidate:
+    """`data validate` must validate the JSON dataset that actually ships."""
+
+    def test_shipped_dataset_validates(self, runner):
+        result = runner.invoke(cli, ["data", "validate"])
+
+        assert result.exit_code == 0, result.output
+        assert "licenses/spdx" not in result.output, (
+            "The pre-migration YAML layout no longer ships and must not "
+            "be required for validation"
+        )
+        assert "Data summary" in result.output
+
+    def test_shipped_dataset_validates_with_explicit_dir(self, runner):
+        import ospac
+
+        data_dir = Path(ospac.__file__).parent / "data"
+        result = runner.invoke(cli, ["data", "validate", "-d", str(data_dir)])
+
+        assert result.exit_code == 0, result.output
+
+    def test_corrupt_dataset_fails(self, runner, tmp_path):
+        json_dir = tmp_path / "licenses" / "json"
+        json_dir.mkdir(parents=True)
+        # id does not match the filename and every required field is missing
+        (json_dir / "Broken-1.0.json").write_text('{"license": {"id": "Other"}}')
+
+        result = runner.invoke(cli, ["data", "validate", "-d", str(tmp_path)])
+
+        assert result.exit_code != 0, result.output
+        assert "Broken-1.0" in result.output
+
+    def test_unparseable_json_fails(self, runner, tmp_path):
+        json_dir = tmp_path / "licenses" / "json"
+        json_dir.mkdir(parents=True)
+        (json_dir / "Mangled-1.0.json").write_text("{not json")
+
+        result = runner.invoke(cli, ["data", "validate", "-d", str(tmp_path)])
+
+        assert result.exit_code != 0, result.output
+
+
+class TestObligationEnrichment:
+    """Obligation enrichment must use packaged data, not the process cwd."""
+
+    def test_evaluate_carries_obligations_without_local_data_dir(self, runner):
+        # isolated_filesystem chdirs into an empty temp directory, so a
+        # cwd-relative "data/" lookup would find nothing and enrichment
+        # would silently become a no-op.
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                cli, ["evaluate", "-l", "MIT", "--output", "json"]
+            )
+
+            assert result.exit_code == 0, result.output
+            output = json.loads(result.output)
+            requirements = output["result"]["requirements"]
+            assert any(r.startswith("MIT: ") for r in requirements), (
+                "evaluate must carry per-license obligations in its "
+                f"requirements regardless of cwd, got: {requirements}"
+            )
+            assert "MIT: Retain copyright notices" in requirements

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,161 @@
+"""
+Tests for the OSPAC CLI commands.
+
+These tests exercise the full CLI path, including the evaluation context
+construction in `evaluate`. This matters because policy templates generated
+by `policy init` match on `license_type`, which must be resolved from the
+license dataset at evaluation time - a hand-built context in unit tests
+would never catch a CLI that forgets to populate it.
+"""
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from ospac.cli.commands import cli
+
+
+# Templates whose rules deny strong copyleft licenses
+DENY_COPYLEFT_TEMPLATES = ["mobile", "desktop", "web", "server", "embedded", "library"]
+
+
+@pytest.fixture
+def runner():
+    """Provide a Click CLI test runner."""
+    return CliRunner()
+
+
+def _init_policy(runner, tmp_path, template):
+    """Generate a policy file from a template and return its path."""
+    policy_file = tmp_path / f"{template}_policy.yaml"
+    result = runner.invoke(
+        cli, ["policy", "init", "-t", template, "-o", str(policy_file)]
+    )
+    assert result.exit_code == 0, result.output
+    assert policy_file.exists()
+    return policy_file
+
+
+def _evaluate(runner, licenses, distribution, policy_file=None):
+    """Run `ospac evaluate` with JSON output and return the parsed result."""
+    args = ["evaluate", "-l", licenses, "-d", distribution, "--output", "json"]
+    if policy_file is not None:
+        args.extend(["-p", str(policy_file)])
+    result = runner.invoke(cli, args)
+    assert result.exit_code == 0, result.output
+    return json.loads(result.output)
+
+
+class TestPolicyInitTemplatesDenyCopyleft:
+    """Generated templates must actually deny what they claim to deny."""
+
+    @pytest.mark.parametrize("template", DENY_COPYLEFT_TEMPLATES)
+    def test_strong_copyleft_is_denied(self, runner, tmp_path, template):
+        policy_file = _init_policy(runner, tmp_path, template)
+        output = _evaluate(runner, "GPL-3.0", template, policy_file)
+
+        assert output["result"]["action"] == "deny", (
+            f"{template} template must deny GPL-3.0, "
+            f"got: {output['result']}"
+        )
+
+    @pytest.mark.parametrize("template", DENY_COPYLEFT_TEMPLATES)
+    def test_permissive_is_not_denied(self, runner, tmp_path, template):
+        policy_file = _init_policy(runner, tmp_path, template)
+        output = _evaluate(runner, "MIT", template, policy_file)
+
+        assert output["result"]["action"] != "deny", (
+            f"{template} template must not deny MIT, "
+            f"got: {output['result']}"
+        )
+
+    def test_permissive_is_approved_by_mobile_template(self, runner, tmp_path):
+        policy_file = _init_policy(runner, tmp_path, "mobile")
+        output = _evaluate(runner, "MIT", "mobile", policy_file)
+
+        assert output["result"]["action"] == "approve"
+
+    @pytest.mark.parametrize("template", ["mobile", "web", "embedded", "library"])
+    def test_weak_copyleft_is_denied_where_template_says_so(
+        self, runner, tmp_path, template
+    ):
+        policy_file = _init_policy(runner, tmp_path, template)
+        output = _evaluate(runner, "LGPL-3.0-only", template, policy_file)
+
+        assert output["result"]["action"] == "deny", (
+            f"{template} template must deny weak copyleft, "
+            f"got: {output['result']}"
+        )
+
+    @pytest.mark.parametrize("template", ["desktop", "server"])
+    def test_weak_copyleft_is_flagged_for_review_where_template_says_so(
+        self, runner, tmp_path, template
+    ):
+        policy_file = _init_policy(runner, tmp_path, template)
+        output = _evaluate(runner, "LGPL-3.0-only", template, policy_file)
+
+        assert output["result"]["action"] == "flag_for_review", (
+            f"{template} template must flag weak copyleft for review, "
+            f"got: {output['result']}"
+        )
+
+
+class TestEvaluateMultiLicense:
+    """Any-match semantics: one bad license taints the whole evaluation."""
+
+    def test_copyleft_mixed_with_permissive_still_denies(self, runner, tmp_path):
+        policy_file = _init_policy(runner, tmp_path, "mobile")
+        output = _evaluate(runner, "MIT,GPL-3.0", "mobile", policy_file)
+
+        assert output["result"]["action"] == "deny", (
+            "A copyleft license mixed with permissive ones must still deny, "
+            f"got: {output['result']}"
+        )
+
+    def test_all_permissive_multi_license_is_not_denied(self, runner, tmp_path):
+        policy_file = _init_policy(runner, tmp_path, "mobile")
+        output = _evaluate(runner, "MIT,Apache-2.0", "mobile", policy_file)
+
+        assert output["result"]["action"] != "deny"
+
+
+class TestEvaluateContextConstruction:
+    """Regression guards for the evaluation context built by the CLI."""
+
+    def test_license_type_rules_are_matched(self, runner, tmp_path):
+        # Regression guard: the CLI must populate license_type in the
+        # evaluation context, otherwise every license_type rule silently
+        # falls through to "No policies matched" and fails open.
+        policy_file = _init_policy(runner, tmp_path, "mobile")
+        output = _evaluate(runner, "GPL-3.0", "mobile", policy_file)
+
+        assert output["result"]["message"] != "No policies matched", (
+            "GPL-3.0 must match the mobile template's license_type rules; "
+            "'No policies matched' means license_type was never resolved"
+        )
+        assert output["result"]["action"] == "deny"
+
+    def test_unknown_license_does_not_crash(self, runner, tmp_path):
+        policy_file = _init_policy(runner, tmp_path, "mobile")
+        output = _evaluate(runner, "NotARealLicense-1.0", "mobile", policy_file)
+
+        # A license absent from the dataset contributes no type, so no
+        # license_type rule matches - but the command must still succeed.
+        assert "result" in output
+
+
+class TestEvaluateDefaultPolicy:
+    """The built-in enterprise policy must keep working unchanged."""
+
+    def test_gpl_denied_for_commercial(self, runner):
+        output = _evaluate(runner, "GPL-3.0", "commercial")
+
+        assert output["using_default_policy"] is True
+        assert output["result"]["action"] == "deny"
+
+    def test_mit_not_denied_for_commercial(self, runner):
+        output = _evaluate(runner, "MIT", "commercial")
+
+        assert output["using_default_policy"] is True
+        assert output["result"]["action"] != "deny"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,6 +2,10 @@
 Tests for OSPAC data models.
 """
 
+import os
+import subprocess
+import sys
+
 import pytest
 
 from ospac.models.license import License
@@ -369,6 +373,72 @@ class TestPolicyResult:
         assert "req1" in aggregated.requirements
         assert "req2" in aggregated.requirements
         assert "req3" in aggregated.requirements
+
+    def test_aggregate_requirements_preserve_first_seen_order(self):
+        """Aggregated requirements keep first-seen order and drop duplicates."""
+        results = [
+            PolicyResult(
+                rule_id="rule1",
+                action=ActionType.ALLOW,
+                severity="info",
+                requirements=["include_license", "include_copyright"]
+            ),
+            PolicyResult(
+                rule_id="rule2",
+                action=ActionType.ALLOW,
+                severity="info",
+                requirements=["include_copyright", "state_changes"]
+            ),
+            PolicyResult(
+                rule_id="rule3",
+                action=ActionType.ALLOW,
+                severity="info",
+                requirements=["include_license", "include_notice"]
+            )
+        ]
+
+        aggregated = PolicyResult.aggregate(results)
+
+        # Exact sequence: duplicates collapse to their first occurrence
+        assert aggregated.requirements == [
+            "include_license",
+            "include_copyright",
+            "state_changes",
+            "include_notice",
+        ]
+
+    def test_aggregate_requirements_stable_across_hash_seeds(self):
+        """Aggregation order must not depend on string hash randomization."""
+        script = (
+            "from ospac.models.compliance import PolicyResult, ActionType\n"
+            "results = [\n"
+            "    PolicyResult(rule_id='r1', action=ActionType.ALLOW,\n"
+            "                 requirements=['include_license', 'include_copyright']),\n"
+            "    PolicyResult(rule_id='r2', action=ActionType.ALLOW,\n"
+            "                 requirements=['state_changes', 'include_copyright']),\n"
+            "]\n"
+            "print(PolicyResult.aggregate(results).requirements)\n"
+        )
+
+        repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        outputs = set()
+        for seed in ("0", "1", "42"):
+            env = dict(os.environ, PYTHONHASHSEED=seed)
+            env["PYTHONPATH"] = os.pathsep.join(
+                filter(None, [repo_root, env.get("PYTHONPATH")])
+            )
+            proc = subprocess.run(
+                [sys.executable, "-c", script],
+                capture_output=True,
+                text=True,
+                env=env,
+                check=True,
+            )
+            outputs.add(proc.stdout.strip())
+
+        assert outputs == {
+            "['include_license', 'include_copyright', 'state_changes']"
+        }
 
     def test_aggregate_empty_results(self):
         """Test aggregating empty results."""

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -3,6 +3,7 @@ Tests for the policy runtime engine.
 """
 
 import pytest
+import yaml
 from pathlib import Path
 
 from ospac.runtime.engine import PolicyRuntime
@@ -238,3 +239,100 @@ class TestPolicyRuntime:
         context = {"any": "context"}
 
         assert runtime._rule_applies(rule, context) is True
+
+    def test_get_obligations_from_license_dataset(self):
+        """Test obligations are read from the packaged per-license JSON files."""
+        runtime = PolicyRuntime()
+
+        obligations = runtime.get_obligations(["MIT", "Apache-2.0"])
+
+        assert obligations["MIT"]["obligations"] == [
+            "Retain copyright notices",
+            "Include license text"
+        ]
+        assert obligations["Apache-2.0"]["obligations"] == [
+            "Retain copyright notices",
+            "Include license text",
+            "Document changes made to the code"
+        ]
+
+    def test_get_obligations_unknown_license(self):
+        """Test unknown license ids return cleanly with no entry."""
+        runtime = PolicyRuntime()
+
+        obligations = runtime.get_obligations(["Not-A-Real-License-1.0"])
+
+        assert obligations == {}
+
+    def test_check_compatibility_fires_license_type_rule(self, temp_dir):
+        """Test check_compatibility resolves license types so type rules fire."""
+        policy = {
+            "version": "1.0",
+            "name": "Type Rule Policy",
+            "rules": [
+                {
+                    "id": "deny_strong_copyleft",
+                    "when": {"license_type": "copyleft_strong"},
+                    "then": {
+                        "action": "deny",
+                        "severity": "error",
+                        "message": "Strong copyleft is not allowed"
+                    }
+                }
+            ]
+        }
+
+        policy_file = temp_dir / "type_policy.yaml"
+        with open(policy_file, "w") as f:
+            yaml.dump(policy, f)
+
+        runtime = PolicyRuntime(str(temp_dir))
+
+        # GPL-3.0 is copyleft_strong in the dataset, so the rule must fire
+        result = runtime.check_compatibility("MIT", "GPL-3.0")
+        assert result.is_compliant is False
+
+        # Two permissive licenses do not trigger the rule
+        result = runtime.check_compatibility("MIT", "Apache-2.0")
+        assert result.is_compliant is True
+
+    def test_check_compatibility_unknown_license_contributes_no_type(self, temp_dir):
+        """Test licenses missing from the dataset contribute no type and do not raise."""
+        policy = {
+            "version": "1.0",
+            "name": "Type Rule Policy",
+            "rules": [
+                {
+                    "id": "deny_strong_copyleft",
+                    "when": {"license_type": "copyleft_strong"},
+                    "then": {
+                        "action": "deny",
+                        "severity": "error",
+                        "message": "Strong copyleft is not allowed"
+                    }
+                }
+            ]
+        }
+
+        policy_file = temp_dir / "type_policy.yaml"
+        with open(policy_file, "w") as f:
+            yaml.dump(policy, f)
+
+        runtime = PolicyRuntime(str(temp_dir))
+
+        result = runtime.check_compatibility("Not-A-Real-License-1.0", "MIT")
+        assert result.is_compliant is True
+
+    def test_check_compatibility_gpl2_apache_still_incompatible(self):
+        """Regression: GPL-2.0 and Apache-2.0 stay incompatible under the default policy."""
+        runtime = PolicyRuntime()
+
+        result = runtime.check_compatibility("GPL-2.0", "Apache-2.0")
+        assert result.is_compliant is False
+
+    def test_check_compatibility_mit_gpl3_still_compatible(self):
+        """Regression: MIT and GPL-3.0 stay compatible under the default policy."""
+        runtime = PolicyRuntime()
+
+        result = runtime.check_compatibility("MIT", "GPL-3.0")
+        assert result.is_compliant is True

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -211,3 +211,93 @@ class TestIntegrationSecurity:
         assert result1 is None or isinstance(result1, dict)
         assert result2 is None or isinstance(result2, dict)
         assert result3 is None or isinstance(result3, dict)
+
+
+class TestSharedDataValidation:
+    """The dataset validation rules must have exactly one implementation."""
+
+    def test_cli_uses_shared_implementation(self):
+        """The CLI command resolves validate_license to the shared function."""
+        import ospac.cli.commands as commands
+        from ospac.utils import data_validation
+
+        assert commands.validate_license is data_validation.validate_license
+
+    def test_script_uses_shared_implementation(self):
+        """scripts/validate_data.py resolves validate_license to the shared function."""
+        import importlib.util
+
+        from ospac.utils import data_validation
+
+        script_path = Path(__file__).parent.parent / "scripts" / "validate_data.py"
+        spec = importlib.util.spec_from_file_location("validate_data_script", script_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        assert module.validate_license is data_validation.validate_license
+
+    def test_shared_rule_constants(self):
+        """Sanity-check the shared rule tables."""
+        from ospac.utils.data_validation import (
+            KNOWN_LICENSES,
+            REQUIRED_TOP_FIELDS,
+            VALID_CONTAMINATION,
+            VALID_TYPES,
+        )
+
+        assert "MIT" in KNOWN_LICENSES
+        assert KNOWN_LICENSES["GPL-3.0-only"]["type"] == "copyleft_strong"
+        assert "spdx_id" in REQUIRED_TOP_FIELDS
+        assert "permissive" in VALID_TYPES
+        assert "derivative" in VALID_CONTAMINATION
+
+    def test_validate_license_known_good_record(self):
+        """A well-formed record produces no errors and no warnings."""
+        from ospac.utils.data_validation import validate_license
+
+        record = {
+            "id": "MIT",
+            "name": "MIT License",
+            "type": "permissive",
+            "spdx_id": "MIT",
+            "properties": {
+                "commercial_use": True,
+                "distribution": True,
+                "modification": True,
+                "patent_grant": False,
+                "private_use": True,
+            },
+            "requirements": {
+                "disclose_source": False,
+                "include_license": True,
+                "include_copyright": True,
+                "same_license": False,
+                "network_use_disclosure": False,
+                "state_changes": False,
+            },
+            "limitations": {"liability": True, "warranty": True, "trademark_use": False},
+            "compatibility": {
+                "static_linking": {
+                    "compatible_with": ["Apache-2.0"],
+                    "incompatible_with": [],
+                    "requires_review": [],
+                },
+                "dynamic_linking": {
+                    "compatible_with": ["Apache-2.0"],
+                    "incompatible_with": [],
+                    "requires_review": [],
+                },
+                "contamination_effect": "none",
+            },
+            "obligations": ["Include the license text"],
+            "key_requirements": ["Include copyright notice"],
+            "spdx_metadata": {
+                "is_osi_approved": True,
+                "is_fsf_libre": True,
+                "is_deprecated": False,
+            },
+        }
+
+        errors, warnings = validate_license("MIT", record)
+        assert errors == []
+        assert warnings == []

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -301,3 +301,57 @@ class TestSharedDataValidation:
         errors, warnings = validate_license("MIT", record)
         assert errors == []
         assert warnings == []
+
+
+class TestDeprecatedAliasConsistency:
+    """
+    A deprecated SPDX identifier is an alias of a modern one, so the two must classify
+    identically. Six LGPL aliases were marked copyleft_strong while their modern
+    equivalents were copyleft_weak, which made policy rules deny them where the modern
+    spelling was only flagged for review. Nothing detected the disagreement, so the
+    invariant is asserted directly against the shipped dataset.
+    """
+
+    @staticmethod
+    def _canonical(license_id):
+        if license_id.endswith("+"):
+            return license_id[:-1] + "-or-later"
+        return license_id + "-only"
+
+    def _shipped_records(self):
+        import json
+
+        data_dir = Path(__file__).parent.parent / "ospac" / "data" / "licenses" / "json"
+        records = {}
+        for path in data_dir.glob("*.json"):
+            record = json.loads(path.read_text())["license"]
+            records[record["id"]] = record
+        return records
+
+    def test_deprecated_aliases_match_their_canonical_type(self):
+        records = self._shipped_records()
+        mismatches = []
+        for license_id, record in sorted(records.items()):
+            if not record.get("spdx_metadata", {}).get("is_deprecated"):
+                continue
+            canonical = self._canonical(license_id)
+            if canonical not in records:
+                continue
+            if record["type"] != records[canonical]["type"]:
+                mismatches.append(
+                    f"{license_id} is {record['type']} but {canonical} is "
+                    f"{records[canonical]['type']}"
+                )
+        assert mismatches == [], "deprecated aliases disagree with canonical form: " + "; ".join(
+            mismatches
+        )
+
+    def test_lgpl_aliases_are_weak_copyleft(self):
+        """LGPL permits linking from proprietary code, so every spelling is weak copyleft."""
+        records = self._shipped_records()
+        for license_id in ["LGPL-2.0", "LGPL-2.0+", "LGPL-2.1", "LGPL-2.1+",
+                           "LGPL-3.0", "LGPL-3.0+", "LGPL-2.0-only", "LGPL-2.1-only",
+                           "LGPL-3.0-only"]:
+            assert records[license_id]["type"] == "copyleft_weak", (
+                f"{license_id} should be copyleft_weak, got {records[license_id]['type']}"
+            )


### PR DESCRIPTION
Repairs a group of defects left behind by the v1.2.0 YAML to JSON migration. That migration updated the dataset layout and the main evaluation paths, but several peripheral code paths kept reading the old schema and the old file locations.

Minor rather than patch: the fail-open fix changes evaluation outcomes, so builds that passed on 1.2.11 can legitimately start failing.

## The serious one: policy templates approved everything

Every policy written by `ospac policy init` matched no rules and returned `allow`.

The templates match on `license_type`, but `evaluate` never put `license_type` into the evaluation context, and `_check_condition` skips any rule naming an absent context field. So a mobile policy written to deny GPL approved it:

```console
$ ospac policy init -t mobile -o mobile_policy.yaml
$ ospac evaluate -l GPL-3.0 -d mobile -p mobile_policy.yaml
{ "result": { "action": "allow", "message": "No policies matched" } }
```

It failed open, so nothing drew attention to it in CI.

`evaluate` now resolves each license's type from the dataset, and `license_type` matching accepts any evaluated license, mirroring how the `license` key already worked. Evaluating several licenses at once involves more than one type, so a single scalar could not express the case and the generic branch could not compare a list against a list. Scalar contexts keep working, which is what the existing tests rely on. `check_compatibility()` was missing the same field and now populates it too.

All six deny-copyleft templates verified:

| Template | GPL-3.0 | MIT |
|:--|:--|:--|
| mobile, desktop, web, server, embedded, library | `deny` | `approve` |

## A crash the fail-open was hiding

The bundled enterprise policy and the desktop and server templates use `action: review`, but `ActionType` defines only `FLAG_FOR_REVIEW`, so `ActionType["REVIEW"]` raised `KeyError` and the CLI exited with `Error: 'REVIEW'`. Those rules could never fire while templates matched nothing, so the crash was never observed. `review` is now accepted as shorthand for `flag_for_review`.

## Six LGPL identifiers were classified as strong copyleft

`LGPL-2.0`, `LGPL-2.0+`, `LGPL-2.1`, `LGPL-2.1+`, `LGPL-3.0` and `LGPL-3.0+` were typed `copyleft_strong`, while the modern identifiers they are deprecated aliases of were correctly `copyleft_weak`. An alias must classify identically to the identifier it aliases, and LGPL is the canonical weak copyleft license regardless: it permits linking from proprietary code.

The pipeline's correction table already declared LGPL as weak, but listed only the `-only` and `-or-later` spellings, so the misclassification survived for the bare and `+` forms. Those are the spellings that appear most often in real package metadata.

This produced wrong compliance decisions, not just wrong metadata. The `desktop` and `server` templates denied `LGPL-2.1` while merely flagging `LGPL-3.0-only` for review, despite identical obligations:

| Template | before | after |
|:--|:--|:--|
| desktop, server | `LGPL-2.1` denied, `LGPL-3.0-only` reviewed | both `flag_for_review` |

It was latent until `license_type` started reaching the context earlier in this branch, since no rule matching on `license_type` ever fired. Repairing evaluation activated the data defect, which is why both are fixed together.

`type` and the derived `key_requirements` are taken from each alias's canonical counterpart so they cannot disagree, `index.json`'s duplicate `category` field is updated, and the aliases are added to the correction table so regeneration keeps them. A test asserts the invariant against the shipped dataset for **every** deprecated alias, not just LGPL, since nothing previously checked that an alias agrees with what it aliases. Both new tests fail against the old data.

## Also fixed

- **`data validate`** only looked for `licenses/spdx/*.yaml`, the pre-1.2.0 layout, and always exited `SPDX directory not found`. It now validates the shipped JSON dataset, defaults to the packaged data directory, and supports `--strict`.
- **`data show -f text`** read `category`, `permissions` and `conditions`, renamed in the migration to `type`, `properties` and `requirements`, so it printed `Category: None` and empty sections. JSON and YAML output unchanged.
- **`PolicyRuntime.get_obligations()`** read `obligations` from the top level of a record that nests them under a `license` key, so it always returned `{}`.
- **Obligation enrichment** resolved a cwd-relative `data/` path instead of the packaged one, so it was a silent no-op for anyone who pip-installed the package.
- **`requirements` ordering** was not reproducible. `PolicyResult.aggregate` deduplicated through a `set`, so the array came back in a different order every run, which breaks diffing output or keeping it as compliance evidence.
- **The default-policy hint** suggested `ospac init`, which does not exist.

## Test coverage was the root cause

`tests/test_cli.py` is the first CLI-level test file in the project. The absence of any test exercising the CLI's own context construction is what let the fail-open ship with a green suite: the existing tests hand-build contexts that already contain `license_type`, so nothing covered the code that has to derive it.

Suite goes from 64 to **111 passing**.

## Housekeeping

- Validation rules moved to `ospac.utils.data_validation`, imported by both the CLI command and `scripts/validate_data.py`. Rewriting the command briefly duplicated them, and duplicated-then-drifted code is the cause of nearly everything in this PR, so the copy was collapsed before it could drift. Both validators produce identical output.
- `__version__` now reads installed package metadata, making `pyproject.toml` the single source of truth. The SPDX sync bumps only `pyproject.toml`, so the hardcoded literal fell behind every month and had already drifted again. This also fixes `ospac --version` and `ospac.__version__` being able to disagree.
- Coverage config pointed at the `osslili` package. The dead `[tool.pytest.ini_options]` block, shadowed by `pytest.ini`, was removed. `MANIFEST.in` referenced a nonexistent `ospac/ospac/data` path and omitted the dataset's CC BY-NC-SA notice.
- Em dash punctuation removed from documentation and prose, including the sync workflow and release notes templates, which were stamping them into git history monthly.
- License counts no longer hardcoded in prose. The dataset grew from 729 to 733 with the last sync and will keep growing.

## Verification

- 111 tests pass
- All six templates deny their target copyleft class and approve permissive licenses
- Multi-license `MIT,GPL-3.0` denies, proving any-match semantics
- `LGPL-2.1` and `LGPL-3.0-only` now receive identical treatment on every template
- No deprecated alias in the dataset disagrees with its canonical form
- Default policy regressions hold: GPL denied for commercial, GPL-2.0 and Apache-2.0 incompatible, MIT and GPL-3.0 compatible
- `requirements` ordering identical across runs and across `PYTHONHASHSEED` values
- Obligation enrichment works from an unrelated working directory
- Both validators report 733 files, 732 clean, 1 warning, 0 errors; `--strict` exits 1
- sdist builds as `ospac-1.3.0` containing all 733 license files, with `Documentation` pointing at the docs site

## Left for a deliberate decision

- **`LGPLLR` remains `copyleft_strong`.** It is a distinct license rather than a deprecated alias, so the structural invariant above does not settle it, and reclassifying it means reading the license text rather than comparing records. Its structured requirements are identical to `LGPL-2.1`'s and its name points at the lesser model, so it probably belongs in weak, but strong is the conservative direction and this is a legal reading that deserves review rather than a drive-by change.
- **`ActionType.ALLOW` outranks `APPROVE`** in the aggregate priority map, so an unmatched-rule `allow` shadows an explicit `approve`. Both map to `COMPLIANT` so no verdict changes, but it decides which result supplies `remediation`. Changing it would alter stored compliance evidence for any policy mixing both actions.
- **CI coverage has never run.** `pytest-cov` is installed, no `--cov` flag is passed, `coverage.xml` is never written, and the codecov upload swallows the failure. This is why `source = osslili` went unnoticed for so long. Enabling it changes what codecov reports, so it wants its own decision. Baseline is roughly 54%.