### PR TITLE
fix: repair a licence dataset that was never actually analysed

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -22,8 +22,12 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest ruff black
-        pip install -e . || pip install .
+        # Install the project's own test extra rather than naming plugins here. This job
+        # listed pytest without pytest-asyncio while the Tests workflow installed it, so the
+        # two jobs ran the same suite with different plugins and the async tests errored
+        # here only.
+        pip install ruff black
+        pip install -e ".[test]"
 
     - name: Format check with black
       run: |

--- a/.github/workflows/spdx-sync.yml
+++ b/.github/workflows/spdx-sync.yml
@@ -132,6 +132,19 @@ jobs:
         if: steps.spdx-check.outputs.has_work == 'true' || github.event.inputs.force_reprocess == 'true'
         run: python scripts/validate_data.py --data-dir ospac/data
 
+      - name: Upload generated data for review
+        # A partial reprocess is expected to fail the corpus gate below while fabricated
+        # records remain, and a failed job discards its workspace. Uploading the dataset
+        # first means a trial run's output can still be reviewed record by record.
+        if: always() && (steps.spdx-check.outputs.has_work == 'true' || github.event.inputs.force_reprocess == 'true')
+        uses: actions/upload-artifact@v4
+        with:
+          name: generated-data-${{ github.run_id }}
+          path: |
+            ospac/data/licenses/json/
+            ospac/data/index.json
+          retention-days: 14
+
       - name: Corpus quality gate
         # Per-record validation cannot see that the whole corpus is templated, which is
         # exactly how years of fabricated fallback data shipped: every record was

--- a/.github/workflows/spdx-sync.yml
+++ b/.github/workflows/spdx-sync.yml
@@ -132,6 +132,16 @@ jobs:
         if: steps.spdx-check.outputs.has_work == 'true' || github.event.inputs.force_reprocess == 'true'
         run: python scripts/validate_data.py --data-dir ospac/data
 
+      - name: Corpus quality gate
+        # Per-record validation cannot see that the whole corpus is templated, which is
+        # exactly how years of fabricated fallback data shipped: every record was
+        # individually well formed. This gate fails if decision fields are uniform across
+        # the corpus or any record matches a known fallback fingerprint. It runs on full
+        # regenerations; routine deltas would fail on the pre-existing fabricated records
+        # until the first full regeneration clears them.
+        if: github.event.inputs.force_reprocess == 'true'
+        run: python scripts/corpus_quality.py --data-dir ospac/data
+
       - name: Bump patch version
         id: version
         if: steps.spdx-check.outputs.has_work == 'true' || github.event.inputs.force_reprocess == 'true'

--- a/.github/workflows/spdx-sync.yml
+++ b/.github/workflows/spdx-sync.yml
@@ -36,7 +36,21 @@ jobs:
       - name: Install OSPAC and dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[llm]" 2>/dev/null || pip install -e . openai
+          pip install -e ".[llm]"
+
+      - name: Preflight LLM provider check
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          python3 - <<'EOF'
+          from ospac.pipeline.llm_analyzer import LicenseAnalyzer
+
+          # Raises ProviderUnavailableError if the openai package is missing
+          # or the OPENAI_API_KEY secret is not set, failing the job before
+          # any data generation can produce fabricated fallback records.
+          LicenseAnalyzer(provider="openai", require_provider=True)
+          print("Preflight OK: openai package installed and API key present")
+          EOF
 
       - name: Check SPDX upstream state
         id: spdx-check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,11 @@ jobs:
 
     - name: Run tests
       run: |
-        pytest tests/ -v --tb=short
+        # pytest-cov was installed and coverage.xml was uploaded, but no --cov flag was
+        # ever passed, so the file was never written and the upload silently did nothing.
+        # That is why coverage pointing at the wrong package went unnoticed.
+        pytest tests/ -v --tb=short \
+          --cov=ospac --cov-report=term-missing --cov-report=xml
 
     - name: Upload coverage
       if: matrix.os == 'ubuntu-latest'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to OSPAC (Open Source Policy as Code) will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2026-08-11
+
+Clears the three items 1.3.0 left open.
+
+### Fixed
+
+**An explicit approval could be reported as `allow`**
+- A policy rule that states no action falls back to `ALLOW`, and the aggregate ranked
+  `ALLOW` above `APPROVE`, so a single actionless rule made the whole evaluation report
+  `allow` even when another rule had explicitly approved the licenses.
+- That contradicts the documented meaning of the field, where `allow` indicates that no
+  rule matched and is worth treating as a policy bug. A correct policy mixing an explicit
+  `approve` rule with an actionless one therefore looked broken, and CI written against the
+  documented values would fail on it.
+- Between `ALLOW` and `APPROVE` neither is more restrictive, so the more informative one
+  now wins. `DENY`, `CONTAMINATE` and `FLAG_FOR_REVIEW` still outrank both, and an
+  evaluation where nothing matches still reports `allow` with `No policies matched`.
+
+**`LGPLLR` was classified as strong copyleft**
+- Its properties, requirements, limitations and contamination effect are all identical to
+  `LGPL-2.1`, so typing it `copyleft_strong` while `LGPL-2.1` is `copyleft_weak` was
+  inconsistent on the dataset's own terms. It is also, by name and design, the lesser
+  licence for linguistic resources.
+- Corrected in the record and in `index.json`, added to the pipeline correction table so
+  regeneration keeps it, and pinned in the validator spot checks as a deliberate decision.
+
+### Changed
+
+**CI coverage now actually runs**
+- `pytest-cov` was installed and `coverage.xml` was uploaded to Codecov, but no `--cov`
+  flag was ever passed, so the file was never written and the upload silently did nothing.
+  This is why coverage being pointed at the `osslili` package went unnoticed for so long,
+  and why an earlier README could claim full coverage.
+- The test job now passes `--cov=ospac` with terminal and XML reports. A `codecov.yml`
+  marks both the project and patch statuses as informational, so coverage is reported and
+  commented but can never fail a pull request. Enforcing a target remains a separate
+  decision. Current coverage is 64%.
+
 ## [1.3.0] - 2026-08-11
 
 This release repairs a group of defects left behind by the v1.2.0 migration from YAML to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,9 @@ Clears the three items 1.3.0 left open.
 - The test job now passes `--cov=ospac` with terminal and XML reports. A `codecov.yml`
   marks both the project and patch statuses as informational, so coverage is reported and
   commented but can never fail a pull request. Enforcing a target remains a separate
-  decision. Current coverage is 64%.
+  decision. Coverage measures 54% in CI. It reads higher on a developer machine that has
+  the optional LLM SDKs installed, because the pipeline modules then take import branches
+  the runner does not, so the CI figure is the one to trust.
 
 ## [1.3.0] - 2026-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@ never actually been analysed.
   `approve` rule with an actionless one therefore looked broken, and CI written against the
   documented values would fail on it.
 - Between `ALLOW` and `APPROVE` neither is more restrictive, so the more informative one
-  now wins. `DENY`, `CONTAMINATE` and `FLAG_FOR_REVIEW` still outrank both, and an
-  evaluation where nothing matches still reports `allow` with `No policies matched`.
+  now wins. `DENY`, `CONTAMINATE` and `FLAG_FOR_REVIEW` still outrank both. An evaluation
+  where nothing matches returns `flag_for_review`, described under its own entry below.
 
 **`LGPLLR` was classified as strong copyleft**
 - Its properties, requirements, limitations and contamination effect are all identical to
@@ -97,7 +97,92 @@ never actually been analysed.
   section. Its other entries duplicated rules that already exist, and config that looks
   authoritative while never executing is how several defects here went unnoticed.
 
+**One license in a set could answer for all of them**
+- Evaluation ran once over the whole license list, so a rule matched by any license
+  produced a result and the no-match fail-safe never ran for the others.
+  `evaluate -l "MIT,AGPL-3.0"` was approved: MIT fired the permissive rule, AGPL matched
+  nothing, and nothing spoke for it. Real dependency lists almost always contain a
+  permissive license, so the fail-safe was inert exactly where it mattered.
+- Each license is now evaluated independently and the verdicts aggregate with
+  most-restrictive-wins. A license that matches no rule falls to the fail-safe on its own,
+  so `MIT,MPL-2.0` reports `flag_for_review` and `MIT,AGPL-3.0` reports `deny`. The JSON
+  output gains a `per_license` map showing each license's own verdict.
+
+**`ospac check` reported a license as incompatible with itself**
+- The fail-safe applied to compatibility checks too, and the check context carries no
+  distribution type, so no category rule could match, nothing matched at all, and the
+  review answer surfaced as `compatible: false` with empty violations for 80 licenses,
+  including `check GPL-3.0-only GPL-3.0-only`.
+- A compatibility question asks whether a conflict is known, so no conflict rule matching
+  now answers "no known conflicts" rather than "needs review". The review default remains
+  for `evaluate`, where an unmatched case genuinely is an unanswered question.
+- `check` output gains `requires_review` and `warnings`, and warns when a license id does
+  not resolve in the dataset instead of letting a typo read as clean compatibility.
+
+**The policy's compatibility matrix was dead config**
+- The `compatibility:` section in the bundled policy was never read by the runtime, so
+  `ospac check BSD-4-Clause GPL-3.0-only` reported compatible while the policy's own file
+  declared that pair incompatible. Its pairs are now real rules, including both directions
+  of the BSD-4-Clause advertising-clause conflict and the one-way MIT into GPL-2.0 and
+  Apache-2.0 into GPL-3.0 combinations, and the dead section is removed.
+
+**Weak copyleft had no passing path**
+- The category rules added for weak copyleft could deny and review but nothing ever
+  approved, so `MPL-2.0` had no outcome other than review in any context. A category rule
+  now approves weak copyleft under dynamic linking with the containment requirements, and
+  the general context stays a review because the tool cannot see how the component is
+  linked.
+
+**`-o markdown` rendered every approval as Denied**
+- The renderer treated only the literal action `allow` as good, so `approve` printed
+  `❌ Denied` and the text renderer coloured it red. Category approval moved 645 licenses
+  from `allow` to `approve`, turning a latent bug into "Denied" for Zlib and ISC in
+  anything that pasted the markdown into a report. Both renderers now map every action to
+  an honest status, including `⚠️ Requires review`.
+
+**`data generate` without `--use-llm` wrote an inverted dataset**
+- With the fallback now failing closed, the no-provider path produced records claiming
+  0BSD forbids commercial use and requires source disclosure, printed a green checkmark
+  and exited zero. The command now refuses to run without `--use-llm`, since every record
+  on that path is a placeholder, and the shipped package already contains real data.
+- When the fallback gate does trip on an LLM run, the fabricated records are now deleted
+  before exiting, because delta processing treats on-disk files as complete and a rerun
+  would have skipped the poisoned records while reporting a clean dataset.
+
+**Restrictions stated in license names and identifiers are now derived, not hand edits**
+- The ShareAlike retypes shipped earlier in this release existed only as edited JSON: the
+  pipeline would have written `permissive` back over them on the next regeneration, and
+  the validator would have accepted it. The same silent-revert failure this release
+  diagnoses elsewhere, one field over.
+- The pipeline now retypes ShareAlike and reciprocal licenses out of `permissive` itself,
+  types NoDerivatives records as `no_derivatives`, and forces `noncommercial` regardless
+  of what the analysis claimed. Name stems catch Non-Profit, Reciprocal and copyleft
+  naming, adding `NPOSL-3.0`, `MS-RL`, `RPL`, `CERN-OHL` and the `copyleft-next` family.
+- Mainstream licenses the fabricated data recorded as freely permissive are pinned in the
+  correction table with what their texts actually say: EPL, CDDL, EUPL, OSL, SSPL, CAL,
+  BUSL, Elastic, Parity, Aladdin, ODbL and CDLA-Sharing. `SSPL-1.0` for SaaS now denies.
+- A test asserts every shipped record is exactly what the pipeline reproduces for it, so a
+  repair that exists only as a hand edit can no longer ship.
+- Validator invariants strengthened accordingly: `commercial_use` false requires the
+  `noncommercial` type, `modification` false and `same_license` true each contradict
+  `permissive`. 86 records were re-repaired under these rules, and compatibility
+  descriptors on retyped records no longer describe them as permissive.
+
 ### Added
+
+**A corpus-level quality gate**
+- Per-record validation cannot see that a whole dataset is templated, which is exactly how
+  years of fabricated records shipped: each record was individually well formed.
+  `scripts/corpus_quality.py` fails when decision fields are uniform across the corpus or
+  when any record matches a known fallback fingerprint, and runs in the sync workflow on
+  full regenerations.
+
+**A `no_derivatives` license type**
+- NoDerivatives licenses permit verbatim redistribution, including commercially, but
+  forbid distributing modified versions. They sat in `permissive` with
+  `modification: false`, which the category approval rule blessed for commercial
+  distribution without surfacing the restriction. The bundled policy flags them for a
+  human to confirm the component is unmodified.
 
 **A `noncommercial` license type**
 - Licences that permit use, modification and redistribution but withhold commercial use had

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ All notable changes to OSPAC (Open Source Policy as Code) will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.3.1] - 2026-08-11
+## [1.4.0] - 2026-08-11
 
-Clears the three items 1.3.0 left open.
+Clears the three items 1.3.0 left open, and repairs a licence dataset that had
+never actually been analysed.
 
 ### Fixed
 
@@ -30,6 +31,56 @@ Clears the three items 1.3.0 left open.
   licence for linguistic resources.
 - Corrected in the record and in `index.json`, added to the pipeline correction table so
   regeneration keeps it, and pinned in the validator spot checks as a deliberate decision.
+
+**The LLM analysis had never run, and its fallback fabricated permissive data**
+- `.github/workflows/spdx-sync.yml` installs with `pip install -e ".[llm]" 2>/dev/null || pip
+  install -e . openai`, but the `[llm]` extra contained only `strands-agents`, so the first
+  command succeeded and the fallback that installs `openai` never ran. The package the
+  provider imports was never present.
+- The provider caught the `ImportError`, set itself unavailable, and every licence fell
+  through to `_get_fallback_analysis()`, which hardcoded `category: "permissive"` with
+  `commercial_use: True` and every copyleft condition false. The job exited zero, the
+  validator passed, the pull request auto-merged and published.
+- 683 of 733 records carry that fingerprint. The 50 that do not are the GPL, LGPL, MPL and
+  public domain families, which a deterministic name matcher already handled. No record in
+  the dataset was ever produced by an actual model.
+- Provider construction now raises instead of degrading, so an explicitly requested
+  provider that cannot initialise aborts the run before any licence is processed, and the
+  workflow gained a preflight step that fails immediately on a missing package or secret.
+- The fallback now fails closed rather than open: category `unknown`, every permission
+  denied, obligations that ask for manual legal review. A run that produced any fallback
+  record reports the identifiers and exits non-zero, so a partly fabricated dataset cannot
+  be published.
+- The `[llm]` extra now installs `openai`, `anthropic` and `ollama`, which are what the
+  three providers actually import. `strands-agents` was imported nowhere and was dropped.
+
+**Every NonCommercial licence was marked commercially usable**
+- A consequence of the fallback above. `ospac evaluate -l CC-BY-NC-3.0-IGO -d commercial`
+  returned `allow`, which is the most dangerous direction for a compliance tool to be wrong
+  in. OSPAC's own dataset licence, CC BY-NC-SA 4.0, was described as permissive and
+  commercially usable, contradicting `DATA_LICENSE`.
+- 43 records repaired: 26 NonCommercial licences that permitted commercial use, 13
+  NoDerivatives licences that permitted modification, and 21 ShareAlike licences that
+  carried no same-licence requirement.
+- Creative Commons states these terms in the identifier itself, so the pipeline now derives
+  them rather than asking a model. Matching is on hyphen-delimited identifier components,
+  with a punctuation-insensitive name check that also catches `NCGL-UK-2.0` and
+  `PolyForm-Noncommercial-1.0.0`, neither of which has an `NC` component.
+- The validator gained the matching invariants as errors, so the class cannot ship again.
+- The bundled enterprise policy now denies NonCommercial licences for commercial, SaaS,
+  embedded, mobile, desktop, web, cloud and API distribution, and flags them for review
+  elsewhere. Repairing the data alone was not enough, since no rule covered them.
+
+### Added
+
+**A `noncommercial` license type**
+- Licences that permit use, modification and redistribution but withhold commercial use had
+  no honest category. `permissive` is a contradiction, `source_available` describes source
+  visibility, and `proprietary` means all rights reserved. Because policy rules match on
+  `license_type`, leaving them in `permissive` is what let a permissive-allow rule approve
+  them for commercial distribution.
+- ShareAlike licences still typed `permissive` were moved to `copyleft_weak`, since a
+  share-alike term binds derivative works.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,32 @@ never actually been analysed.
   embedded, mobile, desktop, web, cloud and API distribution, and flags them for review
   elsewhere. Repairing the data alone was not enough, since no rule covered them.
 
+**An unmatched evaluation reported `allow`**
+- When no rule matched, the result was `action: allow` with `No policies matched`. A policy
+  with no rule for a case has not approved it, it has no answer, and reporting those
+  identically meant a policy whose rules had silently stopped matching read as a clean pass.
+- Unmatched evaluations now return `flag_for_review` with a warning severity and a
+  remediation suggesting either a rule for the case or an explicit approval after review.
+- This is a behaviour change for anyone whose CI treated `allow` as success. Uncovered cases
+  now arrive as `flag_for_review`.
+
+**The bundled policy denied copyleft by enumerated identifier only**
+- `no_gpl_in_products` and `no_agpl_in_services` list individual licenses, so a copyleft
+  license nobody had listed fell through every rule. `AGPL-3.0` evaluated for commercial
+  distribution came back permitted.
+- Added category rules for strong copyleft in distributed products, network copyleft in
+  hosted services, and weak copyleft under static linking. These match on `license_type`,
+  which only began working earlier in this release.
+
+**Permissive licenses were approved only if individually listed**
+- The rule approving permissive and public domain licenses by category existed solely in the
+  policy's `decision_tree` section, which the runtime never reads: it evaluates `rules` only.
+  So `MIT`, `Apache-2.0` and `BSD` passed because they are enumerated, while `ISC`, `Zlib`
+  and several hundred others matched nothing at all. Invisible while unmatched meant `allow`.
+- Ported that rule into `rules` as `approve_permissive`, and removed the `decision_tree`
+  section. Its other entries duplicated rules that already exist, and config that looks
+  authoritative while never executing is how several defects here went unnoticed.
+
 ### Added
 
 **A `noncommercial` license type**

--- a/README.md
+++ b/README.md
@@ -74,8 +74,10 @@ You never run the generation pipeline to use OSPAC. See [The dataset](https://se
 
 ```bash
 ACTION=$(ospac evaluate -l "$LICENSES" -d mobile | jq -r '.result.action')
-[ "$ACTION" = "deny" ] && exit 1
+case "$ACTION" in deny|flag_for_review) exit 1 ;; esac
 ```
+
+**An unanswered question is not an approval.** When no rule matches, OSPAC returns `flag_for_review`, not `allow`. A policy with no rule for a case has not permitted it, so the gap is reported rather than treated as a pass.
 
 See [Integration](https://semclone.github.io/ospac/integration/) for a CI gate that cannot pass by accident.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,21 @@
+# Coverage is reported but never gates a merge.
+#
+# Until now no coverage was produced at all: pytest-cov was installed, no --cov flag was
+# passed, and the upload step pointed at a coverage.xml that nothing wrote. Turning real
+# reporting on would otherwise let Codecov's default project status start failing pull
+# requests on any coverage dip, which is not a gate this project has opted into.
+#
+# informational keeps the status advisory, so Codecov comments and reports without ever
+# marking a check as failed. Remove these once the team decides to enforce a target.
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: "reach, diff, files"
+  require_changes: true

--- a/docs/api.md
+++ b/docs/api.md
@@ -83,6 +83,26 @@ A context missing a field that a rule matches on causes that rule to be skipped,
 error. If evaluation returns `flag_for_review` with `"No policy rule matched"` when you
 expected a denial, the rule was skipped: check the context keys first.
 
+### evaluate_licenses
+
+```python
+result, per_license = runtime.evaluate_licenses(
+    ["MIT", "MPL-2.0"],
+    {"distribution_type": "commercial", "distribution": "commercial",
+     "context": "general", "linking_type": None},
+)
+```
+
+The per-license entry point, and the one the CLI uses. Each license is evaluated
+independently, with its own `license_type` resolved from the dataset, and the verdicts
+aggregate with most-restrictive-wins. `evaluate()` judges the context as a single unit, so
+a rule matched by one license produces a result and the no-match fail-safe never runs for
+the others: with `evaluate()`, one permissive license in the list can answer for a license
+that matched nothing. Use `evaluate_licenses` whenever the input is a list of licenses.
+
+`per_license` maps each license id to its own `PolicyResult`, so you can report which
+license drove the aggregate verdict.
+
 ### check_compatibility
 
 ```python

--- a/docs/api.md
+++ b/docs/api.md
@@ -29,8 +29,8 @@ runtime = PolicyRuntime(skip_default=True)      # no policy at all
 
 `PolicyRuntime._using_default` tells you whether the default policy was loaded. It is
 underscore-prefixed but it is what the CLI checks to emit its warning, and it is worth
-asserting on in automation. See the fail-open discussion in
-[Policies]({{ site.baseurl }}/policies/#nothing-matching-means-allow).
+asserting on in automation. See
+[Policies]({{ site.baseurl }}/policies/#nothing-matching-means-review-not-approval).
 
 ```python
 runtime = PolicyRuntime("./policy.yaml")
@@ -80,8 +80,8 @@ if result.action == ActionType.DENY:
 ```
 
 A context missing a field that a rule matches on causes that rule to be skipped, not to
-error. If evaluation returns `allow` with `"No policies matched"` when you expected a
-denial, check the context keys first.
+error. If evaluation returns `flag_for_review` with `"No policy rule matched"` when you
+expected a denial, the rule was skipped: check the context keys first.
 
 ### check_compatibility
 

--- a/docs/dataset.md
+++ b/docs/dataset.md
@@ -136,7 +136,7 @@ the file on disk has the extra nesting level.
 
 | Field | Meaning |
 |:--|:--|
-| `type` | Family: `permissive`, `copyleft_weak`, `copyleft_strong`, `proprietary`, `public_domain`. Policy rules match on this via `license_type`. |
+| `type` | Family: `permissive`, `copyleft_weak`, `copyleft_strong`, `network_copyleft`, `noncommercial`, `no_derivatives`, `source_available`, `proprietary`, `public_domain`, `unknown`. Policy rules match on this via `license_type`. `noncommercial` and `no_derivatives` exist because those restrictions contradict `permissive`, and policy rules that approve by category would otherwise bless them. |
 | `properties` | What the license lets you do. |
 | `requirements` | Conditions you must satisfy. The booleans here drive `obligations`. |
 | `limitations` | What the license withholds: warranty, liability, trademark grant. |

--- a/docs/index.md
+++ b/docs/index.md
@@ -99,10 +99,7 @@ no network calls and consults no model. LLMs appear in exactly one place, regene
 dataset, a maintainer task described in [The dataset]({{ site.baseurl }}/dataset/). The tool
 you install does not use them.
 
-Decisions are reproducible, with one wrinkle: the `requirements` array comes back in a
-different order on each run. See
-[Integration]({{ site.baseurl }}/integration/#the-semclone-toolchain) before you diff ospac
-output between runs.
+Decisions are reproducible, so the same inputs give byte-identical output run to run.
 
 ## Where to go next
 

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -232,7 +232,15 @@ The fields worth building on, all present in `evaluate` output:
 | `result.requirements` | Obligations attached to the decision |
 | `using_default_policy` | Whether your policy or the bundled default answered |
 
-`check` returns `compatible` as a boolean plus `violations`. `obligations -f json` returns
+`evaluate` also returns a `per_license` map with each license's own action, so a review or
+denial can be attributed to the license that caused it rather than to the set.
+
+`check` returns `compatible` plus `requires_review`, `violations` and `warnings`.
+`compatible: false` with `requires_review: true` means a human needs to look, not that a
+conflict is known; a warning is added when a license id does not resolve in the dataset,
+so a typo cannot read as clean compatibility. When no conflict rule matches, `check`
+answers "no known conflicts" rather than review, so a license is always compatible with
+itself. `obligations -f json` returns
 the full licence records under `license_data`, whose schema is in
 [The dataset]({{ site.baseurl }}/dataset/#what-a-license-record-contains).
 

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -38,9 +38,9 @@ policy, a malformed dataset.
 
 ## A CI gate that cannot pass by accident
 
-Three things can make a compliance check silently succeed: the decision is ignored (above),
-the custom policy failed to load and the default answered instead, or the rules matched
-nothing and the result defaulted to `allow`. This job guards all three.
+Two things can still make a compliance check pass without meaning much: the decision is
+ignored (above), or the custom policy failed to load and the bundled default answered
+instead. This job guards both, and also treats an unanswered case as a failure.
 
 ```yaml
 name: License compliance
@@ -88,8 +88,8 @@ jobs:
 
       - name: Prove the policy still bites
         run: |
-          # A policy whose rules have gone inert returns "allow" for everything.
-          # Assert on a case that must be denied.
+          # Rules going inert now surfaces as flag_for_review rather than a silent pass,
+          # but asserting on a case that must be denied still catches it soonest.
           ACTION=$(ospac evaluate -l GPL-3.0 -d mobile -p ./compliance-policy.yaml \
             | jq -r '.result.action')
           if [ "$ACTION" != "deny" ]; then
@@ -98,8 +98,9 @@ jobs:
           fi
 ```
 
-That last step is the one people leave out. Because unmatched rules produce `allow`, a
-policy that stops matching looks identical to a clean codebase. See
+That last step is worth keeping even though the fail-safe default now covers the same
+ground. It fails on the specific rule you care about rather than on a generic review
+request, which is a much faster diagnosis. See
 [Policies]({{ site.baseurl }}/policies/) for why rules go inert. Most often a `when` clause
 naming a context field that is not populated.
 
@@ -156,21 +157,6 @@ ospac evaluate -l "$LICENSES" -d mobile
 
 Note that `approve` still carries `requirements`. Permission to ship is not the same as
 having nothing to do. Feed those into your NOTICE file.
-
-{: .warning }
-> **`requirements` ordering is not stable.** `PolicyResult.aggregate` deduplicates through a
-> `set`, so the array comes back in a different order on each run:
->
-> ```bash
-> $ for i in 1 2 3; do ospac evaluate -l Apache-2.0 -d mobile | jq -c '.result.requirements'; done
-> ["Include Apache 2.0 license text","State changes made to the code","Preserve copyright and NOTICE file if present"]
-> ["State changes made to the code","Include Apache 2.0 license text","Preserve copyright and NOTICE file if present"]
-> ["State changes made to the code","Preserve copyright and NOTICE file if present","Include Apache 2.0 license text"]
-> ```
->
-> The contents are stable; only the order moves. Do not diff this array between runs or
-> commit it as evidence unchanged. Sort it first (`jq '.result.requirements | sort'`), or
-> compare as a set.
 
 Install the neighbours with the extra:
 
@@ -239,7 +225,7 @@ The fields worth building on, all present in `evaluate` output:
 
 | Field | Use |
 |:--|:--|
-| `result.action` | The decision: `approve`, `deny`, `flag_for_review`, or `allow` when nothing matched |
+| `result.action` | The decision: `approve`, `deny`, or `flag_for_review`. Also `allow` when a matched rule states no action of its own |
 | `result.severity` | `error`, `warning`, `info` |
 | `result.message` | Why |
 | `result.remediation` | What to do instead, on a denial |
@@ -250,16 +236,26 @@ The fields worth building on, all present in `evaluate` output:
 the full licence records under `license_data`, whose schema is in
 [The dataset]({{ site.baseurl }}/dataset/#what-a-license-record-contains).
 
-Treat `allow` and `approve` as distinct. `approve` means a rule matched and permitted it;
-`allow` means nothing matched at all. The second is frequently a policy bug, and it is worth
-logging differently:
+An evaluation that matches no rule returns `flag_for_review`, not `allow`. A policy with no
+rule for a case has not approved it, it has no answer, so ospac surfaces that rather than
+permitting it. Handle all four values explicitly:
 
 ```bash
 RESULT=$(ospac evaluate -l "$LICENSES" -d "$DIST" -p ./policy.yaml)
 case "$(echo "$RESULT" | jq -r '.result.action')" in
   deny)            echo "blocked"; exit 1 ;;
-  flag_for_review) echo "needs review" ;;
+  flag_for_review) echo "needs review"; exit 1 ;;
   approve)         echo "ok" ;;
-  allow)           echo "no rule matched, check the policy covers $DIST"; exit 1 ;;
+  allow)           echo "permitted by a rule that states no action" ;;
 esac
 ```
+
+Whether `flag_for_review` should fail the build is yours to decide. Failing is the safer
+default, since it covers both "legal must look at this" and "the policy does not mention
+this case". If you let it pass, log it somewhere a human reads, otherwise a policy that has
+drifted out of coverage becomes invisible again.
+
+{: .note }
+> Before 1.4.0 an unmatched evaluation returned `allow`, so a CI job checking only for `deny`
+> would pass on a policy whose rules had stopped matching entirely. If you wrote such a job
+> against an earlier version, uncovered cases now arrive as `flag_for_review`.

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -77,45 +77,27 @@ values are conventionally more important.
 | `context` | The `-c` value | `general` by default. |
 | `linking_type` | The `-c` value, but **only if it contains "linking"** | `null` otherwise, so a `linking_type` rule is inert unless you pass `-c static_linking` or `-c dynamic_linking`. |
 
-{: .warning }
-> **`license_type` does not work, and the built-in templates depend on it.**
->
-> `ospac evaluate` never puts `license_type` into the context, so any rule matching on
-> `license_type: copyleft_strong` is silently skipped. Every policy written by
-> `ospac policy init` matches on `license_type`, which means the generated templates match
-> nothing:
->
-> ```bash
-> $ ospac policy init --template mobile --output mobile_policy.yaml
-> $ ospac evaluate -l GPL-3.0 -d mobile -p mobile_policy.yaml
-> {
->   "result": {
->     "action": "allow",
->     "message": "No policies matched"
->   }
-> }
-> ```
->
-> GPL-3.0 under a mobile policy that is written to deny it returns `allow`. This fails
-> open, so it will not draw attention to itself in CI.
->
-> Until this is fixed, match on `license` with explicit SPDX IDs instead of on
-> `license_type`. That path works: it is what the bundled default enterprise policy uses,
-> and why the default policy produces correct answers while the templates do not.
+{: .note }
+> **Before 1.3.0, `license_type` never reached the evaluation context**, so rules
+> matching on it were silently skipped and the generated templates matched nothing. That
+> is fixed: `evaluate` resolves each license's type from the dataset, and each license in
+> a multi-license evaluation is judged independently, so one permissive license cannot
+> answer for the others.
 
-Rewriting the example above to match on `license` makes it fire:
+Matching on `license_type` is now the preferred way to write category rules, because it
+covers licenses nobody remembered to enumerate:
 
 ```yaml
 rules:
-  - id: deny_gpl_mobile
+  - id: deny_strong_copyleft_mobile
     priority: 10
     when:
       distribution_type: ["mobile"]
-      license: ["GPL-2.0", "GPL-3.0", "GPL-3.0-only", "GPL-3.0-or-later"]
+      license_type: "copyleft_strong"
     then:
       action: deny
       severity: error
-      message: "GPL conflicts with app store terms"
+      message: "Strong copyleft conflicts with app store terms"
       remediation: "Use an MIT or Apache-2.0 alternative"
 ```
 
@@ -125,11 +107,17 @@ $ ospac evaluate -l GPL-3.0 -d mobile -p mobile_policy.yaml
     "remediation": "Use an MIT or Apache-2.0 alternative"
 ```
 
-The cost of this approach is that ID lists need maintaining, since a license family has many
-spellings (`GPL-3.0`, `GPL-3.0-only`, `GPL-3.0-or-later`, `GPL-3.0+`), and a missing
-variant is a rule that quietly does not cover it. Enumerate the variants you actually
-encounter, and read `ospac/data/compatibility/categories.json` for the full membership of
-each family.
+The types the dataset uses are listed in
+[The dataset]({{ site.baseurl }}/dataset/#what-a-license-record-contains). Two exist
+precisely so category rules stay honest: `noncommercial` for licenses that forbid
+commercial use, and `no_derivatives` for licenses that forbid distributing modified
+versions. Neither may sit in `permissive`, so a rule approving permissive licenses cannot
+bless them by accident.
+
+Matching on `license` with explicit SPDX IDs still works and is right for rules about one
+specific license. Its cost is that ID lists need maintaining, since a license family has
+many spellings (`GPL-3.0`, `GPL-3.0-only`, `GPL-3.0-or-later`, `GPL-3.0+`), and a missing
+variant is a rule that quietly does not cover it.
 
 ## Nothing matching means review, not approval
 
@@ -176,10 +164,14 @@ answer into a review request.
 With no `-p`, ospac loads `ospac/defaults/enterprise_policy.yaml` and prints a notice on
 stderr. It is a real, opinionated policy:
 
-- GPL is denied for `commercial`, `embedded`, `saas`, `mobile`, `desktop` and `web`
-- AGPL is denied for `saas`, `cloud` and `api`
-- LGPL with `static_linking` is flagged for review, with requirements attached
-- LGPL with dynamic linking is allowed
+- strong copyleft is denied for `commercial`, `embedded`, `saas`, `mobile`, `desktop` and `web`, by category
+- network copyleft is denied for `saas`, `cloud`, `api` and `web`
+- NonCommercial licenses are denied for every commercial-adjacent distribution type
+- weak copyleft is approved under `dynamic_linking`, reviewed under `static_linking`, and
+  reviewed when the linking context is unknown
+- permissive and public domain licenses are approved by category
+- no-derivatives, source-available and unknown licenses are flagged for review
+- known incompatible pairs, such as GPL-2.0 with Apache-2.0, are denied by `check`
 
 Those are defensible defaults for a commercial product and wrong for plenty of other
 projects. Copy it as a starting point rather than inheriting it by accident:
@@ -188,17 +180,17 @@ projects. Copy it as a starting point rather than inheriting it by accident:
 cp "$(python -c 'import ospac,pathlib;print(pathlib.Path(ospac.__file__).parent)')/defaults/enterprise_policy.yaml" ./policy.yaml
 ```
 
-Editing that file gives you a policy that already matches on `license`, which sidesteps the
-`license_type` problem entirely.
-
 ## Templates
 
 `ospac policy init -t NAME` writes one of `mobile`, `desktop`, `web`, `server`, `embedded`,
 `library`, or `custom`. They differ mainly in copyleft treatment: `mobile` denies both
-strong and weak copyleft, `library` and `server` are laxer.
+strong and weak copyleft, `library` and `server` are laxer. All of them deny
+`noncommercial` licenses and flag `no_derivatives`, `source_available`,
+`network_copyleft` and `unknown` for review.
 
-Given the `license_type` issue above, treat these as a sketch of intent to be rewritten
-against `license`, not as working policies.
+They are working starting points. Edit them rather than inheriting them unread: the
+choices they make, such as denying weak copyleft outright on mobile, are defensible
+defaults and not universal truths.
 
 ## Validating
 

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -131,16 +131,35 @@ variant is a rule that quietly does not cover it. Enumerate the variants you act
 encounter, and read `ospac/data/compatibility/categories.json` for the full membership of
 each family.
 
-## Nothing matching means `allow`
+## Nothing matching means review, not approval
 
-When no rule matches, the result is `action: "allow"` with `"No policies matched"`. ospac
-defaults to permitting what it was not told to forbid.
+When no rule matches, ospac returns `flag_for_review`:
 
-This matters because a broken policy and a genuinely clean set of licenses are reported
-identically. Two habits protect you:
+```json
+{
+  "action": "flag_for_review",
+  "severity": "warning",
+  "message": "No policy rule matched, so this needs review",
+  "remediation": "Add a rule covering this case, or approve it explicitly after review"
+}
+```
 
-Assert that your policy is actually loaded. `using_default_policy` is in every `evaluate`
-and `check` result for this reason:
+A policy that has no rule for a situation has not approved it, it simply has no answer, and
+those are different things. ospac reports the absence of an answer rather than treating it
+as permission.
+
+{: .note }
+> This changed in 1.4.0. Earlier versions returned `allow` here, which meant an unanswered
+> question and an explicit approval were indistinguishable, so a policy whose rules had
+> silently stopped matching read as a clean pass. If your CI treated `allow` as success,
+> note that uncovered cases now surface as `flag_for_review` instead.
+
+The practical consequence is that a policy needs to cover the licenses you actually use, or
+you will get review requests. That is the intended pressure: the alternative is a policy
+that quietly permits everything it forgot to mention.
+
+Two habits still help. Assert that your policy is actually loaded, since a policy that fails
+to parse falls back to the bundled default:
 
 ```bash
 ospac evaluate -l MIT -p ./policy.yaml -o json \
@@ -148,9 +167,9 @@ ospac evaluate -l MIT -p ./policy.yaml -o json \
   || { echo "custom policy was not loaded"; exit 1; }
 ```
 
-Keep a case in your test suite that must be denied. If your policy denies GPL for mobile,
-test exactly that, so a policy that silently stops matching fails a test instead of
-approving everything.
+And keep a case in your test suite that must be denied. If your policy denies GPL for
+mobile, test exactly that, so rules going inert fails a test rather than turning every
+answer into a review request.
 
 ## The default policy
 

--- a/ospac/cli/commands.py
+++ b/ospac/cli/commands.py
@@ -88,30 +88,19 @@ def evaluate(policy_dir: str, licenses: str, context: str,
 
         license_list = [l.strip() for l in licenses.split(",")]
 
-        # Resolve license types from the dataset so rules matching on
-        # license_type (e.g. copyleft_strong) can fire. Licenses missing
-        # from the dataset simply contribute no type.
-        license_types = []
-        for license_id in license_list:
-            try:
-                license_data = runtime.lookup_license_data(license_id)
-            except ValueError:
-                continue
-            license_type = (license_data or {}).get("license", {}).get("type")
-            if license_type and license_type not in license_types:
-                license_types.append(license_type)
-
-        eval_context = {
-            "licenses_found": license_list,
-            "licenses": license_list,  # Support both keys
-            "license_type": license_types,
+        base_context = {
             "context": context,
             "distribution": distribution,
             "distribution_type": distribution,  # Support both keys
             "linking_type": context if "linking" in context else None
         }
 
-        result = runtime.evaluate(eval_context)
+        # Each license is evaluated on its own, then the verdicts are aggregated with
+        # most-restrictive-wins. Evaluating the set in one pass let a single license's
+        # approval answer for licenses that matched no rule at all: "MIT,AGPL-3.0" was
+        # approved because MIT fired the permissive rule and the no-match fail-safe
+        # therefore never ran for AGPL.
+        result, per_license = runtime.evaluate_licenses(license_list, base_context)
 
         # Add license obligations to requirements regardless of policy decision
         _enhance_result_with_obligations(result, license_list, runtime)
@@ -125,6 +114,10 @@ def evaluate(policy_dir: str, licenses: str, context: str,
                 "context": context,
                 "distribution": distribution,
                 "result": result_dict,
+                "per_license": {
+                    lid: {"action": r.action.value, "message": r.message}
+                    for lid, r in per_license.items()
+                },
                 "using_default_policy": runtime._using_default
             }
             click.echo(json.dumps(output_data, indent=2))
@@ -168,13 +161,26 @@ def check(license1: str, license2: str, context: str, policy_dir: str, output: s
 
         result = runtime.check_compatibility(license1, license2, context)
 
+        # A license id that does not resolve in the dataset cannot be checked, only not
+        # contradicted. Say so instead of letting a typo read as a clean compatibility.
+        warnings = list(result.warnings) if result.warnings else []
+        for license_id in (license1, license2):
+            if runtime.resolve_license_type(license_id) is None:
+                warnings.append({
+                    "rule_id": "unknown_license",
+                    "message": f"{license_id} is not in the license dataset, so this "
+                               f"compatibility is unverified"
+                })
+
         if output == "json":
             output_data = {
                 "license1": license1,
                 "license2": license2,
                 "context": context,
                 "compatible": result.is_compliant,
+                "requires_review": result.needs_review,
                 "violations": result.violations if result.violations else [],
+                "warnings": warnings,
                 "using_default_policy": runtime._using_default
             }
             click.echo(json.dumps(output_data, indent=2))
@@ -182,6 +188,8 @@ def check(license1: str, license2: str, context: str, policy_dir: str, output: s
             # Text output
             if result.is_compliant:
                 click.secho(f"✓ {license1} and {license2} are compatible", fg="green")
+            elif result.needs_review:
+                click.secho(f"? {license1} and {license2} require review", fg="yellow")
             else:
                 click.secho(f"✗ {license1} and {license2} are incompatible", fg="red")
 
@@ -189,6 +197,8 @@ def check(license1: str, license2: str, context: str, policy_dir: str, output: s
                     click.echo("\nViolations:")
                     for violation in result.violations:
                         click.echo(f"  - {violation['message']}")
+            for warning in warnings:
+                click.secho(f"  ! {warning['message']}", fg="yellow")
 
     except Exception as e:
         click.secho(f"Error: {e}", fg="red", err=True)
@@ -347,9 +357,16 @@ def generate(output_dir: str, force: bool, force_reprocess: bool, limit: Optiona
             )
             click.echo(f"Using {llm_provider.upper()} LLM provider for enhanced analysis")
         else:
-            generator = PolicyDataGenerator(Path(output_dir))
-            click.secho("⚠ Running without LLM analysis. Data will be basic.", fg="yellow")
-            click.echo("To enable LLM analysis, use --use-llm flag with --llm-provider")
+            # Without a provider every record comes from the fail-closed fallback:
+            # type unknown, every permission denied. That output exists so a failed
+            # analysis cannot over-permit, not to be a dataset, so refuse to write a
+            # whole corpus of it. The shipped package already includes real data.
+            click.secho(
+                "✗ data generate requires --use-llm. Without a provider every record "
+                "is a conservative placeholder (type unknown, all permissions denied), "
+                "which is not a usable dataset.", fg="red", err=True)
+            click.echo("Use --use-llm with --llm-provider openai|claude|ollama.", err=True)
+            sys.exit(1)
 
         click.echo(f"Generating policy data in {output_dir}...")
 
@@ -390,6 +407,19 @@ def generate(output_dir: str, force: bool, force_reprocess: bool, limit: Optiona
                     f"instead of {llm_provider.upper()}: {preview}",
                     fg="red", err=True
                 )
+                # Remove the fabricated records. Delta processing uses on-disk files as
+                # its record of what is done, so leaving these in place would make the
+                # next run skip them and report a clean dataset over stale placeholders.
+                removed = 0
+                for fallback_id in fallback_ids:
+                    record_path = Path(output_dir) / "licenses" / "json" / f"{fallback_id}.json"
+                    if record_path.exists():
+                        record_path.unlink()
+                        removed += 1
+                if removed:
+                    click.secho(
+                        f"  Removed {removed} placeholder record(s) so the next run "
+                        f"reprocesses them.", fg="yellow", err=True)
                 click.secho(
                     "Fallback records deliberately under-permit and must not be published. "
                     "Fix the provider errors logged above and re-run.",
@@ -648,6 +678,28 @@ def init(template: str, output: str, format: str):
                     "description": "Allow permissive licenses",
                     "when": {"license_type": ["permissive", "public_domain"]},
                     "then": {"action": "approve"}
+                },
+                {
+                    "id": "deny_noncommercial",
+                    "description": "Deny NonCommercial licenses in distributed products",
+                    "when": {"license_type": "noncommercial"},
+                    "then": {
+                        "action": "deny",
+                        "severity": "error",
+                        "message": "NonCommercial licenses forbid commercial use",
+                        "remediation": "Replace with a permissive alternative, or obtain a commercial license from the rights holder"
+                    }
+                },
+                {
+                    "id": "review_restricted",
+                    "description": "Review licenses with restrictions the tool cannot verify",
+                    "when": {"license_type": ["no_derivatives", "source_available",
+                                              "network_copyleft", "unknown"]},
+                    "then": {
+                        "action": "flag_for_review",
+                        "severity": "warning",
+                        "message": "This license carries restrictions that need human review"
+                    }
                 }
             ]
         },
@@ -681,6 +733,28 @@ def init(template: str, output: str, format: str):
                     "description": "Allow permissive licenses",
                     "when": {"license_type": ["permissive", "public_domain"]},
                     "then": {"action": "approve"}
+                },
+                {
+                    "id": "deny_noncommercial",
+                    "description": "Deny NonCommercial licenses in distributed products",
+                    "when": {"license_type": "noncommercial"},
+                    "then": {
+                        "action": "deny",
+                        "severity": "error",
+                        "message": "NonCommercial licenses forbid commercial use",
+                        "remediation": "Replace with a permissive alternative, or obtain a commercial license from the rights holder"
+                    }
+                },
+                {
+                    "id": "review_restricted",
+                    "description": "Review licenses with restrictions the tool cannot verify",
+                    "when": {"license_type": ["no_derivatives", "source_available",
+                                              "network_copyleft", "unknown"]},
+                    "then": {
+                        "action": "flag_for_review",
+                        "severity": "warning",
+                        "message": "This license carries restrictions that need human review"
+                    }
                 }
             ]
         },
@@ -716,6 +790,28 @@ def init(template: str, output: str, format: str):
                     "description": "Allow permissive licenses",
                     "when": {"license_type": ["permissive", "public_domain"]},
                     "then": {"action": "approve"}
+                },
+                {
+                    "id": "deny_noncommercial",
+                    "description": "Deny NonCommercial licenses in distributed products",
+                    "when": {"license_type": "noncommercial"},
+                    "then": {
+                        "action": "deny",
+                        "severity": "error",
+                        "message": "NonCommercial licenses forbid commercial use",
+                        "remediation": "Replace with a permissive alternative, or obtain a commercial license from the rights holder"
+                    }
+                },
+                {
+                    "id": "review_restricted",
+                    "description": "Review licenses with restrictions the tool cannot verify",
+                    "when": {"license_type": ["no_derivatives", "source_available",
+                                              "network_copyleft", "unknown"]},
+                    "then": {
+                        "action": "flag_for_review",
+                        "severity": "warning",
+                        "message": "This license carries restrictions that need human review"
+                    }
                 }
             ]
         },
@@ -749,6 +845,28 @@ def init(template: str, output: str, format: str):
                     "description": "Allow permissive licenses",
                     "when": {"license_type": ["permissive", "public_domain"]},
                     "then": {"action": "approve"}
+                },
+                {
+                    "id": "deny_noncommercial",
+                    "description": "Deny NonCommercial licenses in distributed products",
+                    "when": {"license_type": "noncommercial"},
+                    "then": {
+                        "action": "deny",
+                        "severity": "error",
+                        "message": "NonCommercial licenses forbid commercial use",
+                        "remediation": "Replace with a permissive alternative, or obtain a commercial license from the rights holder"
+                    }
+                },
+                {
+                    "id": "review_restricted",
+                    "description": "Review licenses with restrictions the tool cannot verify",
+                    "when": {"license_type": ["no_derivatives", "source_available",
+                                              "network_copyleft", "unknown"]},
+                    "then": {
+                        "action": "flag_for_review",
+                        "severity": "warning",
+                        "message": "This license carries restrictions that need human review"
+                    }
                 }
             ]
         },
@@ -784,6 +902,28 @@ def init(template: str, output: str, format: str):
                     "description": "Allow permissive licenses for embedded",
                     "when": {"license_type": ["permissive", "public_domain"]},
                     "then": {"action": "approve"}
+                },
+                {
+                    "id": "deny_noncommercial",
+                    "description": "Deny NonCommercial licenses in distributed products",
+                    "when": {"license_type": "noncommercial"},
+                    "then": {
+                        "action": "deny",
+                        "severity": "error",
+                        "message": "NonCommercial licenses forbid commercial use",
+                        "remediation": "Replace with a permissive alternative, or obtain a commercial license from the rights holder"
+                    }
+                },
+                {
+                    "id": "review_restricted",
+                    "description": "Review licenses with restrictions the tool cannot verify",
+                    "when": {"license_type": ["no_derivatives", "source_available",
+                                              "network_copyleft", "unknown"]},
+                    "then": {
+                        "action": "flag_for_review",
+                        "severity": "warning",
+                        "message": "This license carries restrictions that need human review"
+                    }
                 }
             ]
         },
@@ -819,6 +959,28 @@ def init(template: str, output: str, format: str):
                     "description": "Allow permissive licenses",
                     "when": {"license_type": ["permissive", "public_domain"]},
                     "then": {"action": "approve"}
+                },
+                {
+                    "id": "deny_noncommercial",
+                    "description": "Deny NonCommercial licenses in distributed products",
+                    "when": {"license_type": "noncommercial"},
+                    "then": {
+                        "action": "deny",
+                        "severity": "error",
+                        "message": "NonCommercial licenses forbid commercial use",
+                        "remediation": "Replace with a permissive alternative, or obtain a commercial license from the rights holder"
+                    }
+                },
+                {
+                    "id": "review_restricted",
+                    "description": "Review licenses with restrictions the tool cannot verify",
+                    "when": {"license_type": ["no_derivatives", "source_available",
+                                              "network_copyleft", "unknown"]},
+                    "then": {
+                        "action": "flag_for_review",
+                        "severity": "warning",
+                        "message": "This license carries restrictions that need human review"
+                    }
                 }
             ]
         },
@@ -858,8 +1020,18 @@ def _output_text(result, licenses):
     click.echo("-" * 50)
 
     if hasattr(result, "action"):
-        action_color = "green" if result.action.value == "allow" else "red"
-        click.secho(f"Action: {result.action.value}", fg=action_color)
+        # Colour by what the action means, not by string equality with one value.
+        # Approvals were rendered red because only "allow" was treated as good, and the
+        # markdown renderer below printed "Denied" for them outright.
+        _ACTION_STYLE = {
+            "approve": "green",
+            "allow": "green",
+            "flag_for_review": "yellow",
+            "contaminate": "red",
+            "deny": "red",
+        }
+        click.secho(f"Action: {result.action.value}",
+                    fg=_ACTION_STYLE.get(result.action.value, "yellow"))
 
         if result.message:
             click.echo(f"Message: {result.message}")
@@ -876,7 +1048,14 @@ def _output_markdown(result, licenses):
     click.echo(f"**Licenses evaluated:** {', '.join(licenses)}\n")
 
     if hasattr(result, "action"):
-        status = "✅ Allowed" if result.action.value == "allow" else "❌ Denied"
+        _ACTION_STATUS = {
+            "approve": "✅ Approved",
+            "allow": "✅ Allowed",
+            "flag_for_review": "⚠️ Requires review",
+            "contaminate": "❌ Denied (contaminating)",
+            "deny": "❌ Denied",
+        }
+        status = _ACTION_STATUS.get(result.action.value, f"⚠️ {result.action.value}")
         click.echo(f"## Status: {status}\n")
 
         if result.message:

--- a/ospac/cli/commands.py
+++ b/ospac/cli/commands.py
@@ -335,11 +335,15 @@ def generate(output_dir: str, force: bool, force_reprocess: bool, limit: Optiona
     async def run_generation():
         # Create generator with LLM configuration
         if use_llm:
+            # require_provider=True makes provider initialization a preflight
+            # check: a missing package or API key aborts here, before any
+            # license is processed, instead of silently producing fallback data.
             generator = PolicyDataGenerator(
                 output_dir=Path(output_dir),
                 llm_provider=llm_provider,
                 llm_model=llm_model,
-                llm_api_key=llm_api_key
+                llm_api_key=llm_api_key,
+                require_provider=True
             )
             click.echo(f"Using {llm_provider.upper()} LLM provider for enhanced analysis")
         else:
@@ -372,6 +376,27 @@ def generate(output_dir: str, force: bool, force_reprocess: bool, limit: Optiona
             click.secho("✓ All data validated successfully", fg="green")
         else:
             click.secho(f"⚠ Validation issues found: {len(validation.get('validation_errors', []))}", fg="yellow")
+
+        # Fail closed if any record came from fallback instead of the LLM.
+        # A partially fabricated compliance dataset must not be publishable.
+        if use_llm:
+            fallback_ids = sorted(getattr(generator.llm_analyzer, "fallback_licenses", set()))
+            if fallback_ids:
+                preview = ", ".join(fallback_ids[:10])
+                if len(fallback_ids) > 10:
+                    preview += f", and {len(fallback_ids) - 10} more"
+                click.secho(
+                    f"✗ {len(fallback_ids)} license record(s) were produced by fallback analysis "
+                    f"instead of {llm_provider.upper()}: {preview}",
+                    fg="red", err=True
+                )
+                click.secho(
+                    "Fallback records deliberately under-permit and must not be published. "
+                    "Fix the provider errors logged above and re-run.",
+                    fg="red", err=True
+                )
+                sys.exit(1)
+            click.secho("✓ No fallback records: all licenses analyzed by the LLM provider", fg="green")
 
     try:
         asyncio.run(run_generation())

--- a/ospac/data/index.json
+++ b/ospac/data/index.json
@@ -2687,7 +2687,7 @@
     },
     "LGPLLR": {
       "name": "Lesser General Public License For Linguistic Resources",
-      "category": "copyleft_strong",
+      "category": "copyleft_weak",
       "file": "licenses/json/LGPLLR.json",
       "is_deprecated": false,
       "obligations_count": 4

--- a/ospac/data/index.json
+++ b/ospac/data/index.json
@@ -279,10 +279,10 @@
     },
     "Aladdin": {
       "name": "Aladdin Free Public License",
-      "category": "permissive",
+      "category": "noncommercial",
       "file": "licenses/json/Aladdin.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "Apache-1.0": {
       "name": "Apache License 1.0",
@@ -643,7 +643,7 @@
     },
     "BUSL-1.1": {
       "name": "Business Source License 1.1",
-      "category": "permissive",
+      "category": "source_available",
       "file": "licenses/json/BUSL-1.1.json",
       "is_deprecated": false,
       "obligations_count": 2
@@ -783,10 +783,10 @@
     },
     "CAL-1.0": {
       "name": "Cryptographic Autonomy License 1.0",
-      "category": "permissive",
+      "category": "network_copyleft",
       "file": "licenses/json/CAL-1.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 5
     },
     "CAPEC-tou": {
       "name": "Common Attack    Pattern Enumeration and Classification License",
@@ -1056,42 +1056,42 @@
     },
     "CC-BY-ND-1.0": {
       "name": "Creative Commons Attribution No Derivatives 1.0 Generic",
-      "category": "permissive",
+      "category": "no_derivatives",
       "file": "licenses/json/CC-BY-ND-1.0.json",
       "is_deprecated": false,
       "obligations_count": 3
     },
     "CC-BY-ND-2.0": {
       "name": "Creative Commons Attribution No Derivatives 2.0 Generic",
-      "category": "permissive",
+      "category": "no_derivatives",
       "file": "licenses/json/CC-BY-ND-2.0.json",
       "is_deprecated": false,
       "obligations_count": 3
     },
     "CC-BY-ND-2.5": {
       "name": "Creative Commons Attribution No Derivatives 2.5 Generic",
-      "category": "permissive",
+      "category": "no_derivatives",
       "file": "licenses/json/CC-BY-ND-2.5.json",
       "is_deprecated": false,
       "obligations_count": 3
     },
     "CC-BY-ND-3.0-DE": {
       "name": "Creative Commons Attribution No Derivatives 3.0 Germany",
-      "category": "permissive",
+      "category": "no_derivatives",
       "file": "licenses/json/CC-BY-ND-3.0-DE.json",
       "is_deprecated": false,
       "obligations_count": 3
     },
     "CC-BY-ND-3.0": {
       "name": "Creative Commons Attribution No Derivatives 3.0 Unported",
-      "category": "permissive",
+      "category": "no_derivatives",
       "file": "licenses/json/CC-BY-ND-3.0.json",
       "is_deprecated": false,
       "obligations_count": 3
     },
     "CC-BY-ND-4.0": {
       "name": "Creative Commons Attribution No Derivatives 4.0 International",
-      "category": "permissive",
+      "category": "no_derivatives",
       "file": "licenses/json/CC-BY-ND-4.0.json",
       "is_deprecated": false,
       "obligations_count": 3
@@ -1196,17 +1196,17 @@
     },
     "CDDL-1.0": {
       "name": "Common Development and Distribution License 1.0",
-      "category": "permissive",
+      "category": "copyleft_weak",
       "file": "licenses/json/CDDL-1.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 4
     },
     "CDDL-1.1": {
       "name": "Common Development and Distribution License 1.1",
-      "category": "permissive",
+      "category": "copyleft_weak",
       "file": "licenses/json/CDDL-1.1.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 4
     },
     "CDL-1.0": {
       "name": "Common Documentation License 1.0",
@@ -1231,10 +1231,10 @@
     },
     "CDLA-Sharing-1.0": {
       "name": "Community Data License Agreement Sharing 1.0",
-      "category": "permissive",
+      "category": "copyleft_weak",
       "file": "licenses/json/CDLA-Sharing-1.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "CECILL-1.0": {
       "name": "CeCILL Free Software License Agreement v1.0",
@@ -1301,17 +1301,17 @@
     },
     "CERN-OHL-S-2.0": {
       "name": "CERN Open Hardware Licence Version 2 - Strongly Reciprocal",
-      "category": "permissive",
+      "category": "copyleft_strong",
       "file": "licenses/json/CERN-OHL-S-2.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 4
     },
     "CERN-OHL-W-2.0": {
       "name": "CERN Open Hardware Licence Version 2 - Weakly Reciprocal",
-      "category": "permissive",
+      "category": "copyleft_weak",
       "file": "licenses/json/CERN-OHL-W-2.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 4
     },
     "CFITSIO": {
       "name": "CFITSIO License",
@@ -1609,17 +1609,17 @@
     },
     "EPL-1.0": {
       "name": "Eclipse Public License 1.0",
-      "category": "permissive",
+      "category": "copyleft_weak",
       "file": "licenses/json/EPL-1.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 4
     },
     "EPL-2.0": {
       "name": "Eclipse Public License 2.0",
-      "category": "permissive",
+      "category": "copyleft_weak",
       "file": "licenses/json/EPL-2.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 4
     },
     "ESA-PL-permissive-2.4": {
       "name": "European Space Agency Public License \u2013 v2.4 \u2013 Permissive (Type 3)",
@@ -1630,17 +1630,17 @@
     },
     "ESA-PL-strong-copyleft-2.4": {
       "name": "European Space Agency Public License (ESA-PL) - V2.4 - Strong Copyleft (Type 1)",
-      "category": "permissive",
+      "category": "copyleft_strong",
       "file": "licenses/json/ESA-PL-strong-copyleft-2.4.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 4
     },
     "ESA-PL-weak-copyleft-2.4": {
       "name": "European Space Agency Public License \u2013 v2.4 \u2013 Weak Copyleft (Type 2)",
-      "category": "permissive",
+      "category": "copyleft_weak",
       "file": "licenses/json/ESA-PL-weak-copyleft-2.4.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "EUDatagrid": {
       "name": "EU DataGrid Software License",
@@ -1658,21 +1658,21 @@
     },
     "EUPL-1.1": {
       "name": "European Union Public License 1.1",
-      "category": "permissive",
+      "category": "copyleft_strong",
       "file": "licenses/json/EUPL-1.1.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 4
     },
     "EUPL-1.2": {
       "name": "European Union Public License 1.2",
-      "category": "permissive",
+      "category": "copyleft_strong",
       "file": "licenses/json/EUPL-1.2.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 4
     },
     "Elastic-2.0": {
       "name": "Elastic License 2.0",
-      "category": "permissive",
+      "category": "source_available",
       "file": "licenses/json/Elastic-2.0.json",
       "is_deprecated": false,
       "obligations_count": 2
@@ -2834,24 +2834,24 @@
     },
     "Linux-man-pages-copyleft-2-para": {
       "name": "Linux man-pages Copyleft - 2 paragraphs",
-      "category": "permissive",
+      "category": "copyleft_weak",
       "file": "licenses/json/Linux-man-pages-copyleft-2-para.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "Linux-man-pages-copyleft-var": {
       "name": "Linux man-pages Copyleft Variant",
-      "category": "permissive",
+      "category": "copyleft_weak",
       "file": "licenses/json/Linux-man-pages-copyleft-var.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "Linux-man-pages-copyleft": {
       "name": "Linux man-pages Copyleft",
-      "category": "permissive",
+      "category": "copyleft_weak",
       "file": "licenses/json/Linux-man-pages-copyleft.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "Lucida-Bitmap-Fonts": {
       "name": "Lucida Bitmap Fonts License",
@@ -3037,10 +3037,10 @@
     },
     "MS-RL": {
       "name": "Microsoft Reciprocal License",
-      "category": "permissive",
+      "category": "copyleft_weak",
       "file": "licenses/json/MS-RL.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "MTLL": {
       "name": "Matrix Template Library License",
@@ -3275,10 +3275,10 @@
     },
     "NPOSL-3.0": {
       "name": "Non-Profit Open Software License 3.0",
-      "category": "permissive",
+      "category": "noncommercial",
       "file": "licenses/json/NPOSL-3.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "NRL": {
       "name": "NRL License",
@@ -3394,10 +3394,10 @@
     },
     "ODbL-1.0": {
       "name": "Open Data Commons Open Database License v1.0",
-      "category": "permissive",
+      "category": "copyleft_weak",
       "file": "licenses/json/ODbL-1.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "OFFIS": {
       "name": "OFFIS License",
@@ -3688,10 +3688,10 @@
     },
     "OSL-3.0": {
       "name": "Open Software License 3.0",
-      "category": "permissive",
+      "category": "network_copyleft",
       "file": "licenses/json/OSL-3.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 5
     },
     "OSSP": {
       "name": "OSSP License",
@@ -3793,10 +3793,10 @@
     },
     "Parity-7.0.0": {
       "name": "The Parity Public License 7.0.0",
-      "category": "permissive",
+      "category": "copyleft_strong",
       "file": "licenses/json/Parity-7.0.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 4
     },
     "Pixar": {
       "name": "Pixar License",
@@ -3877,17 +3877,17 @@
     },
     "RPL-1.1": {
       "name": "Reciprocal Public License 1.1",
-      "category": "permissive",
+      "category": "copyleft_strong",
       "file": "licenses/json/RPL-1.1.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 4
     },
     "RPL-1.5": {
       "name": "Reciprocal Public License 1.5",
-      "category": "permissive",
+      "category": "copyleft_strong",
       "file": "licenses/json/RPL-1.5.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 4
     },
     "RPSL-1.0": {
       "name": "RealNetworks Public Source License v1.0",
@@ -4094,10 +4094,10 @@
     },
     "SSPL-1.0": {
       "name": "Server Side Public License, v 1",
-      "category": "permissive",
+      "category": "network_copyleft",
       "file": "licenses/json/SSPL-1.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 5
     },
     "SUL-1.0": {
       "name": "Sustainable Use License v1.0",
@@ -4759,17 +4759,17 @@
     },
     "copyleft-next-0.3.0": {
       "name": "copyleft-next 0.3.0",
-      "category": "permissive",
+      "category": "copyleft_weak",
       "file": "licenses/json/copyleft-next-0.3.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "copyleft-next-0.3.1": {
       "name": "copyleft-next 0.3.1",
-      "category": "permissive",
+      "category": "copyleft_weak",
       "file": "licenses/json/copyleft-next-0.3.1.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "curl": {
       "name": "curl License",

--- a/ospac/data/index.json
+++ b/ospac/data/index.json
@@ -888,283 +888,283 @@
     },
     "CC-BY-NC-1.0": {
       "name": "Creative Commons Attribution Non Commercial 1.0 Generic",
-      "category": "permissive",
+      "category": "noncommercial",
       "file": "licenses/json/CC-BY-NC-1.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "CC-BY-NC-2.0": {
       "name": "Creative Commons Attribution Non Commercial 2.0 Generic",
-      "category": "permissive",
+      "category": "noncommercial",
       "file": "licenses/json/CC-BY-NC-2.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "CC-BY-NC-2.5": {
       "name": "Creative Commons Attribution Non Commercial 2.5 Generic",
-      "category": "permissive",
+      "category": "noncommercial",
       "file": "licenses/json/CC-BY-NC-2.5.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "CC-BY-NC-3.0-DE": {
       "name": "Creative Commons Attribution Non Commercial 3.0 Germany",
-      "category": "permissive",
+      "category": "noncommercial",
       "file": "licenses/json/CC-BY-NC-3.0-DE.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "CC-BY-NC-3.0-IGO": {
       "name": "Creative Commons Attribution Non Commercial 3.0 IGO",
-      "category": "permissive",
+      "category": "noncommercial",
       "file": "licenses/json/CC-BY-NC-3.0-IGO.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "CC-BY-NC-3.0": {
       "name": "Creative Commons Attribution Non Commercial 3.0 Unported",
-      "category": "permissive",
+      "category": "noncommercial",
       "file": "licenses/json/CC-BY-NC-3.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "CC-BY-NC-4.0": {
       "name": "Creative Commons Attribution Non Commercial 4.0 International",
-      "category": "permissive",
+      "category": "noncommercial",
       "file": "licenses/json/CC-BY-NC-4.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "CC-BY-NC-ND-1.0": {
       "name": "Creative Commons Attribution Non Commercial No Derivatives 1.0 Generic",
-      "category": "permissive",
+      "category": "noncommercial",
       "file": "licenses/json/CC-BY-NC-ND-1.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 4
     },
     "CC-BY-NC-ND-2.0": {
       "name": "Creative Commons Attribution Non Commercial No Derivatives 2.0 Generic",
-      "category": "permissive",
+      "category": "noncommercial",
       "file": "licenses/json/CC-BY-NC-ND-2.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 4
     },
     "CC-BY-NC-ND-2.5": {
       "name": "Creative Commons Attribution Non Commercial No Derivatives 2.5 Generic",
-      "category": "permissive",
+      "category": "noncommercial",
       "file": "licenses/json/CC-BY-NC-ND-2.5.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 4
     },
     "CC-BY-NC-ND-3.0-DE": {
       "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Germany",
-      "category": "permissive",
+      "category": "noncommercial",
       "file": "licenses/json/CC-BY-NC-ND-3.0-DE.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 4
     },
     "CC-BY-NC-ND-3.0-IGO": {
       "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 IGO",
-      "category": "permissive",
+      "category": "noncommercial",
       "file": "licenses/json/CC-BY-NC-ND-3.0-IGO.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 4
     },
     "CC-BY-NC-ND-3.0": {
       "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported",
-      "category": "permissive",
+      "category": "noncommercial",
       "file": "licenses/json/CC-BY-NC-ND-3.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 4
     },
     "CC-BY-NC-ND-4.0": {
       "name": "Creative Commons Attribution Non Commercial No Derivatives 4.0 International",
-      "category": "permissive",
+      "category": "noncommercial",
       "file": "licenses/json/CC-BY-NC-ND-4.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 4
     },
     "CC-BY-NC-SA-1.0": {
       "name": "Creative Commons Attribution Non Commercial Share Alike 1.0 Generic",
-      "category": "permissive",
+      "category": "noncommercial",
       "file": "licenses/json/CC-BY-NC-SA-1.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 4
     },
     "CC-BY-NC-SA-2.0-DE": {
       "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Germany",
-      "category": "permissive",
+      "category": "noncommercial",
       "file": "licenses/json/CC-BY-NC-SA-2.0-DE.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 4
     },
     "CC-BY-NC-SA-2.0-FR": {
       "name": "Creative Commons Attribution-NonCommercial-ShareAlike 2.0 France",
-      "category": "permissive",
+      "category": "noncommercial",
       "file": "licenses/json/CC-BY-NC-SA-2.0-FR.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 4
     },
     "CC-BY-NC-SA-2.0-UK": {
       "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 England and Wales",
-      "category": "permissive",
+      "category": "noncommercial",
       "file": "licenses/json/CC-BY-NC-SA-2.0-UK.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 4
     },
     "CC-BY-NC-SA-2.0": {
       "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Generic",
-      "category": "permissive",
+      "category": "noncommercial",
       "file": "licenses/json/CC-BY-NC-SA-2.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 4
     },
     "CC-BY-NC-SA-2.5": {
       "name": "Creative Commons Attribution Non Commercial Share Alike 2.5 Generic",
-      "category": "permissive",
+      "category": "noncommercial",
       "file": "licenses/json/CC-BY-NC-SA-2.5.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 4
     },
     "CC-BY-NC-SA-3.0-DE": {
       "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Germany",
-      "category": "permissive",
+      "category": "noncommercial",
       "file": "licenses/json/CC-BY-NC-SA-3.0-DE.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 4
     },
     "CC-BY-NC-SA-3.0-IGO": {
       "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 IGO",
-      "category": "permissive",
+      "category": "noncommercial",
       "file": "licenses/json/CC-BY-NC-SA-3.0-IGO.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 4
     },
     "CC-BY-NC-SA-3.0": {
       "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Unported",
-      "category": "permissive",
+      "category": "noncommercial",
       "file": "licenses/json/CC-BY-NC-SA-3.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 4
     },
     "CC-BY-NC-SA-4.0": {
       "name": "Creative Commons Attribution Non Commercial Share Alike 4.0 International",
-      "category": "permissive",
+      "category": "noncommercial",
       "file": "licenses/json/CC-BY-NC-SA-4.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 4
     },
     "CC-BY-ND-1.0": {
       "name": "Creative Commons Attribution No Derivatives 1.0 Generic",
       "category": "permissive",
       "file": "licenses/json/CC-BY-ND-1.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "CC-BY-ND-2.0": {
       "name": "Creative Commons Attribution No Derivatives 2.0 Generic",
       "category": "permissive",
       "file": "licenses/json/CC-BY-ND-2.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "CC-BY-ND-2.5": {
       "name": "Creative Commons Attribution No Derivatives 2.5 Generic",
       "category": "permissive",
       "file": "licenses/json/CC-BY-ND-2.5.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "CC-BY-ND-3.0-DE": {
       "name": "Creative Commons Attribution No Derivatives 3.0 Germany",
       "category": "permissive",
       "file": "licenses/json/CC-BY-ND-3.0-DE.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "CC-BY-ND-3.0": {
       "name": "Creative Commons Attribution No Derivatives 3.0 Unported",
       "category": "permissive",
       "file": "licenses/json/CC-BY-ND-3.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "CC-BY-ND-4.0": {
       "name": "Creative Commons Attribution No Derivatives 4.0 International",
       "category": "permissive",
       "file": "licenses/json/CC-BY-ND-4.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "CC-BY-SA-1.0": {
       "name": "Creative Commons Attribution Share Alike 1.0 Generic",
-      "category": "permissive",
+      "category": "copyleft_weak",
       "file": "licenses/json/CC-BY-SA-1.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "CC-BY-SA-2.0-UK": {
       "name": "Creative Commons Attribution Share Alike 2.0 England and Wales",
-      "category": "permissive",
+      "category": "copyleft_weak",
       "file": "licenses/json/CC-BY-SA-2.0-UK.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "CC-BY-SA-2.0": {
       "name": "Creative Commons Attribution Share Alike 2.0 Generic",
-      "category": "permissive",
+      "category": "copyleft_weak",
       "file": "licenses/json/CC-BY-SA-2.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "CC-BY-SA-2.1-JP": {
       "name": "Creative Commons Attribution Share Alike 2.1 Japan",
-      "category": "permissive",
+      "category": "copyleft_weak",
       "file": "licenses/json/CC-BY-SA-2.1-JP.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "CC-BY-SA-2.5": {
       "name": "Creative Commons Attribution Share Alike 2.5 Generic",
-      "category": "permissive",
+      "category": "copyleft_weak",
       "file": "licenses/json/CC-BY-SA-2.5.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "CC-BY-SA-3.0-AT": {
       "name": "Creative Commons Attribution Share Alike 3.0 Austria",
-      "category": "permissive",
+      "category": "copyleft_weak",
       "file": "licenses/json/CC-BY-SA-3.0-AT.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "CC-BY-SA-3.0-DE": {
       "name": "Creative Commons Attribution Share Alike 3.0 Germany",
-      "category": "permissive",
+      "category": "copyleft_weak",
       "file": "licenses/json/CC-BY-SA-3.0-DE.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "CC-BY-SA-3.0-IGO": {
       "name": "Creative Commons Attribution-ShareAlike 3.0 IGO",
-      "category": "permissive",
+      "category": "copyleft_weak",
       "file": "licenses/json/CC-BY-SA-3.0-IGO.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "CC-BY-SA-3.0": {
       "name": "Creative Commons Attribution Share Alike 3.0 Unported",
-      "category": "permissive",
+      "category": "copyleft_weak",
       "file": "licenses/json/CC-BY-SA-3.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "CC-BY-SA-4.0": {
       "name": "Creative Commons Attribution Share Alike 4.0 International",
-      "category": "permissive",
+      "category": "copyleft_weak",
       "file": "licenses/json/CC-BY-SA-4.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "CC-PDDC": {
       "name": "Creative Commons Public Domain Dedication and Certification",
@@ -1182,10 +1182,10 @@
     },
     "CC-SA-1.0": {
       "name": "Creative Commons Share Alike 1.0 Generic",
-      "category": "permissive",
+      "category": "copyleft_weak",
       "file": "licenses/json/CC-SA-1.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "CC0-1.0": {
       "name": "Creative Commons Zero v1.0 Universal",
@@ -3170,10 +3170,10 @@
     },
     "NCGL-UK-2.0": {
       "name": "Non-Commercial Government Licence",
-      "category": "permissive",
+      "category": "noncommercial",
       "file": "licenses/json/NCGL-UK-2.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "NCL": {
       "name": "NCL Source Code License",
@@ -3814,10 +3814,10 @@
     },
     "PolyForm-Noncommercial-1.0.0": {
       "name": "PolyForm Noncommercial License 1.0.0",
-      "category": "permissive",
+      "category": "noncommercial",
       "file": "licenses/json/PolyForm-Noncommercial-1.0.0.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 3
     },
     "PolyForm-Small-Business-1.0.0": {
       "name": "PolyForm Small Business License 1.0.0",

--- a/ospac/data/licenses/json/Aladdin.json
+++ b/ospac/data/licenses/json/Aladdin.json
@@ -2,10 +2,10 @@
   "license": {
     "id": "Aladdin",
     "name": "Aladdin Free Public License",
-    "type": "permissive",
+    "type": "noncommercial",
     "spdx_id": "Aladdin",
     "properties": {
-      "commercial_use": true,
+      "commercial_use": false,
       "distribution": true,
       "modification": true,
       "patent_grant": false,
@@ -41,14 +41,16 @@
         "requires_review": []
       },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "NonCommercial license: commercial use is not permitted"
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Non-commercial use only"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Commercial use not permitted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/BUSL-1.1.json
+++ b/ospac/data/licenses/json/BUSL-1.1.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "BUSL-1.1",
     "name": "Business Source License 1.1",
-    "type": "permissive",
+    "type": "source_available",
     "spdx_id": "BUSL-1.1",
     "properties": {
       "commercial_use": true,
@@ -40,15 +40,15 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "unknown",
+      "notes": "Source-available license: usage restrictions apply, review the terms"
     },
     "obligations": [
       "Retain copyright notices",
       "Include license text"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Source visible but redistribution restricted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CAL-1.0.json
+++ b/ospac/data/licenses/json/CAL-1.0.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "CAL-1.0",
     "name": "Cryptographic Autonomy License 1.0",
-    "type": "permissive",
+    "type": "network_copyleft",
     "spdx_id": "CAL-1.0",
     "properties": {
       "commercial_use": true,
@@ -12,13 +12,13 @@
       "private_use": true
     },
     "requirements": {
-      "disclose_source": false,
+      "disclose_source": true,
       "include_license": true,
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
-      "network_use_disclosure": false
+      "same_license": true,
+      "network_use_disclosure": true
     },
     "limitations": {
       "liability": false,
@@ -40,15 +40,19 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "full",
+      "notes": "Network copyleft: serving users over a network triggers source disclosure"
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Provide or offer access to complete source code",
+      "Distribute modifications under the same license",
+      "Make source available to users interacting over a network"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Network use triggers source-disclosure obligation"
     ],
     "spdx_metadata": {
       "is_osi_approved": true,

--- a/ospac/data/licenses/json/CC-BY-NC-1.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-1.0.json
@@ -2,10 +2,10 @@
   "license": {
     "id": "CC-BY-NC-1.0",
     "name": "Creative Commons Attribution Non Commercial 1.0 Generic",
-    "type": "permissive",
+    "type": "noncommercial",
     "spdx_id": "CC-BY-NC-1.0",
     "properties": {
-      "commercial_use": true,
+      "commercial_use": false,
       "distribution": true,
       "modification": true,
       "patent_grant": false,
@@ -45,10 +45,12 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Non-commercial use only"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Commercial use not permitted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-NC-1.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-1.0.json
@@ -41,7 +41,7 @@
         "requires_review": []
       },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "NonCommercial license: commercial use is not permitted"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-BY-NC-2.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-2.0.json
@@ -41,7 +41,7 @@
         "requires_review": []
       },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "NonCommercial license: commercial use is not permitted"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-BY-NC-2.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-2.0.json
@@ -2,10 +2,10 @@
   "license": {
     "id": "CC-BY-NC-2.0",
     "name": "Creative Commons Attribution Non Commercial 2.0 Generic",
-    "type": "permissive",
+    "type": "noncommercial",
     "spdx_id": "CC-BY-NC-2.0",
     "properties": {
-      "commercial_use": true,
+      "commercial_use": false,
       "distribution": true,
       "modification": true,
       "patent_grant": false,
@@ -45,10 +45,12 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Non-commercial use only"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Commercial use not permitted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-NC-2.5.json
+++ b/ospac/data/licenses/json/CC-BY-NC-2.5.json
@@ -2,10 +2,10 @@
   "license": {
     "id": "CC-BY-NC-2.5",
     "name": "Creative Commons Attribution Non Commercial 2.5 Generic",
-    "type": "permissive",
+    "type": "noncommercial",
     "spdx_id": "CC-BY-NC-2.5",
     "properties": {
-      "commercial_use": true,
+      "commercial_use": false,
       "distribution": true,
       "modification": true,
       "patent_grant": false,
@@ -45,10 +45,12 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Non-commercial use only"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Commercial use not permitted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-NC-2.5.json
+++ b/ospac/data/licenses/json/CC-BY-NC-2.5.json
@@ -41,7 +41,7 @@
         "requires_review": []
       },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "NonCommercial license: commercial use is not permitted"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-BY-NC-3.0-DE.json
+++ b/ospac/data/licenses/json/CC-BY-NC-3.0-DE.json
@@ -2,10 +2,10 @@
   "license": {
     "id": "CC-BY-NC-3.0-DE",
     "name": "Creative Commons Attribution Non Commercial 3.0 Germany",
-    "type": "permissive",
+    "type": "noncommercial",
     "spdx_id": "CC-BY-NC-3.0-DE",
     "properties": {
-      "commercial_use": true,
+      "commercial_use": false,
       "distribution": true,
       "modification": true,
       "patent_grant": false,
@@ -45,10 +45,12 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Non-commercial use only"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Commercial use not permitted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-NC-3.0-DE.json
+++ b/ospac/data/licenses/json/CC-BY-NC-3.0-DE.json
@@ -41,7 +41,7 @@
         "requires_review": []
       },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "NonCommercial license: commercial use is not permitted"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-BY-NC-3.0-IGO.json
+++ b/ospac/data/licenses/json/CC-BY-NC-3.0-IGO.json
@@ -2,10 +2,10 @@
   "license": {
     "id": "CC-BY-NC-3.0-IGO",
     "name": "Creative Commons Attribution Non Commercial 3.0 IGO",
-    "type": "permissive",
+    "type": "noncommercial",
     "spdx_id": "CC-BY-NC-3.0-IGO",
     "properties": {
-      "commercial_use": true,
+      "commercial_use": false,
       "distribution": true,
       "modification": true,
       "patent_grant": false,
@@ -45,10 +45,12 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Non-commercial use only"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Commercial use not permitted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-NC-3.0-IGO.json
+++ b/ospac/data/licenses/json/CC-BY-NC-3.0-IGO.json
@@ -41,7 +41,7 @@
         "requires_review": []
       },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "NonCommercial license: commercial use is not permitted"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-BY-NC-3.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-3.0.json
@@ -2,10 +2,10 @@
   "license": {
     "id": "CC-BY-NC-3.0",
     "name": "Creative Commons Attribution Non Commercial 3.0 Unported",
-    "type": "permissive",
+    "type": "noncommercial",
     "spdx_id": "CC-BY-NC-3.0",
     "properties": {
-      "commercial_use": true,
+      "commercial_use": false,
       "distribution": true,
       "modification": true,
       "patent_grant": false,
@@ -45,10 +45,12 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Non-commercial use only"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Commercial use not permitted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-NC-3.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-3.0.json
@@ -41,7 +41,7 @@
         "requires_review": []
       },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "NonCommercial license: commercial use is not permitted"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-BY-NC-4.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-4.0.json
@@ -2,10 +2,10 @@
   "license": {
     "id": "CC-BY-NC-4.0",
     "name": "Creative Commons Attribution Non Commercial 4.0 International",
-    "type": "permissive",
+    "type": "noncommercial",
     "spdx_id": "CC-BY-NC-4.0",
     "properties": {
-      "commercial_use": true,
+      "commercial_use": false,
       "distribution": true,
       "modification": true,
       "patent_grant": false,
@@ -45,10 +45,12 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Non-commercial use only"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Commercial use not permitted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-NC-4.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-4.0.json
@@ -41,7 +41,7 @@
         "requires_review": []
       },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "NonCommercial license: commercial use is not permitted"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-BY-NC-ND-1.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-ND-1.0.json
@@ -41,7 +41,7 @@
         "requires_review": []
       },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "NonCommercial license: commercial use is not permitted"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-BY-NC-ND-1.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-ND-1.0.json
@@ -2,12 +2,12 @@
   "license": {
     "id": "CC-BY-NC-ND-1.0",
     "name": "Creative Commons Attribution Non Commercial No Derivatives 1.0 Generic",
-    "type": "permissive",
+    "type": "noncommercial",
     "spdx_id": "CC-BY-NC-ND-1.0",
     "properties": {
-      "commercial_use": true,
+      "commercial_use": false,
       "distribution": true,
-      "modification": true,
+      "modification": false,
       "patent_grant": false,
       "private_use": true
     },
@@ -45,10 +45,13 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Non-commercial use only",
+      "No modification permitted"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Commercial use not permitted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-NC-ND-2.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-ND-2.0.json
@@ -2,12 +2,12 @@
   "license": {
     "id": "CC-BY-NC-ND-2.0",
     "name": "Creative Commons Attribution Non Commercial No Derivatives 2.0 Generic",
-    "type": "permissive",
+    "type": "noncommercial",
     "spdx_id": "CC-BY-NC-ND-2.0",
     "properties": {
-      "commercial_use": true,
+      "commercial_use": false,
       "distribution": true,
-      "modification": true,
+      "modification": false,
       "patent_grant": false,
       "private_use": true
     },
@@ -45,10 +45,13 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Non-commercial use only",
+      "No modification permitted"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Commercial use not permitted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-NC-ND-2.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-ND-2.0.json
@@ -41,7 +41,7 @@
         "requires_review": []
       },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "NonCommercial license: commercial use is not permitted"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-BY-NC-ND-2.5.json
+++ b/ospac/data/licenses/json/CC-BY-NC-ND-2.5.json
@@ -2,12 +2,12 @@
   "license": {
     "id": "CC-BY-NC-ND-2.5",
     "name": "Creative Commons Attribution Non Commercial No Derivatives 2.5 Generic",
-    "type": "permissive",
+    "type": "noncommercial",
     "spdx_id": "CC-BY-NC-ND-2.5",
     "properties": {
-      "commercial_use": true,
+      "commercial_use": false,
       "distribution": true,
-      "modification": true,
+      "modification": false,
       "patent_grant": false,
       "private_use": true
     },
@@ -45,10 +45,13 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Non-commercial use only",
+      "No modification permitted"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Commercial use not permitted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-NC-ND-2.5.json
+++ b/ospac/data/licenses/json/CC-BY-NC-ND-2.5.json
@@ -41,7 +41,7 @@
         "requires_review": []
       },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "NonCommercial license: commercial use is not permitted"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-BY-NC-ND-3.0-DE.json
+++ b/ospac/data/licenses/json/CC-BY-NC-ND-3.0-DE.json
@@ -2,12 +2,12 @@
   "license": {
     "id": "CC-BY-NC-ND-3.0-DE",
     "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Germany",
-    "type": "permissive",
+    "type": "noncommercial",
     "spdx_id": "CC-BY-NC-ND-3.0-DE",
     "properties": {
-      "commercial_use": true,
+      "commercial_use": false,
       "distribution": true,
-      "modification": true,
+      "modification": false,
       "patent_grant": false,
       "private_use": true
     },
@@ -45,10 +45,13 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Non-commercial use only",
+      "No modification permitted"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Commercial use not permitted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-NC-ND-3.0-DE.json
+++ b/ospac/data/licenses/json/CC-BY-NC-ND-3.0-DE.json
@@ -41,7 +41,7 @@
         "requires_review": []
       },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "NonCommercial license: commercial use is not permitted"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-BY-NC-ND-3.0-IGO.json
+++ b/ospac/data/licenses/json/CC-BY-NC-ND-3.0-IGO.json
@@ -41,7 +41,7 @@
         "requires_review": []
       },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "NonCommercial license: commercial use is not permitted"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-BY-NC-ND-3.0-IGO.json
+++ b/ospac/data/licenses/json/CC-BY-NC-ND-3.0-IGO.json
@@ -2,12 +2,12 @@
   "license": {
     "id": "CC-BY-NC-ND-3.0-IGO",
     "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 IGO",
-    "type": "permissive",
+    "type": "noncommercial",
     "spdx_id": "CC-BY-NC-ND-3.0-IGO",
     "properties": {
-      "commercial_use": true,
+      "commercial_use": false,
       "distribution": true,
-      "modification": true,
+      "modification": false,
       "patent_grant": false,
       "private_use": true
     },
@@ -45,10 +45,13 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Non-commercial use only",
+      "No modification permitted"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Commercial use not permitted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-NC-ND-3.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-ND-3.0.json
@@ -2,12 +2,12 @@
   "license": {
     "id": "CC-BY-NC-ND-3.0",
     "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported",
-    "type": "permissive",
+    "type": "noncommercial",
     "spdx_id": "CC-BY-NC-ND-3.0",
     "properties": {
-      "commercial_use": true,
+      "commercial_use": false,
       "distribution": true,
-      "modification": true,
+      "modification": false,
       "patent_grant": false,
       "private_use": true
     },
@@ -45,10 +45,13 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Non-commercial use only",
+      "No modification permitted"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Commercial use not permitted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-NC-ND-3.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-ND-3.0.json
@@ -41,7 +41,7 @@
         "requires_review": []
       },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "NonCommercial license: commercial use is not permitted"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-BY-NC-ND-4.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-ND-4.0.json
@@ -2,12 +2,12 @@
   "license": {
     "id": "CC-BY-NC-ND-4.0",
     "name": "Creative Commons Attribution Non Commercial No Derivatives 4.0 International",
-    "type": "permissive",
+    "type": "noncommercial",
     "spdx_id": "CC-BY-NC-ND-4.0",
     "properties": {
-      "commercial_use": true,
+      "commercial_use": false,
       "distribution": true,
-      "modification": true,
+      "modification": false,
       "patent_grant": false,
       "private_use": true
     },
@@ -45,10 +45,13 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Non-commercial use only",
+      "No modification permitted"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Commercial use not permitted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-NC-ND-4.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-ND-4.0.json
@@ -41,7 +41,7 @@
         "requires_review": []
       },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "NonCommercial license: commercial use is not permitted"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-BY-NC-SA-1.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-SA-1.0.json
@@ -2,10 +2,10 @@
   "license": {
     "id": "CC-BY-NC-SA-1.0",
     "name": "Creative Commons Attribution Non Commercial Share Alike 1.0 Generic",
-    "type": "permissive",
+    "type": "noncommercial",
     "spdx_id": "CC-BY-NC-SA-1.0",
     "properties": {
-      "commercial_use": true,
+      "commercial_use": false,
       "distribution": true,
       "modification": true,
       "patent_grant": false,
@@ -17,7 +17,7 @@
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -45,10 +45,13 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Distribute modifications under the same license",
+      "Non-commercial use only"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Commercial use not permitted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-NC-SA-1.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-SA-1.0.json
@@ -41,7 +41,7 @@
         "requires_review": []
       },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "NonCommercial license: commercial use is not permitted"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-BY-NC-SA-2.0-DE.json
+++ b/ospac/data/licenses/json/CC-BY-NC-SA-2.0-DE.json
@@ -41,7 +41,7 @@
         "requires_review": []
       },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "NonCommercial license: commercial use is not permitted"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-BY-NC-SA-2.0-DE.json
+++ b/ospac/data/licenses/json/CC-BY-NC-SA-2.0-DE.json
@@ -2,10 +2,10 @@
   "license": {
     "id": "CC-BY-NC-SA-2.0-DE",
     "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Germany",
-    "type": "permissive",
+    "type": "noncommercial",
     "spdx_id": "CC-BY-NC-SA-2.0-DE",
     "properties": {
-      "commercial_use": true,
+      "commercial_use": false,
       "distribution": true,
       "modification": true,
       "patent_grant": false,
@@ -17,7 +17,7 @@
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -45,10 +45,13 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Distribute modifications under the same license",
+      "Non-commercial use only"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Commercial use not permitted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-NC-SA-2.0-FR.json
+++ b/ospac/data/licenses/json/CC-BY-NC-SA-2.0-FR.json
@@ -2,10 +2,10 @@
   "license": {
     "id": "CC-BY-NC-SA-2.0-FR",
     "name": "Creative Commons Attribution-NonCommercial-ShareAlike 2.0 France",
-    "type": "permissive",
+    "type": "noncommercial",
     "spdx_id": "CC-BY-NC-SA-2.0-FR",
     "properties": {
-      "commercial_use": true,
+      "commercial_use": false,
       "distribution": true,
       "modification": true,
       "patent_grant": false,
@@ -17,7 +17,7 @@
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -45,10 +45,13 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Distribute modifications under the same license",
+      "Non-commercial use only"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Commercial use not permitted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-NC-SA-2.0-FR.json
+++ b/ospac/data/licenses/json/CC-BY-NC-SA-2.0-FR.json
@@ -41,7 +41,7 @@
         "requires_review": []
       },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "NonCommercial license: commercial use is not permitted"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-BY-NC-SA-2.0-UK.json
+++ b/ospac/data/licenses/json/CC-BY-NC-SA-2.0-UK.json
@@ -2,10 +2,10 @@
   "license": {
     "id": "CC-BY-NC-SA-2.0-UK",
     "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 England and Wales",
-    "type": "permissive",
+    "type": "noncommercial",
     "spdx_id": "CC-BY-NC-SA-2.0-UK",
     "properties": {
-      "commercial_use": true,
+      "commercial_use": false,
       "distribution": true,
       "modification": true,
       "patent_grant": false,
@@ -17,7 +17,7 @@
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -45,10 +45,13 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Distribute modifications under the same license",
+      "Non-commercial use only"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Commercial use not permitted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-NC-SA-2.0-UK.json
+++ b/ospac/data/licenses/json/CC-BY-NC-SA-2.0-UK.json
@@ -41,7 +41,7 @@
         "requires_review": []
       },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "NonCommercial license: commercial use is not permitted"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-BY-NC-SA-2.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-SA-2.0.json
@@ -2,10 +2,10 @@
   "license": {
     "id": "CC-BY-NC-SA-2.0",
     "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Generic",
-    "type": "permissive",
+    "type": "noncommercial",
     "spdx_id": "CC-BY-NC-SA-2.0",
     "properties": {
-      "commercial_use": true,
+      "commercial_use": false,
       "distribution": true,
       "modification": true,
       "patent_grant": false,
@@ -17,7 +17,7 @@
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -45,10 +45,13 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Distribute modifications under the same license",
+      "Non-commercial use only"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Commercial use not permitted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-NC-SA-2.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-SA-2.0.json
@@ -41,7 +41,7 @@
         "requires_review": []
       },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "NonCommercial license: commercial use is not permitted"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-BY-NC-SA-2.5.json
+++ b/ospac/data/licenses/json/CC-BY-NC-SA-2.5.json
@@ -2,10 +2,10 @@
   "license": {
     "id": "CC-BY-NC-SA-2.5",
     "name": "Creative Commons Attribution Non Commercial Share Alike 2.5 Generic",
-    "type": "permissive",
+    "type": "noncommercial",
     "spdx_id": "CC-BY-NC-SA-2.5",
     "properties": {
-      "commercial_use": true,
+      "commercial_use": false,
       "distribution": true,
       "modification": true,
       "patent_grant": false,
@@ -17,7 +17,7 @@
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -45,10 +45,13 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Distribute modifications under the same license",
+      "Non-commercial use only"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Commercial use not permitted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-NC-SA-2.5.json
+++ b/ospac/data/licenses/json/CC-BY-NC-SA-2.5.json
@@ -41,7 +41,7 @@
         "requires_review": []
       },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "NonCommercial license: commercial use is not permitted"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-BY-NC-SA-3.0-DE.json
+++ b/ospac/data/licenses/json/CC-BY-NC-SA-3.0-DE.json
@@ -2,10 +2,10 @@
   "license": {
     "id": "CC-BY-NC-SA-3.0-DE",
     "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Germany",
-    "type": "permissive",
+    "type": "noncommercial",
     "spdx_id": "CC-BY-NC-SA-3.0-DE",
     "properties": {
-      "commercial_use": true,
+      "commercial_use": false,
       "distribution": true,
       "modification": true,
       "patent_grant": false,
@@ -17,7 +17,7 @@
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -45,10 +45,13 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Distribute modifications under the same license",
+      "Non-commercial use only"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Commercial use not permitted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-NC-SA-3.0-DE.json
+++ b/ospac/data/licenses/json/CC-BY-NC-SA-3.0-DE.json
@@ -41,7 +41,7 @@
         "requires_review": []
       },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "NonCommercial license: commercial use is not permitted"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-BY-NC-SA-3.0-IGO.json
+++ b/ospac/data/licenses/json/CC-BY-NC-SA-3.0-IGO.json
@@ -2,10 +2,10 @@
   "license": {
     "id": "CC-BY-NC-SA-3.0-IGO",
     "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 IGO",
-    "type": "permissive",
+    "type": "noncommercial",
     "spdx_id": "CC-BY-NC-SA-3.0-IGO",
     "properties": {
-      "commercial_use": true,
+      "commercial_use": false,
       "distribution": true,
       "modification": true,
       "patent_grant": false,
@@ -17,7 +17,7 @@
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -45,10 +45,13 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Distribute modifications under the same license",
+      "Non-commercial use only"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Commercial use not permitted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-NC-SA-3.0-IGO.json
+++ b/ospac/data/licenses/json/CC-BY-NC-SA-3.0-IGO.json
@@ -41,7 +41,7 @@
         "requires_review": []
       },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "NonCommercial license: commercial use is not permitted"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-BY-NC-SA-3.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-SA-3.0.json
@@ -2,10 +2,10 @@
   "license": {
     "id": "CC-BY-NC-SA-3.0",
     "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Unported",
-    "type": "permissive",
+    "type": "noncommercial",
     "spdx_id": "CC-BY-NC-SA-3.0",
     "properties": {
-      "commercial_use": true,
+      "commercial_use": false,
       "distribution": true,
       "modification": true,
       "patent_grant": false,
@@ -17,7 +17,7 @@
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -45,10 +45,13 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Distribute modifications under the same license",
+      "Non-commercial use only"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Commercial use not permitted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-NC-SA-3.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-SA-3.0.json
@@ -41,7 +41,7 @@
         "requires_review": []
       },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "NonCommercial license: commercial use is not permitted"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-BY-NC-SA-4.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-SA-4.0.json
@@ -2,10 +2,10 @@
   "license": {
     "id": "CC-BY-NC-SA-4.0",
     "name": "Creative Commons Attribution Non Commercial Share Alike 4.0 International",
-    "type": "permissive",
+    "type": "noncommercial",
     "spdx_id": "CC-BY-NC-SA-4.0",
     "properties": {
-      "commercial_use": true,
+      "commercial_use": false,
       "distribution": true,
       "modification": true,
       "patent_grant": false,
@@ -17,7 +17,7 @@
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -45,10 +45,13 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Distribute modifications under the same license",
+      "Non-commercial use only"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Commercial use not permitted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-NC-SA-4.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-SA-4.0.json
@@ -41,7 +41,7 @@
         "requires_review": []
       },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "NonCommercial license: commercial use is not permitted"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-BY-ND-1.0.json
+++ b/ospac/data/licenses/json/CC-BY-ND-1.0.json
@@ -7,7 +7,7 @@
     "properties": {
       "commercial_use": true,
       "distribution": true,
-      "modification": true,
+      "modification": false,
       "patent_grant": false,
       "private_use": true
     },
@@ -45,7 +45,8 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "No modification permitted"
     ],
     "key_requirements": [
       "Attribution required"

--- a/ospac/data/licenses/json/CC-BY-ND-1.0.json
+++ b/ospac/data/licenses/json/CC-BY-ND-1.0.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "CC-BY-ND-1.0",
     "name": "Creative Commons Attribution No Derivatives 1.0 Generic",
-    "type": "permissive",
+    "type": "no_derivatives",
     "spdx_id": "CC-BY-ND-1.0",
     "properties": {
       "commercial_use": true,
@@ -41,7 +41,7 @@
         "requires_review": []
       },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "No-derivatives license: modified versions may not be distributed"
     },
     "obligations": [
       "Retain copyright notices",
@@ -49,7 +49,8 @@
       "No modification permitted"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Distribution of modified versions not permitted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-ND-2.0.json
+++ b/ospac/data/licenses/json/CC-BY-ND-2.0.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "CC-BY-ND-2.0",
     "name": "Creative Commons Attribution No Derivatives 2.0 Generic",
-    "type": "permissive",
+    "type": "no_derivatives",
     "spdx_id": "CC-BY-ND-2.0",
     "properties": {
       "commercial_use": true,
@@ -41,7 +41,7 @@
         "requires_review": []
       },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "No-derivatives license: modified versions may not be distributed"
     },
     "obligations": [
       "Retain copyright notices",
@@ -49,7 +49,8 @@
       "No modification permitted"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Distribution of modified versions not permitted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-ND-2.0.json
+++ b/ospac/data/licenses/json/CC-BY-ND-2.0.json
@@ -7,7 +7,7 @@
     "properties": {
       "commercial_use": true,
       "distribution": true,
-      "modification": true,
+      "modification": false,
       "patent_grant": false,
       "private_use": true
     },
@@ -45,7 +45,8 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "No modification permitted"
     ],
     "key_requirements": [
       "Attribution required"

--- a/ospac/data/licenses/json/CC-BY-ND-2.5.json
+++ b/ospac/data/licenses/json/CC-BY-ND-2.5.json
@@ -7,7 +7,7 @@
     "properties": {
       "commercial_use": true,
       "distribution": true,
-      "modification": true,
+      "modification": false,
       "patent_grant": false,
       "private_use": true
     },
@@ -45,7 +45,8 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "No modification permitted"
     ],
     "key_requirements": [
       "Attribution required"

--- a/ospac/data/licenses/json/CC-BY-ND-2.5.json
+++ b/ospac/data/licenses/json/CC-BY-ND-2.5.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "CC-BY-ND-2.5",
     "name": "Creative Commons Attribution No Derivatives 2.5 Generic",
-    "type": "permissive",
+    "type": "no_derivatives",
     "spdx_id": "CC-BY-ND-2.5",
     "properties": {
       "commercial_use": true,
@@ -41,7 +41,7 @@
         "requires_review": []
       },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "No-derivatives license: modified versions may not be distributed"
     },
     "obligations": [
       "Retain copyright notices",
@@ -49,7 +49,8 @@
       "No modification permitted"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Distribution of modified versions not permitted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-ND-3.0-DE.json
+++ b/ospac/data/licenses/json/CC-BY-ND-3.0-DE.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "CC-BY-ND-3.0-DE",
     "name": "Creative Commons Attribution No Derivatives 3.0 Germany",
-    "type": "permissive",
+    "type": "no_derivatives",
     "spdx_id": "CC-BY-ND-3.0-DE",
     "properties": {
       "commercial_use": true,
@@ -41,7 +41,7 @@
         "requires_review": []
       },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "No-derivatives license: modified versions may not be distributed"
     },
     "obligations": [
       "Retain copyright notices",
@@ -49,7 +49,8 @@
       "No modification permitted"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Distribution of modified versions not permitted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-ND-3.0-DE.json
+++ b/ospac/data/licenses/json/CC-BY-ND-3.0-DE.json
@@ -7,7 +7,7 @@
     "properties": {
       "commercial_use": true,
       "distribution": true,
-      "modification": true,
+      "modification": false,
       "patent_grant": false,
       "private_use": true
     },
@@ -45,7 +45,8 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "No modification permitted"
     ],
     "key_requirements": [
       "Attribution required"

--- a/ospac/data/licenses/json/CC-BY-ND-3.0.json
+++ b/ospac/data/licenses/json/CC-BY-ND-3.0.json
@@ -7,7 +7,7 @@
     "properties": {
       "commercial_use": true,
       "distribution": true,
-      "modification": true,
+      "modification": false,
       "patent_grant": false,
       "private_use": true
     },
@@ -45,7 +45,8 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "No modification permitted"
     ],
     "key_requirements": [
       "Attribution required"

--- a/ospac/data/licenses/json/CC-BY-ND-3.0.json
+++ b/ospac/data/licenses/json/CC-BY-ND-3.0.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "CC-BY-ND-3.0",
     "name": "Creative Commons Attribution No Derivatives 3.0 Unported",
-    "type": "permissive",
+    "type": "no_derivatives",
     "spdx_id": "CC-BY-ND-3.0",
     "properties": {
       "commercial_use": true,
@@ -41,7 +41,7 @@
         "requires_review": []
       },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "No-derivatives license: modified versions may not be distributed"
     },
     "obligations": [
       "Retain copyright notices",
@@ -49,7 +49,8 @@
       "No modification permitted"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Distribution of modified versions not permitted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-ND-4.0.json
+++ b/ospac/data/licenses/json/CC-BY-ND-4.0.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "CC-BY-ND-4.0",
     "name": "Creative Commons Attribution No Derivatives 4.0 International",
-    "type": "permissive",
+    "type": "no_derivatives",
     "spdx_id": "CC-BY-ND-4.0",
     "properties": {
       "commercial_use": true,
@@ -41,7 +41,7 @@
         "requires_review": []
       },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "No-derivatives license: modified versions may not be distributed"
     },
     "obligations": [
       "Retain copyright notices",
@@ -49,7 +49,8 @@
       "No modification permitted"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Distribution of modified versions not permitted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-ND-4.0.json
+++ b/ospac/data/licenses/json/CC-BY-ND-4.0.json
@@ -7,7 +7,7 @@
     "properties": {
       "commercial_use": true,
       "distribution": true,
-      "modification": true,
+      "modification": false,
       "patent_grant": false,
       "private_use": true
     },
@@ -45,7 +45,8 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "No modification permitted"
     ],
     "key_requirements": [
       "Attribution required"

--- a/ospac/data/licenses/json/CC-BY-SA-1.0.json
+++ b/ospac/data/licenses/json/CC-BY-SA-1.0.json
@@ -40,8 +40,8 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "derivative",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-BY-SA-1.0.json
+++ b/ospac/data/licenses/json/CC-BY-SA-1.0.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "CC-BY-SA-1.0",
     "name": "Creative Commons Attribution Share Alike 1.0 Generic",
-    "type": "permissive",
+    "type": "copyleft_weak",
     "spdx_id": "CC-BY-SA-1.0",
     "properties": {
       "commercial_use": true,
@@ -17,7 +17,7 @@
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -45,10 +45,12 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Distribute modifications under the same license"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Modifications to covered files must stay open-source"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-SA-2.0-UK.json
+++ b/ospac/data/licenses/json/CC-BY-SA-2.0-UK.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "CC-BY-SA-2.0-UK",
     "name": "Creative Commons Attribution Share Alike 2.0 England and Wales",
-    "type": "permissive",
+    "type": "copyleft_weak",
     "spdx_id": "CC-BY-SA-2.0-UK",
     "properties": {
       "commercial_use": true,
@@ -17,7 +17,7 @@
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -45,10 +45,12 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Distribute modifications under the same license"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Modifications to covered files must stay open-source"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-SA-2.0-UK.json
+++ b/ospac/data/licenses/json/CC-BY-SA-2.0-UK.json
@@ -40,8 +40,8 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "derivative",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-BY-SA-2.0.json
+++ b/ospac/data/licenses/json/CC-BY-SA-2.0.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "CC-BY-SA-2.0",
     "name": "Creative Commons Attribution Share Alike 2.0 Generic",
-    "type": "permissive",
+    "type": "copyleft_weak",
     "spdx_id": "CC-BY-SA-2.0",
     "properties": {
       "commercial_use": true,
@@ -17,7 +17,7 @@
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -45,10 +45,12 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Distribute modifications under the same license"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Modifications to covered files must stay open-source"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-SA-2.0.json
+++ b/ospac/data/licenses/json/CC-BY-SA-2.0.json
@@ -40,8 +40,8 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "derivative",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-BY-SA-2.1-JP.json
+++ b/ospac/data/licenses/json/CC-BY-SA-2.1-JP.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "CC-BY-SA-2.1-JP",
     "name": "Creative Commons Attribution Share Alike 2.1 Japan",
-    "type": "permissive",
+    "type": "copyleft_weak",
     "spdx_id": "CC-BY-SA-2.1-JP",
     "properties": {
       "commercial_use": true,
@@ -17,7 +17,7 @@
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -45,10 +45,12 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Distribute modifications under the same license"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Modifications to covered files must stay open-source"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-SA-2.1-JP.json
+++ b/ospac/data/licenses/json/CC-BY-SA-2.1-JP.json
@@ -40,8 +40,8 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "derivative",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-BY-SA-2.5.json
+++ b/ospac/data/licenses/json/CC-BY-SA-2.5.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "CC-BY-SA-2.5",
     "name": "Creative Commons Attribution Share Alike 2.5 Generic",
-    "type": "permissive",
+    "type": "copyleft_weak",
     "spdx_id": "CC-BY-SA-2.5",
     "properties": {
       "commercial_use": true,
@@ -17,7 +17,7 @@
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -45,10 +45,12 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Distribute modifications under the same license"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Modifications to covered files must stay open-source"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-SA-2.5.json
+++ b/ospac/data/licenses/json/CC-BY-SA-2.5.json
@@ -40,8 +40,8 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "derivative",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-BY-SA-3.0-AT.json
+++ b/ospac/data/licenses/json/CC-BY-SA-3.0-AT.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "CC-BY-SA-3.0-AT",
     "name": "Creative Commons Attribution Share Alike 3.0 Austria",
-    "type": "permissive",
+    "type": "copyleft_weak",
     "spdx_id": "CC-BY-SA-3.0-AT",
     "properties": {
       "commercial_use": true,
@@ -17,7 +17,7 @@
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -45,10 +45,12 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Distribute modifications under the same license"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Modifications to covered files must stay open-source"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-SA-3.0-AT.json
+++ b/ospac/data/licenses/json/CC-BY-SA-3.0-AT.json
@@ -40,8 +40,8 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "derivative",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-BY-SA-3.0-DE.json
+++ b/ospac/data/licenses/json/CC-BY-SA-3.0-DE.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "CC-BY-SA-3.0-DE",
     "name": "Creative Commons Attribution Share Alike 3.0 Germany",
-    "type": "permissive",
+    "type": "copyleft_weak",
     "spdx_id": "CC-BY-SA-3.0-DE",
     "properties": {
       "commercial_use": true,
@@ -17,7 +17,7 @@
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -45,10 +45,12 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Distribute modifications under the same license"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Modifications to covered files must stay open-source"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-SA-3.0-DE.json
+++ b/ospac/data/licenses/json/CC-BY-SA-3.0-DE.json
@@ -40,8 +40,8 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "derivative",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-BY-SA-3.0-IGO.json
+++ b/ospac/data/licenses/json/CC-BY-SA-3.0-IGO.json
@@ -40,8 +40,8 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "derivative",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-BY-SA-3.0-IGO.json
+++ b/ospac/data/licenses/json/CC-BY-SA-3.0-IGO.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "CC-BY-SA-3.0-IGO",
     "name": "Creative Commons Attribution-ShareAlike 3.0 IGO",
-    "type": "permissive",
+    "type": "copyleft_weak",
     "spdx_id": "CC-BY-SA-3.0-IGO",
     "properties": {
       "commercial_use": true,
@@ -17,7 +17,7 @@
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -45,10 +45,12 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Distribute modifications under the same license"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Modifications to covered files must stay open-source"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-SA-3.0.json
+++ b/ospac/data/licenses/json/CC-BY-SA-3.0.json
@@ -40,8 +40,8 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "derivative",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-BY-SA-3.0.json
+++ b/ospac/data/licenses/json/CC-BY-SA-3.0.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "CC-BY-SA-3.0",
     "name": "Creative Commons Attribution Share Alike 3.0 Unported",
-    "type": "permissive",
+    "type": "copyleft_weak",
     "spdx_id": "CC-BY-SA-3.0",
     "properties": {
       "commercial_use": true,
@@ -17,7 +17,7 @@
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -45,10 +45,12 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Distribute modifications under the same license"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Modifications to covered files must stay open-source"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-SA-4.0.json
+++ b/ospac/data/licenses/json/CC-BY-SA-4.0.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "CC-BY-SA-4.0",
     "name": "Creative Commons Attribution Share Alike 4.0 International",
-    "type": "permissive",
+    "type": "copyleft_weak",
     "spdx_id": "CC-BY-SA-4.0",
     "properties": {
       "commercial_use": true,
@@ -17,7 +17,7 @@
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -45,10 +45,12 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Distribute modifications under the same license"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Modifications to covered files must stay open-source"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CC-BY-SA-4.0.json
+++ b/ospac/data/licenses/json/CC-BY-SA-4.0.json
@@ -40,8 +40,8 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "derivative",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-SA-1.0.json
+++ b/ospac/data/licenses/json/CC-SA-1.0.json
@@ -40,8 +40,8 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "derivative",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/CC-SA-1.0.json
+++ b/ospac/data/licenses/json/CC-SA-1.0.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "CC-SA-1.0",
     "name": "Creative Commons Share Alike 1.0 Generic",
-    "type": "permissive",
+    "type": "copyleft_weak",
     "spdx_id": "CC-SA-1.0",
     "properties": {
       "commercial_use": true,
@@ -17,7 +17,7 @@
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -45,10 +45,12 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Distribute modifications under the same license"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Modifications to covered files must stay open-source"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CDDL-1.0.json
+++ b/ospac/data/licenses/json/CDDL-1.0.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "CDDL-1.0",
     "name": "Common Development and Distribution License 1.0",
-    "type": "permissive",
+    "type": "copyleft_weak",
     "spdx_id": "CDDL-1.0",
     "properties": {
       "commercial_use": true,
@@ -12,12 +12,12 @@
       "private_use": true
     },
     "requirements": {
-      "disclose_source": false,
+      "disclose_source": true,
       "include_license": true,
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -40,15 +40,18 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "module",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Provide or offer access to complete source code",
+      "Distribute modifications under the same license"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Modifications to covered files must stay open-source"
     ],
     "spdx_metadata": {
       "is_osi_approved": true,

--- a/ospac/data/licenses/json/CDDL-1.1.json
+++ b/ospac/data/licenses/json/CDDL-1.1.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "CDDL-1.1",
     "name": "Common Development and Distribution License 1.1",
-    "type": "permissive",
+    "type": "copyleft_weak",
     "spdx_id": "CDDL-1.1",
     "properties": {
       "commercial_use": true,
@@ -12,12 +12,12 @@
       "private_use": true
     },
     "requirements": {
-      "disclose_source": false,
+      "disclose_source": true,
       "include_license": true,
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -40,15 +40,18 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "module",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Provide or offer access to complete source code",
+      "Distribute modifications under the same license"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Modifications to covered files must stay open-source"
     ],
     "spdx_metadata": {
       "is_osi_approved": true,

--- a/ospac/data/licenses/json/CDLA-Sharing-1.0.json
+++ b/ospac/data/licenses/json/CDLA-Sharing-1.0.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "CDLA-Sharing-1.0",
     "name": "Community Data License Agreement Sharing 1.0",
-    "type": "permissive",
+    "type": "copyleft_weak",
     "spdx_id": "CDLA-Sharing-1.0",
     "properties": {
       "commercial_use": true,
@@ -17,7 +17,7 @@
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -40,15 +40,17 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "module",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Distribute modifications under the same license"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Modifications to covered files must stay open-source"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/CERN-OHL-S-2.0.json
+++ b/ospac/data/licenses/json/CERN-OHL-S-2.0.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "CERN-OHL-S-2.0",
     "name": "CERN Open Hardware Licence Version 2 - Strongly Reciprocal",
-    "type": "permissive",
+    "type": "copyleft_strong",
     "spdx_id": "CERN-OHL-S-2.0",
     "properties": {
       "commercial_use": true,
@@ -12,12 +12,12 @@
       "private_use": true
     },
     "requirements": {
-      "disclose_source": false,
+      "disclose_source": true,
       "include_license": true,
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -40,15 +40,18 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "full",
+      "notes": "Strong copyleft: the combined work must be released under the same license"
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Provide or offer access to complete source code",
+      "Distribute modifications under the same license"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Combined works must be released under the same license"
     ],
     "spdx_metadata": {
       "is_osi_approved": true,

--- a/ospac/data/licenses/json/CERN-OHL-W-2.0.json
+++ b/ospac/data/licenses/json/CERN-OHL-W-2.0.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "CERN-OHL-W-2.0",
     "name": "CERN Open Hardware Licence Version 2 - Weakly Reciprocal",
-    "type": "permissive",
+    "type": "copyleft_weak",
     "spdx_id": "CERN-OHL-W-2.0",
     "properties": {
       "commercial_use": true,
@@ -12,12 +12,12 @@
       "private_use": true
     },
     "requirements": {
-      "disclose_source": false,
+      "disclose_source": true,
       "include_license": true,
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -40,15 +40,18 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "module",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Provide or offer access to complete source code",
+      "Distribute modifications under the same license"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Modifications to covered files must stay open-source"
     ],
     "spdx_metadata": {
       "is_osi_approved": true,

--- a/ospac/data/licenses/json/EPL-1.0.json
+++ b/ospac/data/licenses/json/EPL-1.0.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "EPL-1.0",
     "name": "Eclipse Public License 1.0",
-    "type": "permissive",
+    "type": "copyleft_weak",
     "spdx_id": "EPL-1.0",
     "properties": {
       "commercial_use": true,
@@ -12,12 +12,12 @@
       "private_use": true
     },
     "requirements": {
-      "disclose_source": false,
+      "disclose_source": true,
       "include_license": true,
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -40,15 +40,18 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "module",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Provide or offer access to complete source code",
+      "Distribute modifications under the same license"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Modifications to covered files must stay open-source"
     ],
     "spdx_metadata": {
       "is_osi_approved": true,

--- a/ospac/data/licenses/json/EPL-2.0.json
+++ b/ospac/data/licenses/json/EPL-2.0.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "EPL-2.0",
     "name": "Eclipse Public License 2.0",
-    "type": "permissive",
+    "type": "copyleft_weak",
     "spdx_id": "EPL-2.0",
     "properties": {
       "commercial_use": true,
@@ -12,12 +12,12 @@
       "private_use": true
     },
     "requirements": {
-      "disclose_source": false,
+      "disclose_source": true,
       "include_license": true,
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -40,15 +40,18 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "module",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Provide or offer access to complete source code",
+      "Distribute modifications under the same license"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Modifications to covered files must stay open-source"
     ],
     "spdx_metadata": {
       "is_osi_approved": true,

--- a/ospac/data/licenses/json/ESA-PL-strong-copyleft-2.4.json
+++ b/ospac/data/licenses/json/ESA-PL-strong-copyleft-2.4.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "ESA-PL-strong-copyleft-2.4",
     "name": "European Space Agency Public License (ESA-PL) - V2.4 - Strong Copyleft (Type 1)",
-    "type": "permissive",
+    "type": "copyleft_strong",
     "spdx_id": "ESA-PL-strong-copyleft-2.4",
     "properties": {
       "commercial_use": true,
@@ -12,12 +12,12 @@
       "private_use": true
     },
     "requirements": {
-      "disclose_source": false,
+      "disclose_source": true,
       "include_license": true,
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -40,15 +40,18 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "full",
+      "notes": "Strong copyleft: the combined work must be released under the same license"
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Provide or offer access to complete source code",
+      "Distribute modifications under the same license"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Combined works must be released under the same license"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/ESA-PL-weak-copyleft-2.4.json
+++ b/ospac/data/licenses/json/ESA-PL-weak-copyleft-2.4.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "ESA-PL-weak-copyleft-2.4",
     "name": "European Space Agency Public License \u2013 v2.4 \u2013 Weak Copyleft (Type 2)",
-    "type": "permissive",
+    "type": "copyleft_weak",
     "spdx_id": "ESA-PL-weak-copyleft-2.4",
     "properties": {
       "commercial_use": true,
@@ -17,7 +17,7 @@
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -40,15 +40,17 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "module",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Distribute modifications under the same license"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Modifications to covered files must stay open-source"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/EUPL-1.1.json
+++ b/ospac/data/licenses/json/EUPL-1.1.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "EUPL-1.1",
     "name": "European Union Public License 1.1",
-    "type": "permissive",
+    "type": "copyleft_strong",
     "spdx_id": "EUPL-1.1",
     "properties": {
       "commercial_use": true,
@@ -12,12 +12,12 @@
       "private_use": true
     },
     "requirements": {
-      "disclose_source": false,
+      "disclose_source": true,
       "include_license": true,
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -40,15 +40,18 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "full",
+      "notes": "Strong copyleft: the combined work must be released under the same license"
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Provide or offer access to complete source code",
+      "Distribute modifications under the same license"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Combined works must be released under the same license"
     ],
     "spdx_metadata": {
       "is_osi_approved": true,

--- a/ospac/data/licenses/json/EUPL-1.2.json
+++ b/ospac/data/licenses/json/EUPL-1.2.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "EUPL-1.2",
     "name": "European Union Public License 1.2",
-    "type": "permissive",
+    "type": "copyleft_strong",
     "spdx_id": "EUPL-1.2",
     "properties": {
       "commercial_use": true,
@@ -12,12 +12,12 @@
       "private_use": true
     },
     "requirements": {
-      "disclose_source": false,
+      "disclose_source": true,
       "include_license": true,
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -40,15 +40,18 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "full",
+      "notes": "Strong copyleft: the combined work must be released under the same license"
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Provide or offer access to complete source code",
+      "Distribute modifications under the same license"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Combined works must be released under the same license"
     ],
     "spdx_metadata": {
       "is_osi_approved": true,

--- a/ospac/data/licenses/json/Elastic-2.0.json
+++ b/ospac/data/licenses/json/Elastic-2.0.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "Elastic-2.0",
     "name": "Elastic License 2.0",
-    "type": "permissive",
+    "type": "source_available",
     "spdx_id": "Elastic-2.0",
     "properties": {
       "commercial_use": true,
@@ -40,15 +40,15 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "unknown",
+      "notes": "Source-available license: usage restrictions apply, review the terms"
     },
     "obligations": [
       "Retain copyright notices",
       "Include license text"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Source visible but redistribution restricted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/LGPL-2.0+.json
+++ b/ospac/data/licenses/json/LGPL-2.0+.json
@@ -48,8 +48,8 @@
           "category:proprietary"
         ]
       },
-      "contamination_effect": "full",
-      "notes": "Strong copyleft with viral effect"
+      "contamination_effect": "module",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/LGPL-2.0-only.json
+++ b/ospac/data/licenses/json/LGPL-2.0-only.json
@@ -48,8 +48,8 @@
           "category:proprietary"
         ]
       },
-      "contamination_effect": "full",
-      "notes": "Strong copyleft with viral effect"
+      "contamination_effect": "module",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/LGPL-2.0-or-later.json
+++ b/ospac/data/licenses/json/LGPL-2.0-or-later.json
@@ -48,8 +48,8 @@
           "category:proprietary"
         ]
       },
-      "contamination_effect": "full",
-      "notes": "Strong copyleft with viral effect"
+      "contamination_effect": "module",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/LGPL-2.0.json
+++ b/ospac/data/licenses/json/LGPL-2.0.json
@@ -48,8 +48,8 @@
           "category:proprietary"
         ]
       },
-      "contamination_effect": "full",
-      "notes": "Strong copyleft with viral effect"
+      "contamination_effect": "module",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/LGPL-2.1+.json
+++ b/ospac/data/licenses/json/LGPL-2.1+.json
@@ -48,8 +48,8 @@
           "category:proprietary"
         ]
       },
-      "contamination_effect": "full",
-      "notes": "Strong copyleft with viral effect"
+      "contamination_effect": "module",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/LGPL-2.1-only.json
+++ b/ospac/data/licenses/json/LGPL-2.1-only.json
@@ -48,8 +48,8 @@
           "category:proprietary"
         ]
       },
-      "contamination_effect": "full",
-      "notes": "Strong copyleft with viral effect"
+      "contamination_effect": "module",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/LGPL-2.1-or-later.json
+++ b/ospac/data/licenses/json/LGPL-2.1-or-later.json
@@ -48,8 +48,8 @@
           "category:proprietary"
         ]
       },
-      "contamination_effect": "full",
-      "notes": "Strong copyleft with viral effect"
+      "contamination_effect": "module",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/LGPL-2.1.json
+++ b/ospac/data/licenses/json/LGPL-2.1.json
@@ -48,8 +48,8 @@
           "category:proprietary"
         ]
       },
-      "contamination_effect": "full",
-      "notes": "Strong copyleft with viral effect"
+      "contamination_effect": "module",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/LGPL-3.0+.json
+++ b/ospac/data/licenses/json/LGPL-3.0+.json
@@ -48,8 +48,8 @@
           "category:proprietary"
         ]
       },
-      "contamination_effect": "full",
-      "notes": "Strong copyleft with viral effect"
+      "contamination_effect": "module",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/LGPL-3.0-only.json
+++ b/ospac/data/licenses/json/LGPL-3.0-only.json
@@ -48,8 +48,8 @@
           "category:proprietary"
         ]
       },
-      "contamination_effect": "full",
-      "notes": "Strong copyleft with viral effect"
+      "contamination_effect": "module",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/LGPL-3.0-or-later.json
+++ b/ospac/data/licenses/json/LGPL-3.0-or-later.json
@@ -48,8 +48,8 @@
           "category:proprietary"
         ]
       },
-      "contamination_effect": "full",
-      "notes": "Strong copyleft with viral effect"
+      "contamination_effect": "module",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/LGPL-3.0.json
+++ b/ospac/data/licenses/json/LGPL-3.0.json
@@ -48,8 +48,8 @@
           "category:proprietary"
         ]
       },
-      "contamination_effect": "full",
-      "notes": "Strong copyleft with viral effect"
+      "contamination_effect": "module",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/LGPLLR.json
+++ b/ospac/data/licenses/json/LGPLLR.json
@@ -48,8 +48,8 @@
           "category:proprietary"
         ]
       },
-      "contamination_effect": "full",
-      "notes": "Strong copyleft with viral effect"
+      "contamination_effect": "module",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/LGPLLR.json
+++ b/ospac/data/licenses/json/LGPLLR.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "LGPLLR",
     "name": "Lesser General Public License For Linguistic Resources",
-    "type": "copyleft_strong",
+    "type": "copyleft_weak",
     "spdx_id": "LGPLLR",
     "properties": {
       "commercial_use": true,
@@ -59,7 +59,7 @@
     ],
     "key_requirements": [
       "Attribution required",
-      "Combined works must be released under the same license"
+      "Modifications to covered files must stay open-source"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/Linux-man-pages-copyleft-2-para.json
+++ b/ospac/data/licenses/json/Linux-man-pages-copyleft-2-para.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "Linux-man-pages-copyleft-2-para",
     "name": "Linux man-pages Copyleft - 2 paragraphs",
-    "type": "permissive",
+    "type": "copyleft_weak",
     "spdx_id": "Linux-man-pages-copyleft-2-para",
     "properties": {
       "commercial_use": true,
@@ -17,7 +17,7 @@
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -40,15 +40,17 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "module",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Distribute modifications under the same license"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Modifications to covered files must stay open-source"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/Linux-man-pages-copyleft-var.json
+++ b/ospac/data/licenses/json/Linux-man-pages-copyleft-var.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "Linux-man-pages-copyleft-var",
     "name": "Linux man-pages Copyleft Variant",
-    "type": "permissive",
+    "type": "copyleft_weak",
     "spdx_id": "Linux-man-pages-copyleft-var",
     "properties": {
       "commercial_use": true,
@@ -17,7 +17,7 @@
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -40,15 +40,17 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "module",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Distribute modifications under the same license"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Modifications to covered files must stay open-source"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/Linux-man-pages-copyleft.json
+++ b/ospac/data/licenses/json/Linux-man-pages-copyleft.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "Linux-man-pages-copyleft",
     "name": "Linux man-pages Copyleft",
-    "type": "permissive",
+    "type": "copyleft_weak",
     "spdx_id": "Linux-man-pages-copyleft",
     "properties": {
       "commercial_use": true,
@@ -17,7 +17,7 @@
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -40,15 +40,17 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "module",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Distribute modifications under the same license"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Modifications to covered files must stay open-source"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/MPL-2.0-no-copyleft-exception.json
+++ b/ospac/data/licenses/json/MPL-2.0-no-copyleft-exception.json
@@ -40,8 +40,8 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "module",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/MPL-2.0.json
+++ b/ospac/data/licenses/json/MPL-2.0.json
@@ -40,8 +40,8 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "module",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/MS-RL.json
+++ b/ospac/data/licenses/json/MS-RL.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "MS-RL",
     "name": "Microsoft Reciprocal License",
-    "type": "permissive",
+    "type": "copyleft_weak",
     "spdx_id": "MS-RL",
     "properties": {
       "commercial_use": true,
@@ -17,7 +17,7 @@
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -40,15 +40,17 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "module",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Distribute modifications under the same license"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Modifications to covered files must stay open-source"
     ],
     "spdx_metadata": {
       "is_osi_approved": true,

--- a/ospac/data/licenses/json/NCGL-UK-2.0.json
+++ b/ospac/data/licenses/json/NCGL-UK-2.0.json
@@ -2,10 +2,10 @@
   "license": {
     "id": "NCGL-UK-2.0",
     "name": "Non-Commercial Government Licence",
-    "type": "permissive",
+    "type": "noncommercial",
     "spdx_id": "NCGL-UK-2.0",
     "properties": {
-      "commercial_use": true,
+      "commercial_use": false,
       "distribution": true,
       "modification": true,
       "patent_grant": false,
@@ -45,10 +45,12 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Non-commercial use only"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Commercial use not permitted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/NCGL-UK-2.0.json
+++ b/ospac/data/licenses/json/NCGL-UK-2.0.json
@@ -41,7 +41,7 @@
         "requires_review": []
       },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "NonCommercial license: commercial use is not permitted"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/NPOSL-3.0.json
+++ b/ospac/data/licenses/json/NPOSL-3.0.json
@@ -2,10 +2,10 @@
   "license": {
     "id": "NPOSL-3.0",
     "name": "Non-Profit Open Software License 3.0",
-    "type": "permissive",
+    "type": "noncommercial",
     "spdx_id": "NPOSL-3.0",
     "properties": {
-      "commercial_use": true,
+      "commercial_use": false,
       "distribution": true,
       "modification": true,
       "patent_grant": false,
@@ -41,14 +41,16 @@
         "requires_review": []
       },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "NonCommercial license: commercial use is not permitted"
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Non-commercial use only"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Commercial use not permitted"
     ],
     "spdx_metadata": {
       "is_osi_approved": true,

--- a/ospac/data/licenses/json/ODbL-1.0.json
+++ b/ospac/data/licenses/json/ODbL-1.0.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "ODbL-1.0",
     "name": "Open Data Commons Open Database License v1.0",
-    "type": "permissive",
+    "type": "copyleft_weak",
     "spdx_id": "ODbL-1.0",
     "properties": {
       "commercial_use": true,
@@ -17,7 +17,7 @@
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -40,15 +40,17 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "module",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Distribute modifications under the same license"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Modifications to covered files must stay open-source"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/OSL-3.0.json
+++ b/ospac/data/licenses/json/OSL-3.0.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "OSL-3.0",
     "name": "Open Software License 3.0",
-    "type": "permissive",
+    "type": "network_copyleft",
     "spdx_id": "OSL-3.0",
     "properties": {
       "commercial_use": true,
@@ -12,13 +12,13 @@
       "private_use": true
     },
     "requirements": {
-      "disclose_source": false,
+      "disclose_source": true,
       "include_license": true,
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
-      "network_use_disclosure": false
+      "same_license": true,
+      "network_use_disclosure": true
     },
     "limitations": {
       "liability": false,
@@ -40,15 +40,19 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "full",
+      "notes": "Network copyleft: serving users over a network triggers source disclosure"
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Provide or offer access to complete source code",
+      "Distribute modifications under the same license",
+      "Make source available to users interacting over a network"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Network use triggers source-disclosure obligation"
     ],
     "spdx_metadata": {
       "is_osi_approved": true,

--- a/ospac/data/licenses/json/Parity-7.0.0.json
+++ b/ospac/data/licenses/json/Parity-7.0.0.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "Parity-7.0.0",
     "name": "The Parity Public License 7.0.0",
-    "type": "permissive",
+    "type": "copyleft_strong",
     "spdx_id": "Parity-7.0.0",
     "properties": {
       "commercial_use": true,
@@ -12,12 +12,12 @@
       "private_use": true
     },
     "requirements": {
-      "disclose_source": false,
+      "disclose_source": true,
       "include_license": true,
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -40,15 +40,18 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "full",
+      "notes": "Strong copyleft: the combined work must be released under the same license"
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Provide or offer access to complete source code",
+      "Distribute modifications under the same license"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Combined works must be released under the same license"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/PolyForm-Noncommercial-1.0.0.json
+++ b/ospac/data/licenses/json/PolyForm-Noncommercial-1.0.0.json
@@ -2,10 +2,10 @@
   "license": {
     "id": "PolyForm-Noncommercial-1.0.0",
     "name": "PolyForm Noncommercial License 1.0.0",
-    "type": "permissive",
+    "type": "noncommercial",
     "spdx_id": "PolyForm-Noncommercial-1.0.0",
     "properties": {
-      "commercial_use": true,
+      "commercial_use": false,
       "distribution": true,
       "modification": true,
       "patent_grant": false,
@@ -45,10 +45,12 @@
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Non-commercial use only"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Commercial use not permitted"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/PolyForm-Noncommercial-1.0.0.json
+++ b/ospac/data/licenses/json/PolyForm-Noncommercial-1.0.0.json
@@ -41,7 +41,7 @@
         "requires_review": []
       },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "NonCommercial license: commercial use is not permitted"
     },
     "obligations": [
       "Retain copyright notices",

--- a/ospac/data/licenses/json/RPL-1.1.json
+++ b/ospac/data/licenses/json/RPL-1.1.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "RPL-1.1",
     "name": "Reciprocal Public License 1.1",
-    "type": "permissive",
+    "type": "copyleft_strong",
     "spdx_id": "RPL-1.1",
     "properties": {
       "commercial_use": true,
@@ -12,12 +12,12 @@
       "private_use": true
     },
     "requirements": {
-      "disclose_source": false,
+      "disclose_source": true,
       "include_license": true,
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -40,15 +40,18 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "full",
+      "notes": "Strong copyleft: the combined work must be released under the same license"
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Provide or offer access to complete source code",
+      "Distribute modifications under the same license"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Combined works must be released under the same license"
     ],
     "spdx_metadata": {
       "is_osi_approved": true,

--- a/ospac/data/licenses/json/RPL-1.5.json
+++ b/ospac/data/licenses/json/RPL-1.5.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "RPL-1.5",
     "name": "Reciprocal Public License 1.5",
-    "type": "permissive",
+    "type": "copyleft_strong",
     "spdx_id": "RPL-1.5",
     "properties": {
       "commercial_use": true,
@@ -12,12 +12,12 @@
       "private_use": true
     },
     "requirements": {
-      "disclose_source": false,
+      "disclose_source": true,
       "include_license": true,
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -40,15 +40,18 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "full",
+      "notes": "Strong copyleft: the combined work must be released under the same license"
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Provide or offer access to complete source code",
+      "Distribute modifications under the same license"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Combined works must be released under the same license"
     ],
     "spdx_metadata": {
       "is_osi_approved": true,

--- a/ospac/data/licenses/json/SSPL-1.0.json
+++ b/ospac/data/licenses/json/SSPL-1.0.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "SSPL-1.0",
     "name": "Server Side Public License, v 1",
-    "type": "permissive",
+    "type": "network_copyleft",
     "spdx_id": "SSPL-1.0",
     "properties": {
       "commercial_use": true,
@@ -12,13 +12,13 @@
       "private_use": true
     },
     "requirements": {
-      "disclose_source": false,
+      "disclose_source": true,
       "include_license": true,
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
-      "network_use_disclosure": false
+      "same_license": true,
+      "network_use_disclosure": true
     },
     "limitations": {
       "liability": false,
@@ -40,15 +40,19 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "full",
+      "notes": "Network copyleft: serving users over a network triggers source disclosure"
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Provide or offer access to complete source code",
+      "Distribute modifications under the same license",
+      "Make source available to users interacting over a network"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Network use triggers source-disclosure obligation"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/copyleft-next-0.3.0.json
+++ b/ospac/data/licenses/json/copyleft-next-0.3.0.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "copyleft-next-0.3.0",
     "name": "copyleft-next 0.3.0",
-    "type": "permissive",
+    "type": "copyleft_weak",
     "spdx_id": "copyleft-next-0.3.0",
     "properties": {
       "commercial_use": true,
@@ -17,7 +17,7 @@
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -40,15 +40,17 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "module",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Distribute modifications under the same license"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Modifications to covered files must stay open-source"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/copyleft-next-0.3.1.json
+++ b/ospac/data/licenses/json/copyleft-next-0.3.1.json
@@ -2,7 +2,7 @@
   "license": {
     "id": "copyleft-next-0.3.1",
     "name": "copyleft-next 0.3.1",
-    "type": "permissive",
+    "type": "copyleft_weak",
     "spdx_id": "copyleft-next-0.3.1",
     "properties": {
       "commercial_use": true,
@@ -17,7 +17,7 @@
       "include_copyright": true,
       "include_notice": false,
       "state_changes": false,
-      "same_license": false,
+      "same_license": true,
       "network_use_disclosure": false
     },
     "limitations": {
@@ -40,15 +40,17 @@
         "incompatible_with": [],
         "requires_review": []
       },
-      "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "contamination_effect": "module",
+      "notes": "Weak copyleft: changes to the covered component must stay under its license"
     },
     "obligations": [
       "Retain copyright notices",
-      "Include license text"
+      "Include license text",
+      "Distribute modifications under the same license"
     ],
     "key_requirements": [
-      "Attribution required"
+      "Attribution required",
+      "Modifications to covered files must stay open-source"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/defaults/enterprise_policy.yaml
+++ b/ospac/defaults/enterprise_policy.yaml
@@ -71,6 +71,39 @@ rules:
         - "Prefer dynamic linking, or confirm the license permits static linking here"
         - "Provide a means to relink against a modified version of the component"
 
+  - id: allow_weak_copyleft_dynamic
+    description: "Approve weak copyleft with dynamic linking, by category"
+    priority: 3
+    when:
+      linking_type: "dynamic_linking"
+      license_type: "copyleft_weak"
+    then:
+      action: approve
+      severity: info
+      message: "Weak copyleft is contained at the library boundary when dynamically linked"
+      requirements:
+        - "Include the license text"
+        - "Keep modifications to the covered component under its own license"
+        - "Provide source, or a link to it, for the covered component"
+
+  # No-derivatives licenses permit verbatim redistribution, including commercially, but
+  # forbid distributing modified versions. Whether a use complies depends on whether the
+  # component is patched, which the tool cannot see, so this is a review rather than a
+  # verdict either way.
+  - id: review_no_derivatives
+    description: "No-derivatives licenses need a human to confirm the component is unmodified"
+    priority: 5
+    when:
+      license_type: "no_derivatives"
+    then:
+      action: flag_for_review
+      severity: warning
+      message: "No-derivatives license: distribution is only permitted for unmodified copies"
+      notify: ["legal@company.com"]
+      requirements:
+        - "Confirm the component is redistributed without modification"
+        - "Retain attribution and license text"
+
   # Weak Copyleft Rules
   - id: review_lgpl
     description: "Flag LGPL for legal review"
@@ -298,54 +331,108 @@ rules:
       message: "GPL-3.0 and GPL-2.0 are incompatible - cannot mix versions"
       remediation: "Use consistent GPL version across all components"
 
-# The decision_tree section that used to sit here was never executed: the runtime
-# reads only the 'rules' list above. Its entries duplicated rules that already
-# exist, except the permissive approval, which has been ported to 'approve_permissive'.
-# Config that looks authoritative but never runs is how several defects in this
-# project went unnoticed, so it is removed rather than left as documentation.
+  # Ported from the file's former compatibility matrix, which the runtime never read.
+  # These pairs sat in dead config while 'ospac check' reported them compatible.
+  - id: gpl3_bsd4_incompatible
+    description: "GPL-3.0 and BSD-4-Clause are incompatible"
+    priority: 10
+    when:
+      license1: ["GPL-3.0", "GPL-3.0-only", "GPL-3.0-or-later"]
+      license2: ["BSD-4-Clause"]
+    then:
+      action: deny
+      severity: error
+      message: "BSD-4-Clause's advertising clause is an additional restriction GPL-3.0 does not permit"
+      remediation: "Replace the BSD-4-Clause component, or obtain it under a 3-clause license"
 
-obligations:
-  attribution:
-    - MIT
-    - Apache-2.0
-    - BSD-2-Clause
-    - BSD-3-Clause
+  - id: bsd4_gpl3_incompatible
+    description: "BSD-4-Clause and GPL-3.0 are incompatible (reverse check)"
+    priority: 10
+    when:
+      license1: ["BSD-4-Clause"]
+      license2: ["GPL-3.0", "GPL-3.0-only", "GPL-3.0-or-later"]
+    then:
+      action: deny
+      severity: error
+      message: "BSD-4-Clause's advertising clause is an additional restriction GPL-3.0 does not permit"
+      remediation: "Replace the BSD-4-Clause component, or obtain it under a 3-clause license"
 
-  include_license:
-    - MIT
-    - Apache-2.0
-    - BSD-2-Clause
-    - BSD-3-Clause
-    - GPL-2.0-only
-    - GPL-3.0-only
-    - LGPL-2.1-only
-    - LGPL-3.0-only
+  - id: mit_gpl2_one_way
+    description: "MIT into GPL-2.0 is one-way; the combination is GPL-2.0"
+    priority: 5
+    when:
+      license1: ["MIT"]
+      license2: ["GPL-2.0", "GPL-2.0-only"]
+    then:
+      action: flag_for_review
+      severity: warning
+      message: "Compatibility is one-way, the combined work must be distributed under GPL-2.0"
+      requirements:
+        - "Confirm the combined work is distributed under GPL-2.0 terms"
 
-  source_disclosure:
-    conditions:
-      - license: ["GPL-2.0-only", "GPL-3.0-only"]
-        distribution: ["commercial", "embedded"]
-      - license: ["LGPL-2.1-only", "LGPL-3.0-only"]
-        linking: "static"
+  - id: gpl2_mit_one_way
+    description: "MIT into GPL-2.0 is one-way (reverse check)"
+    priority: 5
+    when:
+      license1: ["GPL-2.0", "GPL-2.0-only"]
+      license2: ["MIT"]
+    then:
+      action: flag_for_review
+      severity: warning
+      message: "Compatibility is one-way, the combined work must be distributed under GPL-2.0"
+      requirements:
+        - "Confirm the combined work is distributed under GPL-2.0 terms"
 
-  state_changes:
-    - Apache-2.0
+  - id: apache_gpl3_one_way
+    description: "Apache-2.0 into GPL-3.0 is one-way; the combination is GPL-3.0"
+    priority: 5
+    when:
+      license1: ["Apache-2.0"]
+      license2: ["GPL-3.0", "GPL-3.0-only"]
+    then:
+      action: flag_for_review
+      severity: warning
+      message: "Compatibility is one-way, the combined work must be distributed under GPL-3.0"
+      requirements:
+        - "Confirm the combined work is distributed under GPL-3.0 terms"
 
-  patent_grant:
-    - Apache-2.0
+  - id: gpl3_apache_one_way
+    description: "Apache-2.0 into GPL-3.0 is one-way (reverse check)"
+    priority: 5
+    when:
+      license1: ["GPL-3.0", "GPL-3.0-only"]
+      license2: ["Apache-2.0"]
+    then:
+      action: flag_for_review
+      severity: warning
+      message: "Compatibility is one-way, the combined work must be distributed under GPL-3.0"
+      requirements:
+        - "Confirm the combined work is distributed under GPL-3.0 terms"
 
-  no_endorsement:
-    - BSD-3-Clause
-    - Apache-2.0
+  - id: lgpl21_lgpl30_review
+    description: "LGPL-2.1-only and LGPL-3.0-only mix needs review"
+    priority: 5
+    when:
+      license1: ["LGPL-2.1-only"]
+      license2: ["LGPL-3.0-only"]
+    then:
+      action: flag_for_review
+      severity: warning
+      message: "LGPL-2.1-only and LGPL-3.0-only combine one-way; review the direction"
 
-# Compatibility matrix overrides
-compatibility:
-  incompatible:
-    - ["GPL-2.0-only", "GPL-3.0-only"]
-    - ["GPL-2.0-only", "Apache-2.0"]  # Due to GPL-2.0 patent clause conflict
-    - ["GPL-3.0-only", "BSD-4-Clause"]  # Due to advertising clause
+  - id: lgpl30_lgpl21_review
+    description: "LGPL-2.1-only and LGPL-3.0-only mix needs review (reverse check)"
+    priority: 5
+    when:
+      license1: ["LGPL-3.0-only"]
+      license2: ["LGPL-2.1-only"]
+    then:
+      action: flag_for_review
+      severity: warning
+      message: "LGPL-2.1-only and LGPL-3.0-only combine one-way; review the direction"
 
-  require_review:
-    - ["MIT", "GPL-2.0-only"]  # One-way compatibility
-    - ["Apache-2.0", "GPL-3.0-only"]  # One-way compatibility
-    - ["LGPL-2.1-only", "LGPL-3.0-only"]
+  # Ported from the file's former '# The obligations map and the compatibility matrix that used to sit here were dead
+# config: the runtime reads only the 'rules' list, so neither ever influenced a
+# decision, and 'ospac check' contradicted the matrix outright. The matrix pairs are
+# now real rules above (gpl3_bsd4_incompatible, mit_gpl2_one_way and friends), and
+# per-license obligations live in the dataset records.

--- a/ospac/defaults/enterprise_policy.yaml
+++ b/ospac/defaults/enterprise_policy.yaml
@@ -28,6 +28,49 @@ rules:
       message: "AGPL licenses require source disclosure for network services"
       remediation: "Use Apache-2.0 or MIT licensed alternatives"
 
+  # The two rules above name individual licenses, which only covers the licenses somebody
+  # remembered to list. The rules below match on license_type, so a copyleft license that
+  # is not enumerated anywhere is still caught. AGPL-3.0 evaluated for commercial
+  # distribution used to fall through every rule and come back permitted.
+  - id: no_strong_copyleft_in_products
+    description: "Prevent strong copyleft in distributed products, by category"
+    priority: 9
+    when:
+      distribution_type: ["commercial", "embedded", "saas", "mobile", "desktop", "web"]
+      license_type: "copyleft_strong"
+    then:
+      action: deny
+      severity: error
+      message: "Strong copyleft requires releasing the combined work under the same license"
+      remediation: "Replace with a permissive alternative, or isolate the component behind a process boundary"
+
+  - id: no_network_copyleft_in_services
+    description: "Prevent network copyleft in hosted services, by category"
+    priority: 9
+    when:
+      distribution_type: ["saas", "cloud", "api", "web"]
+      license_type: "network_copyleft"
+    then:
+      action: deny
+      severity: error
+      message: "Network copyleft triggers source disclosure for users interacting over a network"
+      remediation: "Replace with a permissive alternative, or accept the source disclosure obligation deliberately"
+
+  - id: review_weak_copyleft_static
+    description: "Weak copyleft is safe dynamically but needs review when statically linked"
+    priority: 6
+    when:
+      linking_type: "static_linking"
+      license_type: "copyleft_weak"
+    then:
+      action: flag_for_review
+      severity: warning
+      message: "Weak copyleft with static linking can extend the license to the combined work"
+      notify: ["legal@company.com"]
+      requirements:
+        - "Prefer dynamic linking, or confirm the license permits static linking here"
+        - "Provide a means to relink against a modified version of the component"
+
   # Weak Copyleft Rules
   - id: review_lgpl
     description: "Flag LGPL for legal review"
@@ -60,6 +103,24 @@ rules:
         - "Provide source or link to LGPL component"
 
   # Permissive License Rules
+  #
+  # This category rule was previously written only in the decision_tree section, which the
+  # runtime never reads, so permissive licenses were approved solely by the enumerated
+  # rules below. Anything not named there, ISC and Zlib for example, matched nothing at
+  # all. That was invisible while an unmatched evaluation returned allow, and became
+  # visible once it started returning flag_for_review.
+  - id: approve_permissive
+    description: "Approve permissive and public domain licenses by category"
+    priority: 1
+    when:
+      license_type: ["permissive", "public_domain"]
+    then:
+      action: approve
+      severity: info
+      message: "Permissive and public domain licenses are pre-approved"
+      requirements:
+        - "Retain copyright notices and license text"
+
   - id: approve_mit
     description: "Automatically approve MIT license"
     priority: 1
@@ -237,54 +298,12 @@ rules:
       message: "GPL-3.0 and GPL-2.0 are incompatible - cannot mix versions"
       remediation: "Use consistent GPL version across all components"
 
-decision_tree:
-  # Permissive licenses - always allowed
-  - if:
-      license_type: ["permissive", "public_domain"]
-    then:
-      action: approve
-      automatic: true
-      note: "Permissive and public domain licenses pre-approved"
+# The decision_tree section that used to sit here was never executed: the runtime
+# reads only the 'rules' list above. Its entries duplicated rules that already
+# exist, except the permissive approval, which has been ported to 'approve_permissive'.
+# Config that looks authoritative but never runs is how several defects in this
+# project went unnoticed, so it is removed rather than left as documentation.
 
-  # GPL in development tools
-  - if:
-      license: ["GPL-2.0", "GPL-3.0", "GPL-2.0-only", "GPL-3.0-only"]
-      usage: "development_only"
-    then:
-      action: approve
-      note: "GPL allowed for development tools that are not distributed"
-
-  # LGPL with dynamic linking
-  - if:
-      license: ["LGPL-2.1", "LGPL-3.0", "LGPL-2.1-only", "LGPL-3.0-only"]
-      linking: "dynamic"
-    then:
-      action: approve
-      note: "LGPL allowed with dynamic linking"
-
-  # Strong copyleft in products
-  - if:
-      license_category: "copyleft_strong"
-      distribution: ["commercial", "embedded", "mobile", "desktop"]
-    then:
-      action: deny
-      reason: "Strong copyleft not compatible with distributed products"
-
-  # Proprietary licenses
-  - if:
-      license_type: "proprietary"
-    then:
-      action: review
-      reason: "Proprietary licenses require legal and procurement review"
-
-  # Unknown licenses
-  - if:
-      license_type: "unknown"
-    then:
-      action: review
-      reason: "Unknown licenses require manual review"
-
-# Obligation tracking
 obligations:
   attribution:
     - MIT

--- a/ospac/defaults/enterprise_policy.yaml
+++ b/ospac/defaults/enterprise_policy.yaml
@@ -138,6 +138,33 @@ rules:
       message: "Commercial license requires procurement and legal review"
       notify: ["legal@company.com", "procurement@company.com"]
 
+  # NonCommercial licenses
+  - id: no_noncommercial_in_commercial_products
+    description: "Prevent NonCommercial licenses in anything shipped commercially"
+    priority: 10
+    when:
+      distribution_type: ["commercial", "saas", "embedded", "mobile", "desktop", "web", "cloud", "api"]
+      license_type: "noncommercial"
+    then:
+      action: deny
+      severity: error
+      message: "NonCommercial licenses forbid commercial use, including internal use that supports a commercial product"
+      remediation: "Replace with a permissive alternative, or obtain a separate commercial licence from the rights holder"
+
+  - id: review_noncommercial
+    description: "Flag NonCommercial licenses outside commercial distribution"
+    priority: 5
+    when:
+      license_type: "noncommercial"
+    then:
+      action: flag_for_review
+      severity: warning
+      message: "NonCommercial license: confirm the use really is non-commercial"
+      notify: ["legal@company.com"]
+      requirements:
+        - "Confirm no commercial use, direct or indirect"
+        - "Retain attribution and license text"
+
   # Deprecated Licenses
   - id: warn_deprecated
     description: "Warn about deprecated licenses"

--- a/ospac/models/compliance.py
+++ b/ospac/models/compliance.py
@@ -53,13 +53,18 @@ class PolicyResult:
         severity_order = {"error": 3, "warning": 2, "info": 1}
         highest_severity = max(results, key=lambda r: severity_order.get(r.severity, 0))
 
-        # Determine overall action (most restrictive wins)
+        # Determine overall action (most restrictive wins). Neither ALLOW nor APPROVE is
+        # more restrictive than the other, so between those two the more informative one
+        # wins: APPROVE means a rule explicitly permitted this, while ALLOW is what a rule
+        # falls back to when it states no action. Ranking ALLOW higher let a single
+        # actionless rule report "allow" even though rules had matched, which is the value
+        # callers are told means "no rule matched" and treat as a policy bug.
         action_priority = {
             ActionType.DENY: 5,
             ActionType.CONTAMINATE: 4,
             ActionType.FLAG_FOR_REVIEW: 3,
-            ActionType.ALLOW: 2,
-            ActionType.APPROVE: 1,
+            ActionType.APPROVE: 2,
+            ActionType.ALLOW: 1,
         }
 
         most_restrictive = max(results, key=lambda r: action_priority.get(r.action, 0))

--- a/ospac/models/compliance.py
+++ b/ospac/models/compliance.py
@@ -42,11 +42,19 @@ class PolicyResult:
     def aggregate(cls, results: List["PolicyResult"]) -> "PolicyResult":
         """Aggregate multiple results into a single result."""
         if not results:
+            # No rule matched, so the policy has no answer for this case. Return it for
+            # review rather than permitting it. This used to report ALLOW, which meant an
+            # unanswered question and an explicit approval were indistinguishable, and a
+            # policy that silently stopped matching read as a clean pass.
             return cls(
                 rule_id="aggregate",
-                action=ActionType.ALLOW,
-                severity="info",
-                message="No policies matched",
+                action=ActionType.FLAG_FOR_REVIEW,
+                severity="warning",
+                message="No policy rule matched, so this needs review",
+                requirements=[
+                    "Confirm the policy is meant to cover this license and distribution type"
+                ],
+                remediation="Add a rule covering this case, or approve it explicitly after review",
             )
 
         # Find the highest severity result

--- a/ospac/models/compliance.py
+++ b/ospac/models/compliance.py
@@ -39,9 +39,25 @@ class PolicyResult:
     remediation: Optional[str] = None
 
     @classmethod
-    def aggregate(cls, results: List["PolicyResult"]) -> "PolicyResult":
-        """Aggregate multiple results into a single result."""
+    def aggregate(cls, results: List["PolicyResult"],
+                  when_unmatched: str = "review") -> "PolicyResult":
+        """
+        Aggregate multiple results into a single result.
+
+        when_unmatched controls the answer when no rule matched at all. "review" is the
+        default and right for permission questions (evaluate): a policy with no rule for a
+        case has not approved it. "allow" is for conflict questions (check_compatibility),
+        where the absence of any conflict rule genuinely means no known conflict, and where
+        the review default made a licence read as incompatible with itself.
+        """
         if not results:
+            if when_unmatched == "allow":
+                return cls(
+                    rule_id="aggregate",
+                    action=ActionType.ALLOW,
+                    severity="info",
+                    message="No known conflicts",
+                )
             # No rule matched, so the policy has no answer for this case. Return it for
             # review rather than permitting it. This used to report ALLOW, which meant an
             # unanswered question and an explicit approval were indistinguishable, and a

--- a/ospac/pipeline/data_generator.py
+++ b/ospac/pipeline/data_generator.py
@@ -43,6 +43,59 @@ _KNOWN_OVERRIDES: Dict[str, Dict] = {
     # effect are identical to LGPL-2.1's, so typing it strong while LGPL-2.1 is weak was
     # inconsistent on the dataset's own terms.
     "LGPLLR":            {"category": "copyleft_weak"},
+    # Mainstream licenses the broken analysis recorded as freely permissive. Each entry
+    # states what the license text says, so a regeneration cannot reintroduce the error.
+    # EPL and CDDL are weak copyleft with file-level source disclosure.
+    "EPL-1.0":  {"category": "copyleft_weak",
+                 "conditions": {"disclose_source": True, "same_license": True}},
+    "EPL-2.0":  {"category": "copyleft_weak",
+                 "conditions": {"disclose_source": True, "same_license": True}},
+    "CDDL-1.0": {"category": "copyleft_weak",
+                 "conditions": {"disclose_source": True, "same_license": True}},
+    "CDDL-1.1": {"category": "copyleft_weak",
+                 "conditions": {"disclose_source": True, "same_license": True}},
+    # EUPL is copyleft for the work as a whole, with an interoperability compatibility list
+    "EUPL-1.1": {"category": "copyleft_strong",
+                 "conditions": {"disclose_source": True, "same_license": True}},
+    "EUPL-1.2": {"category": "copyleft_strong",
+                 "conditions": {"disclose_source": True, "same_license": True}},
+    # OSL and CAL treat network use as distribution; SSPL extends disclosure to the whole
+    # service stack
+    "OSL-3.0":  {"category": "network_copyleft",
+                 "conditions": {"disclose_source": True, "same_license": True,
+                                "network_use_disclosure": True}},
+    "CAL-1.0":  {"category": "network_copyleft",
+                 "conditions": {"disclose_source": True, "same_license": True,
+                                "network_use_disclosure": True}},
+    "SSPL-1.0": {"category": "network_copyleft",
+                 "conditions": {"disclose_source": True, "same_license": True,
+                                "network_use_disclosure": True}},
+    # Source-available: source is published but use is restricted, so not open source
+    "BUSL-1.1":    {"category": "source_available"},
+    "Elastic-2.0": {"category": "source_available"},
+    # Parity requires releasing all software that uses the work
+    "Parity-7.0.0": {"category": "copyleft_strong",
+                     "conditions": {"disclose_source": True, "same_license": True}},
+    # Aladdin (AFPL) and NPOSL forbid commercial use outright
+    "Aladdin":    {"category": "noncommercial", "permissions": {"commercial_use": False}},
+    "NPOSL-3.0":  {"category": "noncommercial", "permissions": {"commercial_use": False}},
+    # ODbL and CDLA-Sharing are share-alike for data
+    "ODbL-1.0":         {"category": "copyleft_weak", "conditions": {"same_license": True}},
+    "CDLA-Sharing-1.0": {"category": "copyleft_weak", "conditions": {"same_license": True}},
+    # CERN OHL v2: S is strongly reciprocal, W weakly; the name says so
+    "CERN-OHL-S-2.0": {"category": "copyleft_strong",
+                       "conditions": {"disclose_source": True, "same_license": True}},
+    "CERN-OHL-W-2.0": {"category": "copyleft_weak",
+                       "conditions": {"disclose_source": True, "same_license": True}},
+    # RPL extends reciprocity to internal deployment, and ESA-PL's strong variant says
+    # strong in its own name; the reciprocity name stem alone would floor these at weak
+    "RPL-1.1": {"category": "copyleft_strong",
+                "conditions": {"disclose_source": True, "same_license": True}},
+    "RPL-1.5": {"category": "copyleft_strong",
+                "conditions": {"disclose_source": True, "same_license": True}},
+    "ESA-PL-strong-copyleft-2.4": {"category": "copyleft_strong",
+                                   "conditions": {"disclose_source": True,
+                                                  "same_license": True}},
     # MPL-2.0: file-level (weak) copyleft, modified files must stay MPL and source disclosed
     "MPL-2.0": {
         "category": "copyleft_weak",
@@ -288,6 +341,8 @@ class PolicyDataGenerator:
             "source_available":["Source visible but redistribution restricted"],
             "noncommercial":   ["Attribution required",
                                 "Commercial use not permitted"],
+            "no_derivatives":  ["Attribution required",
+                                "Distribution of modified versions not permitted"],
             "proprietary":     ["All rights reserved, no redistribution"],
             "unknown":         ["Review license terms before use"],
         }
@@ -308,6 +363,9 @@ class PolicyDataGenerator:
         if "conditions" in overrides:
             result["conditions"] = dict(result.get("conditions") or {})
             result["conditions"].update(overrides["conditions"])
+        if "permissions" in overrides:
+            result["permissions"] = dict(result.get("permissions") or {})
+            result["permissions"].update(overrides["permissions"])
         return result
 
     @staticmethod
@@ -331,11 +389,14 @@ class PolicyDataGenerator:
         flat = re.sub(r"[^a-z]", "", name.lower())
         restrictions: Dict[str, Any] = {}
 
-        if "NC" in parts or "noncommercial" in flat:
+        if "NC" in parts or "noncommercial" in flat or "nonprofit" in flat:
             restrictions["commercial_use"] = False
         if "ND" in parts or "noderivative" in flat:
             restrictions["modification"] = False
-        if "SA" in parts or "sharealike" in flat:
+        # Reciprocity is frequently stated in the name itself: ShareAlike (CC), Reciprocal
+        # (MS-RL, RPL), or plain copyleft (copyleft-next, the ESA-PL variants).
+        if ("SA" in parts or "sharealike" in flat or "reciprocal" in flat
+                or "copyleft" in flat):
             restrictions["same_license"] = True
 
         return restrictions
@@ -356,9 +417,19 @@ class PolicyDataGenerator:
             result["conditions"] = dict(result.get("conditions") or {})
             result["conditions"]["same_license"] = restrictions["same_license"]
 
-        # A licence that withholds commercial use is not permissive, whatever it was called.
-        if restrictions.get("commercial_use") is False and result.get("category") == "permissive":
+        # The category must be honest about the restriction, whatever the analysis said,
+        # because policy rules match on it. NonCommercial dominates the other markers, and
+        # is forced regardless of the incoming category so a model classifying CC-BY-NC-SA
+        # as copyleft cannot bypass the noncommercial deny rules. ShareAlike and
+        # NoDerivatives only lift a record out of permissive: a stronger category already
+        # expresses the restriction. Leaving these as hand edits in the data was the
+        # original mistake; a regeneration silently reverted them.
+        if restrictions.get("commercial_use") is False:
             result["category"] = "noncommercial"
+        elif restrictions.get("same_license") is True and result.get("category") == "permissive":
+            result["category"] = "copyleft_weak"
+        if restrictions.get("modification") is False and result.get("category") == "permissive":
+            result["category"] = "no_derivatives"
 
         return result
 

--- a/ospac/pipeline/data_generator.py
+++ b/ospac/pipeline/data_generator.py
@@ -4,6 +4,7 @@ Combines SPDX data with LLM analysis to generate comprehensive policy files.
 """
 
 import json
+import re
 import yaml
 import logging
 import asyncio
@@ -285,6 +286,8 @@ class PolicyDataGenerator:
                                 "Network use triggers source-disclosure obligation"],
             "public_domain":   ["No restrictions"],
             "source_available":["Source visible but redistribution restricted"],
+            "noncommercial":   ["Attribution required",
+                                "Commercial use not permitted"],
             "proprietary":     ["All rights reserved, no redistribution"],
             "unknown":         ["Review license terms before use"],
         }
@@ -305,6 +308,58 @@ class PolicyDataGenerator:
         if "conditions" in overrides:
             result["conditions"] = dict(result.get("conditions") or {})
             result["conditions"].update(overrides["conditions"])
+        return result
+
+    @staticmethod
+    def _identifier_restrictions(license_id: str, name: str = "") -> Dict[str, Any]:
+        """
+        Read the restrictions that an SPDX identifier states outright.
+
+        Creative Commons encodes its terms in the identifier itself: NC means
+        NonCommercial, ND means NoDerivatives, SA means ShareAlike. These are facts about
+        the identifier, not judgements about licence text, so they are derived here rather
+        than asked of a model. Every NonCommercial licence in the dataset had been recorded
+        as commercially usable because the analysis silently fell back to a permissive
+        default, which is exactly the kind of answer a model should never be trusted for.
+
+        Matching is on hyphen-delimited components so an identifier that merely contains
+        the letters is not caught. Names are compared with punctuation and case removed,
+        because the wording varies: NCGL-UK-2.0 is the "Non-Commercial Government Licence"
+        and a plain "NonCommercial" test misses it.
+        """
+        parts = set(license_id.split("-"))
+        flat = re.sub(r"[^a-z]", "", name.lower())
+        restrictions: Dict[str, Any] = {}
+
+        if "NC" in parts or "noncommercial" in flat:
+            restrictions["commercial_use"] = False
+        if "ND" in parts or "noderivative" in flat:
+            restrictions["modification"] = False
+        if "SA" in parts or "sharealike" in flat:
+            restrictions["same_license"] = True
+
+        return restrictions
+
+    def _apply_identifier_restrictions(self, license_id: str, analysis: Dict) -> Dict:
+        """Force the terms an identifier states outright, whatever the analysis returned."""
+        restrictions = self._identifier_restrictions(license_id, analysis.get("name", ""))
+        if not restrictions:
+            return analysis
+
+        result = dict(analysis)
+        if "commercial_use" in restrictions or "modification" in restrictions:
+            result["permissions"] = dict(result.get("permissions") or {})
+            for key in ("commercial_use", "modification"):
+                if key in restrictions:
+                    result["permissions"][key] = restrictions[key]
+        if "same_license" in restrictions:
+            result["conditions"] = dict(result.get("conditions") or {})
+            result["conditions"]["same_license"] = restrictions["same_license"]
+
+        # A licence that withholds commercial use is not permissive, whatever it was called.
+        if restrictions.get("commercial_use") is False and result.get("category") == "permissive":
+            result["category"] = "noncommercial"
+
         return result
 
     async def generate_all_data(self, force_download: bool = False,
@@ -375,6 +430,7 @@ class PolicyDataGenerator:
                 analysis["spdx_data"] = license_data  # raw SPDX entry for OSI/FSF/deprecated flags
                 analysis["name"] = license_data.get("name", license_id)
                 analysis = self._apply_known_corrections(license_id, analysis)
+                analysis = self._apply_identifier_restrictions(license_id, analysis)
                 analyzed_licenses.append(analysis)
 
                 # Generate individual policy file immediately
@@ -406,7 +462,10 @@ class PolicyDataGenerator:
                 by_id[lid] = lic
         # Apply overrides to the full merged set so existing on-disk files are also corrected
         all_to_write = [
-            self._apply_known_corrections(l.get("license_id", ""), l)
+            self._apply_identifier_restrictions(
+                l.get("license_id", ""),
+                self._apply_known_corrections(l.get("license_id", ""), l),
+            )
             for l in by_id.values()
         ]
 

--- a/ospac/pipeline/data_generator.py
+++ b/ospac/pipeline/data_generator.py
@@ -37,6 +37,11 @@ _KNOWN_OVERRIDES: Dict[str, Dict] = {
     "LGPL-2.1+":         {"category": "copyleft_weak"},
     "LGPL-3.0":          {"category": "copyleft_weak"},
     "LGPL-3.0+":         {"category": "copyleft_weak"},
+    # LGPLLR is the lesser licence for linguistic resources. It is not an alias of any
+    # LGPL identifier, but its properties, requirements, limitations and contamination
+    # effect are identical to LGPL-2.1's, so typing it strong while LGPL-2.1 is weak was
+    # inconsistent on the dataset's own terms.
+    "LGPLLR":            {"category": "copyleft_weak"},
     # MPL-2.0: file-level (weak) copyleft, modified files must stay MPL and source disclosed
     "MPL-2.0": {
         "category": "copyleft_weak",

--- a/ospac/pipeline/llm_analyzer.py
+++ b/ospac/pipeline/llm_analyzer.py
@@ -5,13 +5,14 @@ Analyzes licenses to extract obligations, compatibility rules, and classificatio
 """
 
 import logging
-from typing import Dict, List, Any, Optional
+from typing import Dict, List, Any, Optional, Set
 import asyncio
 import os
 
 from ospac.pipeline.llm_providers import (
     LLMConfig,
     LLMProvider,
+    ProviderUnavailableError,
     create_llm_provider
 )
 
@@ -24,7 +25,8 @@ class LicenseAnalyzer:
     Supports OpenAI, Anthropic Claude, and local Ollama.
     """
 
-    def __init__(self, provider: str = "ollama", model: str = None, api_key: str = None, **kwargs):
+    def __init__(self, provider: str = "ollama", model: str = None, api_key: str = None,
+                 require_provider: bool = False, **kwargs):
         """
         Initialize the license analyzer with specified provider.
 
@@ -32,9 +34,17 @@ class LicenseAnalyzer:
             provider: LLM provider ("openai", "claude", "ollama")
             model: Model name (auto-selected if not provided)
             api_key: API key for cloud providers (or from environment)
+            require_provider: If True, raise instead of degrading to fallback
+                analysis when the provider cannot be initialized. Set this
+                whenever the caller explicitly requested LLM analysis.
             **kwargs: Additional provider-specific configuration
         """
         self.provider_name = provider.lower()
+
+        # License IDs analyzed by this analyzer's own fallback path
+        # (provider missing). Provider-level fallbacks are tracked by the
+        # provider itself; see the fallback_licenses property.
+        self._fallback_licenses: Set[str] = set()
 
         # Auto-select models if not provided
         if not model:
@@ -52,13 +62,31 @@ class LicenseAnalyzer:
             **kwargs
         )
 
-        # Initialize provider
+        # Initialize provider. This acts as a preflight check: it fails
+        # before any license is processed, not on the first record.
         try:
             self.llm_provider = create_llm_provider(self.config)
             logger.info(f"Initialized {self.provider_name} provider with model {model}")
         except Exception as e:
+            if require_provider:
+                logger.error(f"LLM provider {self.provider_name} was requested but is unavailable: {e}")
+                raise
             logger.error(f"Failed to initialize {self.provider_name} provider: {e}")
+            logger.warning("Continuing without LLM: analyses will be conservative fallback records")
             self.llm_provider = None
+
+    @property
+    def fallback_licenses(self) -> Set[str]:
+        """License IDs whose analysis came from a fallback instead of the LLM."""
+        licenses = set(self._fallback_licenses)
+        if self.llm_provider is not None:
+            licenses |= self.llm_provider.fallback_licenses
+        return licenses
+
+    @property
+    def fallback_count(self) -> int:
+        """Number of licenses whose analysis fell back instead of using the LLM."""
+        return len(self.fallback_licenses)
 
     def _get_default_model(self, provider: str) -> str:
         """Get default model for each provider."""
@@ -104,101 +132,54 @@ class LicenseAnalyzer:
 
     def _get_fallback_analysis(self, license_id: str) -> Dict[str, Any]:
         """
-        Get fallback analysis based on known license patterns.
+        Conservative placeholder used when no LLM provider is available.
+
+        Fails closed: category is "unknown" and every permission is denied,
+        so a record built from this can never silently authorize use of an
+        unanalyzed license. It is meant to be obviously wrong and to force
+        manual review, never to pass as a real analysis.
 
         Args:
             license_id: SPDX license identifier
 
         Returns:
-            Basic analysis results
+            Conservative placeholder analysis
         """
-        # Default analysis structure
-        analysis = {
+        self._fallback_licenses.add(license_id)
+        return {
             "license_id": license_id,
-            "category": "permissive",
+            "category": "unknown",
             "permissions": {
-                "commercial_use": True,
-                "distribution": True,
-                "modification": True,
+                "commercial_use": False,
+                "distribution": False,
+                "modification": False,
                 "patent_grant": False,
-                "private_use": True
+                "private_use": False
             },
             "conditions": {
-                "disclose_source": False,
+                "disclose_source": True,
                 "include_license": True,
                 "include_copyright": True,
-                "include_notice": False,
-                "state_changes": False,
-                "same_license": False,
-                "network_use_disclosure": False
+                "include_notice": True,
+                "state_changes": True,
+                "same_license": True,
+                "network_use_disclosure": True
             },
             "limitations": {
                 "liability": False,
                 "warranty": False,
-                "trademark_use": False
+                "trademark_use": True
             },
             "compatibility": {
-                "can_combine_with_permissive": True,
-                "can_combine_with_weak_copyleft": True,
+                "can_combine_with_permissive": False,
+                "can_combine_with_weak_copyleft": False,
                 "can_combine_with_strong_copyleft": False,
-                "static_linking_restrictions": "none",
-                "dynamic_linking_restrictions": "none"
+                "static_linking_restrictions": "unknown",
+                "dynamic_linking_restrictions": "unknown"
             },
-            "obligations": ["Include license text", "Include copyright notice"],
-            "key_requirements": ["Attribution required"]
+            "obligations": ["Automated license analysis failed, manual legal review required"],
+            "key_requirements": ["Do not rely on this record, manual review required"]
         }
-
-        # Customize based on known patterns
-        if "GPL" in license_id:
-            analysis["category"] = "copyleft_strong"
-            analysis["conditions"]["disclose_source"] = True
-            analysis["conditions"]["same_license"] = True
-            analysis["compatibility"]["can_combine_with_strong_copyleft"] = True
-            analysis["compatibility"]["can_combine_with_permissive"] = False
-            analysis["compatibility"]["static_linking_restrictions"] = "strong"
-            analysis["obligations"] = [
-                "Disclose source code",
-                "Include license text",
-                "State changes",
-                "Use same license for derivatives"
-            ]
-
-        elif "LGPL" in license_id:
-            analysis["category"] = "copyleft_weak"
-            analysis["conditions"]["disclose_source"] = True
-            analysis["compatibility"]["static_linking_restrictions"] = "weak"
-            analysis["obligations"] = [
-                "Disclose source of LGPL components",
-                "Allow relinking",
-                "Include license text"
-            ]
-
-        elif "AGPL" in license_id:
-            analysis["category"] = "copyleft_strong"
-            analysis["conditions"]["disclose_source"] = True
-            analysis["conditions"]["same_license"] = True
-            analysis["conditions"]["network_use_disclosure"] = True
-            analysis["compatibility"]["static_linking_restrictions"] = "strong"
-
-        elif "Apache" in license_id:
-            analysis["category"] = "permissive"
-            analysis["permissions"]["patent_grant"] = True
-            analysis["conditions"]["include_notice"] = True
-            analysis["conditions"]["state_changes"] = True
-            analysis["conditions"]["disclose_source"] = False
-            analysis["conditions"]["same_license"] = False
-
-        elif "MIT" in license_id or "BSD" in license_id or "ISC" in license_id:
-            analysis["category"] = "permissive"
-            analysis["permissions"]["patent_grant"] = False
-
-        elif "CC0" in license_id or "Unlicense" in license_id:
-            analysis["category"] = "public_domain"
-            analysis["conditions"]["include_license"] = False
-            analysis["conditions"]["include_copyright"] = False
-            analysis["obligations"] = []
-
-        return analysis
 
     async def extract_compatibility_rules(self, license_id: str, analysis: Dict[str, Any]) -> Dict[str, Any]:
         """
@@ -212,13 +193,14 @@ class LicenseAnalyzer:
             Compatibility rules
         """
         if not self.llm_provider:
+            self._fallback_licenses.add(license_id)
             return self._get_default_compatibility_rules(license_id, analysis)
 
         return await self.llm_provider.extract_compatibility_rules(license_id, analysis)
 
     def _get_default_compatibility_rules(self, license_id: str, analysis: Dict[str, Any]) -> Dict[str, Any]:
         """Get default compatibility rules based on license category."""
-        category = analysis.get("category", "permissive")
+        category = analysis.get("category", "unknown")
 
         if category == "permissive":
             return {
@@ -284,24 +266,25 @@ class LicenseAnalyzer:
             }
 
         else:
+            # Unknown or unrecognized category: fail closed, require review
             return {
                 "static_linking": {
-                    "compatible_with": ["category:any"],
+                    "compatible_with": [],
                     "incompatible_with": [],
-                    "requires_review": []
+                    "requires_review": ["category:any"]
                 },
                 "dynamic_linking": {
-                    "compatible_with": ["category:any"],
+                    "compatible_with": [],
                     "incompatible_with": [],
-                    "requires_review": []
+                    "requires_review": ["category:any"]
                 },
                 "distribution": {
-                    "can_distribute_with": ["category:any"],
+                    "can_distribute_with": [],
                     "cannot_distribute_with": [],
-                    "special_requirements": []
+                    "special_requirements": ["Manual review required before distribution"]
                 },
-                "contamination_effect": "none",
-                "notes": "Default compatibility rules"
+                "contamination_effect": "unknown",
+                "notes": "Category unknown or unrecognized, manual review required"
             }
 
     async def batch_analyze(self, licenses: List[Dict[str, Any]], max_concurrent: int = 5) -> List[Dict[str, Any]]:

--- a/ospac/pipeline/llm_providers.py
+++ b/ospac/pipeline/llm_providers.py
@@ -6,11 +6,22 @@ Supports OpenAI, Anthropic Claude, and local Ollama.
 import json
 import logging
 import asyncio
+import os
 from abc import ABC, abstractmethod
-from typing import Dict, List, Any, Optional
+from typing import Dict, List, Any, Optional, Set
 from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
+
+
+class ProviderUnavailableError(RuntimeError):
+    """
+    Raised when a requested LLM provider cannot be initialized.
+
+    Callers that explicitly requested a provider must abort instead of
+    silently degrading to fabricated fallback data.
+    """
+    pass
 
 
 @dataclass
@@ -30,6 +41,21 @@ class LLMProvider(ABC):
     def __init__(self, config: LLMConfig):
         self.config = config
         self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
+        self.available = False
+        # License IDs for which any part of the analysis came from a fallback
+        # instead of a real LLM response. A non-empty set means the generated
+        # dataset contains fabricated records and must not be published.
+        self.fallback_licenses: Set[str] = set()
+
+    @property
+    def fallback_count(self) -> int:
+        """Number of licenses whose analysis fell back instead of using the LLM."""
+        return len(self.fallback_licenses)
+
+    def _record_fallback(self, license_id: str, reason: str) -> None:
+        """Record that a license record was produced by fallback, not the LLM."""
+        self.fallback_licenses.add(license_id)
+        self.logger.warning(f"Fallback record for {license_id}: {reason}")
 
     @abstractmethod
     async def analyze_license(self, license_id: str, license_text: str) -> Dict[str, Any]:
@@ -149,61 +175,101 @@ Rules for contamination_effect:
             return self._get_fallback_analysis(license_id)
 
     def _get_fallback_analysis(self, license_id: str) -> Dict[str, Any]:
-        """Get fallback analysis for when LLM fails."""
-        analysis = {
+        """
+        Conservative placeholder used when LLM analysis fails.
+
+        Fails closed: category is "unknown" and every permission is denied,
+        so a record built from this can never silently authorize use of an
+        unanalyzed license. It is meant to be obviously wrong and to force
+        manual review, never to pass as a real analysis.
+        """
+        self._record_fallback(license_id, "LLM analysis unavailable or failed")
+        return {
             "license_id": license_id,
-            "category": "permissive",
+            "category": "unknown",
             "permissions": {
-                "commercial_use": True,
-                "distribution": True,
-                "modification": True,
+                "commercial_use": False,
+                "distribution": False,
+                "modification": False,
                 "patent_grant": False,
-                "private_use": True
+                "private_use": False
             },
             "conditions": {
-                "disclose_source": False,
+                "disclose_source": True,
                 "include_license": True,
                 "include_copyright": True,
-                "include_notice": False,
-                "state_changes": False,
-                "same_license": False,
-                "network_use_disclosure": False
+                "include_notice": True,
+                "state_changes": True,
+                "same_license": True,
+                "network_use_disclosure": True
             },
             "limitations": {
                 "liability": False,
                 "warranty": False,
-                "trademark_use": False
+                "trademark_use": True
             },
             "compatibility": {
-                "can_combine_with_permissive": True,
-                "can_combine_with_weak_copyleft": True,
+                "can_combine_with_permissive": False,
+                "can_combine_with_weak_copyleft": False,
                 "can_combine_with_strong_copyleft": False,
-                "static_linking_restrictions": "none",
-                "dynamic_linking_restrictions": "none"
+                "static_linking_restrictions": "unknown",
+                "dynamic_linking_restrictions": "unknown"
             },
-            "obligations": ["Include license text", "Include copyright notice"],
-            "key_requirements": ["Attribution required"]
+            "obligations": ["Automated license analysis failed, manual legal review required"],
+            "key_requirements": ["Do not rely on this record, manual review required"]
         }
 
-        # Customize based on known patterns
-        if "GPL" in license_id:
-            analysis["category"] = "copyleft_strong"
-            analysis["conditions"]["disclose_source"] = True
-            analysis["conditions"]["same_license"] = True
-        elif "LGPL" in license_id:
-            analysis["category"] = "copyleft_weak"
-            analysis["conditions"]["disclose_source"] = True
-        elif "AGPL" in license_id:
-            analysis["category"] = "copyleft_strong"
-            analysis["conditions"]["network_use_disclosure"] = True
-        elif "Apache" in license_id:
-            analysis["permissions"]["patent_grant"] = True
-            analysis["conditions"]["disclose_source"] = False
-            analysis["conditions"]["same_license"] = False
-        elif "CC0" in license_id or "Unlicense" in license_id:
-            analysis["category"] = "public_domain"
+    def _get_default_compatibility_rules(self, license_id: str, analysis: Dict[str, Any]) -> Dict[str, Any]:
+        """Get default compatibility rules used when LLM extraction fails."""
+        self._record_fallback(license_id, "compatibility rules fell back to category defaults")
+        category = analysis.get("category", "unknown")
 
-        return analysis
+        if category == "permissive":
+            return {
+                "static_linking": {
+                    "compatible_with": ["category:any"],
+                    "incompatible_with": [],
+                    "requires_review": []
+                },
+                "dynamic_linking": {
+                    "compatible_with": ["category:any"],
+                    "incompatible_with": [],
+                    "requires_review": []
+                },
+                "contamination_effect": "none",
+                "notes": "Permissive license with minimal restrictions"
+            }
+        elif category == "copyleft_strong":
+            return {
+                "static_linking": {
+                    "compatible_with": [license_id, "category:copyleft_strong"],
+                    "incompatible_with": ["category:permissive", "category:proprietary"],
+                    "requires_review": ["category:copyleft_weak"]
+                },
+                "dynamic_linking": {
+                    "compatible_with": ["category:any"],
+                    "incompatible_with": [],
+                    "requires_review": ["category:proprietary"]
+                },
+                "contamination_effect": "full",
+                "notes": "Strong copyleft with viral effect"
+            }
+        else:
+            # Unknown or unrecognized category: fail closed, require review
+            return {
+                "static_linking": {
+                    "compatible_with": [],
+                    "incompatible_with": [],
+                    "requires_review": ["category:any"]
+                },
+                "dynamic_linking": {
+                    "compatible_with": [],
+                    "incompatible_with": [],
+                    "requires_review": ["category:any"]
+                },
+                "contamination_effect": "unknown",
+                "notes": "Category unknown or unrecognized, manual review required"
+            }
 
 
 class OpenAIProvider(LLMProvider):
@@ -213,14 +279,23 @@ class OpenAIProvider(LLMProvider):
         super().__init__(config)
         try:
             import openai
+        except ImportError as e:
+            raise ProviderUnavailableError(
+                "OpenAI package not installed. "
+                "Install with: pip install openai (or pip install 'ospac[llm]')"
+            ) from e
+
+        if not config.api_key and not os.getenv("OPENAI_API_KEY"):
+            raise ProviderUnavailableError(
+                "OpenAI API key not set. "
+                "Pass --llm-api-key or set the OPENAI_API_KEY environment variable."
+            )
+
+        try:
             self.client = openai.AsyncOpenAI(api_key=config.api_key)
-            self.available = True
-        except ImportError:
-            self.logger.error("OpenAI package not installed. Install with: pip install openai")
-            self.available = False
         except Exception as e:
-            self.logger.error(f"Failed to initialize OpenAI client: {e}")
-            self.available = False
+            raise ProviderUnavailableError(f"Failed to initialize OpenAI client: {e}") from e
+        self.available = True
 
     async def analyze_license(self, license_id: str, license_text: str) -> Dict[str, Any]:
         """Analyze license using OpenAI."""
@@ -268,56 +343,6 @@ class OpenAIProvider(LLMProvider):
             self.logger.error(f"OpenAI compatibility extraction failed for {license_id}: {e}")
             return self._get_default_compatibility_rules(license_id, analysis)
 
-    def _get_default_compatibility_rules(self, license_id: str, analysis: Dict[str, Any]) -> Dict[str, Any]:
-        """Get default compatibility rules."""
-        category = analysis.get("category", "permissive")
-
-        if category == "permissive":
-            return {
-                "static_linking": {
-                    "compatible_with": ["category:any"],
-                    "incompatible_with": [],
-                    "requires_review": []
-                },
-                "dynamic_linking": {
-                    "compatible_with": ["category:any"],
-                    "incompatible_with": [],
-                    "requires_review": []
-                },
-                "contamination_effect": "none",
-                "notes": "Permissive license with minimal restrictions"
-            }
-        elif category == "copyleft_strong":
-            return {
-                "static_linking": {
-                    "compatible_with": [license_id, "category:copyleft_strong"],
-                    "incompatible_with": ["category:permissive", "category:proprietary"],
-                    "requires_review": ["category:copyleft_weak"]
-                },
-                "dynamic_linking": {
-                    "compatible_with": ["category:any"],
-                    "incompatible_with": [],
-                    "requires_review": ["category:proprietary"]
-                },
-                "contamination_effect": "full",
-                "notes": "Strong copyleft with viral effect"
-            }
-        else:
-            return {
-                "static_linking": {
-                    "compatible_with": ["category:any"],
-                    "incompatible_with": [],
-                    "requires_review": []
-                },
-                "dynamic_linking": {
-                    "compatible_with": ["category:any"],
-                    "incompatible_with": [],
-                    "requires_review": []
-                },
-                "contamination_effect": "none",
-                "notes": "Default compatibility rules"
-            }
-
 
 class ClaudeProvider(LLMProvider):
     """Anthropic Claude LLM provider using Anthropic API."""
@@ -326,14 +351,23 @@ class ClaudeProvider(LLMProvider):
         super().__init__(config)
         try:
             import anthropic
+        except ImportError as e:
+            raise ProviderUnavailableError(
+                "Anthropic package not installed. "
+                "Install with: pip install anthropic (or pip install 'ospac[llm]')"
+            ) from e
+
+        if not config.api_key and not os.getenv("ANTHROPIC_API_KEY"):
+            raise ProviderUnavailableError(
+                "Anthropic API key not set. "
+                "Pass --llm-api-key or set the ANTHROPIC_API_KEY environment variable."
+            )
+
+        try:
             self.client = anthropic.AsyncAnthropic(api_key=config.api_key)
-            self.available = True
-        except ImportError:
-            self.logger.error("Anthropic package not installed. Install with: pip install anthropic")
-            self.available = False
         except Exception as e:
-            self.logger.error(f"Failed to initialize Claude client: {e}")
-            self.available = False
+            raise ProviderUnavailableError(f"Failed to initialize Claude client: {e}") from e
+        self.available = True
 
     async def analyze_license(self, license_id: str, license_text: str) -> Dict[str, Any]:
         """Analyze license using Claude."""
@@ -381,10 +415,6 @@ class ClaudeProvider(LLMProvider):
             self.logger.error(f"Claude compatibility extraction failed for {license_id}: {e}")
             return self._get_default_compatibility_rules(license_id, analysis)
 
-    def _get_default_compatibility_rules(self, license_id: str, analysis: Dict[str, Any]) -> Dict[str, Any]:
-        """Get default compatibility rules (same as OpenAI)."""
-        return OpenAIProvider._get_default_compatibility_rules(self, license_id, analysis)
-
 
 class OllamaProvider(LLMProvider):
     """Local Ollama LLM provider."""
@@ -393,23 +423,29 @@ class OllamaProvider(LLMProvider):
         super().__init__(config)
         try:
             import ollama
+        except ImportError as e:
+            raise ProviderUnavailableError(
+                "Ollama package not installed. "
+                "Install with: pip install ollama (or pip install 'ospac[llm]')"
+            ) from e
+
+        try:
             # Test connection
             models = ollama.list()
             available_models = [model.model for model in models.models]
-
-            if config.model not in available_models:
-                self.logger.warning(f"Model {config.model} not found. Available: {available_models}")
-                self.available = False
-            else:
-                self.client = ollama
-                self.available = True
-
-        except ImportError:
-            self.logger.error("Ollama package not installed. Install with: pip install ollama")
-            self.available = False
         except Exception as e:
-            self.logger.error(f"Failed to initialize Ollama client: {e}")
-            self.available = False
+            raise ProviderUnavailableError(
+                f"Failed to connect to Ollama server: {e}. Is Ollama running?"
+            ) from e
+
+        if config.model not in available_models:
+            raise ProviderUnavailableError(
+                f"Ollama model {config.model} not found. Available: {available_models}. "
+                f"Pull it with: ollama pull {config.model}"
+            )
+
+        self.client = ollama
+        self.available = True
 
     async def analyze_license(self, license_id: str, license_text: str) -> Dict[str, Any]:
         """Analyze license using Ollama."""
@@ -453,13 +489,16 @@ class OllamaProvider(LLMProvider):
             self.logger.error(f"Ollama compatibility extraction failed for {license_id}: {e}")
             return self._get_default_compatibility_rules(license_id, analysis)
 
-    def _get_default_compatibility_rules(self, license_id: str, analysis: Dict[str, Any]) -> Dict[str, Any]:
-        """Get default compatibility rules (same as OpenAI)."""
-        return OpenAIProvider._get_default_compatibility_rules(self, license_id, analysis)
-
 
 def create_llm_provider(config: LLMConfig) -> LLMProvider:
-    """Factory function to create appropriate LLM provider."""
+    """
+    Factory function to create appropriate LLM provider.
+
+    Raises:
+        ProviderUnavailableError: if the requested provider cannot be
+            initialized (missing package, missing API key, unreachable server).
+        ValueError: if the provider name is not recognized.
+    """
     if config.provider.lower() == "openai":
         return OpenAIProvider(config)
     elif config.provider.lower() == "claude":

--- a/ospac/pipeline/llm_providers.py
+++ b/ospac/pipeline/llm_providers.py
@@ -96,7 +96,7 @@ License text:
 Return exactly this JSON structure (all fields required, boolean values only for booleans):
 {{
     "license_id": "{license_id}",
-    "category": "<permissive|copyleft_weak|copyleft_strong|proprietary|public_domain>",
+    "category": "<permissive|copyleft_weak|copyleft_strong|network_copyleft|source_available|noncommercial|no_derivatives|proprietary|public_domain>",
     "permissions": {{
         "commercial_use": <bool>,
         "distribution": <bool>,

--- a/ospac/runtime/engine.py
+++ b/ospac/runtime/engine.py
@@ -62,10 +62,15 @@ class PolicyRuntime:
         """Create a PolicyRuntime instance from a policy directory."""
         return cls(policy_path)
 
-    def evaluate(self, context: Dict[str, Any]) -> PolicyResult:
+    def evaluate(self, context: Dict[str, Any],
+                 when_unmatched: str = "review") -> PolicyResult:
         """
         Evaluate context against all loaded policies.
         No business logic here - just policy execution.
+
+        Evaluates the context as a single unit. For a list of licenses prefer
+        evaluate_licenses(), which evaluates each license independently so that one
+        license matching a rule cannot answer for the others.
         """
         if not self.evaluator:
             raise RuntimeError("No policies loaded. Call load_policies() first.")
@@ -90,7 +95,45 @@ class PolicyRuntime:
             )
             results.append(policy_result)
 
-        return PolicyResult.aggregate(results)
+        return PolicyResult.aggregate(results, when_unmatched=when_unmatched)
+
+    def resolve_license_type(self, license_id: str,
+                             data_dir: Optional[str] = None) -> Optional[str]:
+        """Look up a license's type from the dataset, or None if unresolvable."""
+        try:
+            record = self.lookup_license_data(license_id, data_dir)
+        except ValueError:
+            return None
+        return ((record or {}).get("license") or {}).get("type")
+
+    def evaluate_licenses(self, licenses: List[str],
+                          base_context: Dict[str, Any]) -> tuple:
+        """
+        Evaluate each license independently, then aggregate the per-license verdicts.
+
+        Set-level evaluation let one license answer for the whole set: an approve rule
+        matching MIT approved "MIT,AGPL-3.0", because the rule list was non-empty and the
+        no-match fail-safe never ran for the AGPL that matched nothing. Evaluating per
+        license means every license either gets a verdict from a rule or falls to the
+        fail-safe on its own.
+
+        Returns (aggregated PolicyResult, {license_id: per-license PolicyResult}).
+        base_context carries the shared fields (distribution_type, context, linking_type);
+        the per-license fields are filled in here.
+        """
+        per_license: Dict[str, PolicyResult] = {}
+        for license_id in licenses:
+            license_type = self.resolve_license_type(license_id)
+            ctx = dict(base_context)
+            ctx["licenses"] = [license_id]
+            ctx["licenses_found"] = [license_id]
+            ctx["license_type"] = [license_type] if license_type else []
+            per_license[license_id] = self.evaluate(ctx)
+
+        combined = PolicyResult.aggregate(list(per_license.values()))
+        if len(licenses) > 1:
+            combined.message = f"Evaluated {len(licenses)} licenses"
+        return combined, per_license
 
     def _find_applicable_rules(self, context: Dict[str, Any]) -> List[Dict]:
         """Find all rules that apply to the given context."""
@@ -204,7 +247,12 @@ class PolicyRuntime:
             "compatibility_context": context
         }
 
-        result = self.evaluate(eval_context)
+        # A compatibility check asks whether a conflict is known, so no rule matching
+        # means "no known conflict", not "needs review". The review default belongs to
+        # permission questions; applying it here made every license read as incompatible
+        # with itself, since this context carries no distribution_type and most rules
+        # therefore cannot match.
+        result = self.evaluate(eval_context, when_unmatched="allow")
         return ComplianceResult.from_policy_result(result)
 
     def get_obligations(self, licenses: List[str], data_dir: Optional[str] = None) -> Dict[str, Any]:

--- a/ospac/utils/data_validation.py
+++ b/ospac/utils/data_validation.py
@@ -57,6 +57,12 @@ KNOWN_LICENSES = {
         "type": "copyleft_weak",
         "requirements": {"disclose_source": True},
     },
+    # Pinned after a deliberate reclassification: every structured field matches LGPL-2.1,
+    # so it belongs in the same category rather than in strong copyleft.
+    "LGPLLR": {
+        "type": "copyleft_weak",
+        "requirements": {"disclose_source": True},
+    },
     "AGPL-3.0-only": {
         "type": "copyleft_strong",
         "requirements": {"disclose_source": True, "same_license": True, "network_use_disclosure": True},

--- a/ospac/utils/data_validation.py
+++ b/ospac/utils/data_validation.py
@@ -13,6 +13,8 @@ Keep all rule changes here so both callers stay in sync automatically.
 
 """
 
+import re
+
 # Known-correct values for well-known licenses, used as spot checks.
 KNOWN_LICENSES = {
     "Apache-2.0": {
@@ -103,11 +105,39 @@ REQUIRED_LIMITATIONS = {"liability", "warranty", "trademark_use"}
 REQUIRED_COMPAT_KEYS = {"static_linking", "dynamic_linking", "contamination_effect"}
 REQUIRED_COMPAT_LINK_KEYS = {"compatible_with", "incompatible_with", "requires_review"}
 
+# 'noncommercial' covers licenses that permit use, modification and
+# redistribution but forbid commercial use (CC-BY-NC-*, PolyForm-Noncommercial).
+# They cannot sit in 'permissive': policy rules match on license_type, and a
+# permissive-allow rule would approve them for commercial distribution.
 VALID_TYPES = {"permissive", "copyleft_strong", "copyleft_weak", "public_domain",
-               "network_copyleft", "source_available", "proprietary", "unknown"}
+               "network_copyleft", "source_available", "proprietary", "noncommercial",
+               "unknown"}
 # 'derivative' is valid for share-alike licenses (CC-BY-SA etc.) where only derivative
 # works must use the same license, not the whole combined work.
 VALID_CONTAMINATION = {"none", "module", "full", "derivative", "unknown"}
+
+
+def _id_has_component(identifier: str, component: str) -> bool:
+    """
+    True if ``component`` is a hyphen-delimited component of the SPDX identifier.
+
+    SPDX ids like CC-BY-NC-SA-4.0 encode restrictions as uppercase components
+    (NC, ND, SA). Splitting on hyphens keeps the match exact: a naive substring
+    test would wrongly flag ids that merely contain the letters, such as NCSA,
+    NCL, HPND, NASA-1.3 or SAX-PD.
+    """
+    return component in identifier.split("-")
+
+
+def _name_has_word(name: str, word: str) -> bool:
+    """
+    True if ``word`` (lowercase letters only) appears in the license name once
+    spacing, hyphens and case are ignored. The dataset spells the restrictions
+    inconsistently ("NonCommercial", "Non Commercial", "Non-Commercial",
+    "Noncommercial", "Share Alike"), so compare with everything but letters
+    stripped.
+    """
+    return word in re.sub(r"[^a-z]", "", name.lower())
 
 
 def validate_license(lid: str, lic: dict) -> tuple[list, list]:
@@ -198,6 +228,35 @@ def validate_license(lid: str, lic: dict) -> tuple[list, list]:
             warn(f"spdx_metadata.{f} missing")
         elif not isinstance(meta[f], bool):
             err(f"spdx_metadata.{f} must be bool, got {type(meta[f]).__name__}")
+
+    # Restriction semantics derivable from the identifier or name.
+    # These caught a silent generation failure where a fallback wrote
+    # permissive defaults into NonCommercial / NoDerivatives / ShareAlike
+    # records. Public domain dedications (CC0-1.0, CC-PDDC) have no NC/ND/SA
+    # component and no matching name word, so they are not caught here.
+    spdx_id = str(lic.get("spdx_id") or lid)
+    name = str(lic.get("name") or "")
+
+    noncommercial = _id_has_component(spdx_id, "NC") or _name_has_word(name, "noncommercial")
+    # Singular stem so both NoDerivative and NoDerivatives spellings match.
+    noderivatives = _id_has_component(spdx_id, "ND") or _name_has_word(name, "noderivative")
+    sharealike = _id_has_component(spdx_id, "SA") or _name_has_word(name, "sharealike")
+
+    if noncommercial and props.get("commercial_use") is not False:
+        err(f"NonCommercial license must have properties.commercial_use false, "
+            f"got {props.get('commercial_use')!r}")
+    if noderivatives and props.get("modification") is not False:
+        err(f"NoDerivatives license must have properties.modification false, "
+            f"got {props.get('modification')!r}")
+    if sharealike and reqs.get("same_license") is not True:
+        err(f"ShareAlike license must have requirements.same_license true, "
+            f"got {reqs.get('same_license')!r}")
+
+    # A permissive license permits commercial use by definition, so a record
+    # that forbids commercial use cannot be typed permissive.
+    if props.get("commercial_use") is False and lic.get("type") == "permissive":
+        err("type 'permissive' contradicts properties.commercial_use false, "
+            "a permissive license permits commercial use")
 
     # Known-license spot checks
     if lid in KNOWN_LICENSES:

--- a/ospac/utils/data_validation.py
+++ b/ospac/utils/data_validation.py
@@ -109,9 +109,13 @@ REQUIRED_COMPAT_LINK_KEYS = {"compatible_with", "incompatible_with", "requires_r
 # redistribution but forbid commercial use (CC-BY-NC-*, PolyForm-Noncommercial).
 # They cannot sit in 'permissive': policy rules match on license_type, and a
 # permissive-allow rule would approve them for commercial distribution.
+# 'no_derivatives' covers licenses that permit verbatim redistribution, including
+# commercially, but forbid distributing modified versions (the CC BY-ND family). They
+# cannot sit in 'permissive' for the same reason 'noncommercial' cannot: policy rules
+# match on license_type, and a permissive-approve rule would silently bless them.
 VALID_TYPES = {"permissive", "copyleft_strong", "copyleft_weak", "public_domain",
                "network_copyleft", "source_available", "proprietary", "noncommercial",
-               "unknown"}
+               "no_derivatives", "unknown"}
 # 'derivative' is valid for share-alike licenses (CC-BY-SA etc.) where only derivative
 # works must use the same license, not the whole combined work.
 VALID_CONTAMINATION = {"none", "module", "full", "derivative", "unknown"}
@@ -252,11 +256,18 @@ def validate_license(lid: str, lic: dict) -> tuple[list, list]:
         err(f"ShareAlike license must have requirements.same_license true, "
             f"got {reqs.get('same_license')!r}")
 
-    # A permissive license permits commercial use by definition, so a record
-    # that forbids commercial use cannot be typed permissive.
-    if props.get("commercial_use") is False and lic.get("type") == "permissive":
-        err("type 'permissive' contradicts properties.commercial_use false, "
-            "a permissive license permits commercial use")
+    # The type must be honest about what the booleans say, because policy rules match on
+    # license_type. These are direction-specific: a record whose booleans state a
+    # restriction may not sit in a category that policy rules treat as unrestricted.
+    if props.get("commercial_use") is False and lic.get("type") != "noncommercial":
+        err(f"properties.commercial_use false requires type 'noncommercial', got "
+            f"'{lic.get('type')}'; any other type bypasses the noncommercial policy rules")
+    if props.get("modification") is False and lic.get("type") == "permissive":
+        err("type 'permissive' contradicts properties.modification false, "
+            "a permissive license permits modification")
+    if reqs.get("same_license") is True and lic.get("type") in ("permissive", "public_domain"):
+        err(f"requirements.same_license true contradicts type '{lic.get('type')}', "
+            "a share-alike term binds derivative works")
 
     # Known-license spot checks
     if lid in KNOWN_LICENSES:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ semcl = [
 llm = [
     "openai>=1.0.0",     # OpenAI provider (--llm-provider openai)
     "anthropic>=0.34.0", # Anthropic provider (--llm-provider claude)
-    "ollama>=0.3.0",     # Local Ollama provider (--llm-provider ollama)
+    "ollama>=0.4.0",   # Local Ollama provider; 0.4.0 introduced the response API the provider uses
 ]
 all = [
     "ospac[semcl,llm]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ospac"
-version = "1.3.0"
+version = "1.3.1"
 description = "Open Source Policy as Code - License compliance policy engine"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ospac"
-version = "1.3.1"
+version = "1.4.0"
 description = "Open Source Policy as Code - License compliance policy engine"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -72,7 +72,9 @@ semcl = [
     "upmex>=1.6.0",    # For package metadata extraction
 ]
 llm = [
-    "strands-agents>=0.1.0",  # For LLM-based analysis with Ollama
+    "openai>=1.0.0",     # OpenAI provider (--llm-provider openai)
+    "anthropic>=0.34.0", # Anthropic provider (--llm-provider claude)
+    "ollama>=0.3.0",     # Local Ollama provider (--llm-provider ollama)
 ]
 all = [
     "ospac[semcl,llm]",

--- a/scripts/corpus_quality.py
+++ b/scripts/corpus_quality.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+Corpus-level quality gate for the license dataset.
+
+The per-record validator cannot detect the failure this project actually shipped: the
+LLM analysis silently never ran, a hardcoded fallback wrote the same permissive answer
+into almost every record, and every record was individually well formed. Detecting that
+requires looking across records, not within one.
+
+Two independent signals:
+
+1. Uniformity. A decision-relevant field carrying one value across hundreds of licenses
+   was not analysed. Real licenses differ.
+2. Fallback fingerprints. Both the historical permissive fallback and the current
+   fail-closed fallback have known exact shapes, so fabricated records are countable.
+
+Run after a regeneration, before publishing:
+
+    python scripts/corpus_quality.py --data-dir ospac/data
+
+Exits non-zero on errors. Warnings report but do not fail unless --strict is passed.
+"""
+
+import argparse
+import collections
+import glob
+import json
+import sys
+
+# The historical fallback, which claimed everything was permissive and commercially
+# usable. Any record still matching it end to end was fabricated, never analysed.
+LEGACY_FALLBACK_PROPERTIES = {
+    "commercial_use": True, "distribution": True, "modification": True,
+    "patent_grant": False, "private_use": True,
+}
+LEGACY_FALLBACK_REQUIREMENTS = {
+    "disclose_source": False, "include_license": True, "include_copyright": True,
+    "include_notice": False, "state_changes": False, "same_license": False,
+    "network_use_disclosure": False,
+}
+
+# Fields a person reads to make a decision. These must not be templated corpus-wide.
+DECISION_FIELDS = {
+    "limitations": lambda r: json.dumps(r.get("limitations"), sort_keys=True),
+    "compatibility": lambda r: json.dumps(
+        r.get("compatibility"), sort_keys=True).replace(r["id"], "SELF"),
+    "contamination_effect": lambda r: str(
+        r.get("compatibility", {}).get("contamination_effect")),
+    "obligations": lambda r: json.dumps(r.get("obligations")),
+    "key_requirements": lambda r: json.dumps(r.get("key_requirements")),
+}
+
+MIN_RECORDS = 100      # below this, uniformity says nothing
+MODAL_ERROR = 0.98     # one value covering this share of records is a hard failure
+MODAL_WARN = 0.85      # likely templated, report it
+
+
+def load_records(data_dir):
+    records = []
+    for path in sorted(glob.glob(f"{data_dir}/licenses/json/*.json")):
+        with open(path) as f:
+            records.append(json.load(f)["license"])
+    return records
+
+
+def run(data_dir, strict):
+    records = load_records(data_dir)
+    count = len(records)
+    errors, warnings = [], []
+
+    print(f"corpus quality check: {count} records in {data_dir}\n")
+    print(f"{'field':22} {'distinct':>9} {'modal share':>12}   verdict")
+    print("-" * 64)
+
+    for field, key_of in DECISION_FIELDS.items():
+        counts = collections.Counter(key_of(r) for r in records)
+        distinct = len(counts)
+        modal = counts.most_common(1)[0][1] / count if count else 0
+
+        verdict = "ok"
+        if count >= MIN_RECORDS and distinct == 1:
+            errors.append(f"{field}: a single value across all {count} records, "
+                          f"so this field was never analysed")
+            verdict = "ERROR"
+        elif modal >= MODAL_ERROR:
+            errors.append(f"{field}: {modal * 100:.0f}% of records share one value, "
+                          f"which no real analysis produces")
+            verdict = "ERROR"
+        elif modal >= MODAL_WARN:
+            warnings.append(f"{field}: {modal * 100:.0f}% of records share one value, "
+                            f"likely templated")
+            verdict = "warn"
+        print(f"{field:22} {distinct:>9} {modal * 100:>11.0f}%   {verdict}")
+
+    legacy = sum(
+        1 for r in records
+        if r.get("type") == "permissive"
+        and r.get("properties") == LEGACY_FALLBACK_PROPERTIES
+        and r.get("requirements") == LEGACY_FALLBACK_REQUIREMENTS)
+    unknown = sum(1 for r in records if r.get("type") == "unknown")
+
+    print()
+    print(f"legacy permissive fallback shape : {legacy} "
+          f"({legacy * 100 // count if count else 0}%)")
+    print(f"fail-closed unknown records      : {unknown}")
+
+    if legacy:
+        errors.append(f"{legacy} records carry the legacy permissive fallback shape, "
+                      f"so they were fabricated rather than analysed")
+    if unknown:
+        errors.append(f"{unknown} records are typed unknown, meaning a fallback ran "
+                      f"during generation")
+
+    print()
+    for message in errors:
+        print(f"  ERROR   {message}")
+    for message in warnings:
+        print(f"  WARN    {message}")
+    print()
+
+    if errors:
+        print("FAIL")
+        return 1
+    if warnings:
+        print("PASS with warnings" + (" (strict: FAIL)" if strict else ""))
+        return 1 if strict else 0
+    print("PASS")
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--data-dir", default="ospac/data")
+    parser.add_argument("--strict", action="store_true",
+                        help="Exit non-zero on warnings too")
+    args = parser.parse_args()
+    sys.exit(run(args.data_dir, args.strict))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -269,3 +269,104 @@ class TestObligationEnrichment:
                 f"requirements regardless of cwd, got: {requirements}"
             )
             assert "MIT: Retain copyright notices" in requirements
+
+
+class TestPerLicenseEvaluation:
+    """
+    Each license is evaluated independently and the verdicts aggregate with
+    most-restrictive-wins. Set-level evaluation let one license answer for the whole
+    set: an approve rule matching MIT approved "MIT,AGPL-3.0" because the rule list was
+    non-empty, so the no-match fail-safe never ran for the AGPL that matched nothing.
+    """
+
+    def _action(self, runner, licenses, distribution):
+        result = runner.invoke(cli, ["evaluate", "-l", licenses, "-d", distribution])
+        assert result.exit_code == 0, result.output
+        return json.loads(result.output)
+
+    def test_permissive_license_cannot_mask_an_unmatched_one(self, runner):
+        alone = self._action(runner, "MPL-2.0", "commercial")
+        paired = self._action(runner, "MIT,MPL-2.0", "commercial")
+        assert alone["result"]["action"] == "flag_for_review"
+        assert paired["result"]["action"] == "flag_for_review", (
+            "adding MIT must never upgrade the verdict of the other licenses"
+        )
+
+    def test_permissive_license_cannot_mask_an_unknown_one(self, runner):
+        paired = self._action(runner, "MIT,No-Such-License-1.0", "commercial")
+        assert paired["result"]["action"] == "flag_for_review"
+
+    def test_deny_still_dominates_in_a_mixed_set(self, runner):
+        paired = self._action(runner, "MIT,AGPL-3.0", "commercial")
+        assert paired["result"]["action"] == "deny"
+
+    def test_all_permissive_set_still_approves(self, runner):
+        paired = self._action(runner, "MIT,Apache-2.0,ISC", "commercial")
+        assert paired["result"]["action"] == "approve"
+
+    def test_per_license_breakdown_is_reported(self, runner):
+        data = self._action(runner, "MIT,MPL-2.0", "commercial")
+        assert data["per_license"]["MIT"]["action"] == "approve"
+        assert data["per_license"]["MPL-2.0"]["action"] == "flag_for_review"
+
+
+class TestCheckConflictSemantics:
+    """
+    A compatibility check answers "is a conflict known", so no rule matching means no
+    known conflict. The review default belongs to permission questions; applying it to
+    check made every license read as incompatible with itself.
+    """
+
+    def _check(self, runner, a, b):
+        result = runner.invoke(cli, ["check", a, b])
+        assert result.exit_code == 0, result.output
+        return json.loads(result.output)
+
+    def test_every_license_is_compatible_with_itself(self, runner):
+        for lid in ("MIT", "GPL-3.0-only", "LGPL-2.1", "MPL-2.0"):
+            data = self._check(runner, lid, lid)
+            assert data["compatible"] is True, f"{lid} vs itself must be compatible"
+
+    def test_known_incompatible_pair_still_denies(self, runner):
+        data = self._check(runner, "GPL-2.0", "Apache-2.0")
+        assert data["compatible"] is False
+        assert data["requires_review"] is False
+
+    def test_pair_from_former_dead_matrix_now_denies(self, runner):
+        data = self._check(runner, "BSD-4-Clause", "GPL-3.0-only")
+        assert data["compatible"] is False
+
+    def test_unknown_license_id_is_flagged_as_unverified(self, runner):
+        data = self._check(runner, "MIT", "No-Such-License-9.9")
+        assert any("unverified" in w["message"] for w in data["warnings"])
+
+
+class TestOutputRendering:
+    """Approvals were rendered as denials: only the literal action "allow" was good."""
+
+    def test_markdown_renders_approval_as_approved(self, runner):
+        result = runner.invoke(cli, ["evaluate", "-l", "Zlib", "-d", "commercial",
+                                     "-o", "markdown"])
+        assert result.exit_code == 0
+        assert "✅ Approved" in result.output
+        assert "❌" not in result.output
+
+    def test_markdown_renders_review_as_review(self, runner):
+        result = runner.invoke(cli, ["evaluate", "-l", "MPL-2.0", "-d", "commercial",
+                                     "-o", "markdown"])
+        assert result.exit_code == 0
+        assert "Requires review" in result.output
+        assert "❌" not in result.output
+
+
+class TestGenerateRefusesToFabricate:
+    """Without a provider every record is the fail-closed placeholder, not a dataset."""
+
+    def test_generate_without_use_llm_exits_nonzero_and_writes_nothing(self, runner, tmp_path):
+        out = tmp_path / "generated"
+        result = runner.invoke(cli, ["data", "generate", "--output-dir", str(out),
+                                     "--limit", "1"])
+        assert result.exit_code == 1
+        assert "requires --use-llm" in result.output
+        assert not list((out / "licenses" / "json").glob("*.json")) if (
+            out / "licenses" / "json").exists() else True

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -440,14 +440,21 @@ class TestPolicyResult:
             "['include_license', 'include_copyright', 'state_changes']"
         }
 
-    def test_aggregate_empty_results(self):
-        """Test aggregating empty results."""
+    def test_aggregate_empty_results_asks_for_review(self):
+        """
+        No rule matching means the policy has no answer, which must not read as approval.
+        This previously returned ALLOW, so an unanswered question and an explicit approval
+        were indistinguishable and a policy that silently stopped matching looked like a
+        clean pass.
+        """
         aggregated = PolicyResult.aggregate([])
 
         assert aggregated.rule_id == "aggregate"
-        assert aggregated.action == ActionType.ALLOW
-        assert aggregated.severity == "info"
-        assert aggregated.message == "No policies matched"
+        assert aggregated.action == ActionType.FLAG_FOR_REVIEW
+        assert aggregated.action != ActionType.ALLOW
+        assert aggregated.severity == "warning"
+        assert "review" in aggregated.message.lower()
+        assert aggregated.remediation
 
     def test_explicit_approve_outranks_default_allow(self):
         """

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -448,3 +448,31 @@ class TestPolicyResult:
         assert aggregated.action == ActionType.ALLOW
         assert aggregated.severity == "info"
         assert aggregated.message == "No policies matched"
+
+    def test_explicit_approve_outranks_default_allow(self):
+        """
+        A rule that states no action falls back to ALLOW. When another rule explicitly
+        approves, the aggregate must report approve: callers are told that allow means no
+        rule matched and treat it as a policy bug, so letting an actionless rule report
+        allow made a correct policy look broken.
+        """
+        results = [
+            PolicyResult(rule_id="explicit", action=ActionType.APPROVE, severity="info",
+                         message="vetted"),
+            PolicyResult(rule_id="actionless", action=ActionType.ALLOW, severity="info",
+                         message="noted"),
+        ]
+
+        assert PolicyResult.aggregate(results).action == ActionType.APPROVE
+        # Order of the inputs must not change the outcome.
+        assert PolicyResult.aggregate(list(reversed(results))).action == ActionType.APPROVE
+
+    def test_restrictive_actions_still_dominate_approve(self):
+        """Raising APPROVE above ALLOW must not let it outrank a real restriction."""
+        approve = PolicyResult(rule_id="a", action=ActionType.APPROVE, severity="info",
+                               message="vetted")
+        for stronger in (ActionType.DENY, ActionType.CONTAMINATE, ActionType.FLAG_FOR_REVIEW):
+            other = PolicyResult(rule_id="b", action=stronger, severity="error",
+                                 message="restricted")
+            assert PolicyResult.aggregate([approve, other]).action == stronger
+            assert PolicyResult.aggregate([other, approve]).action == stronger

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -10,6 +10,11 @@ from pathlib import Path
 
 from ospac.pipeline.spdx_processor import SPDXProcessor
 from ospac.pipeline.llm_analyzer import LicenseAnalyzer
+from ospac.pipeline.llm_providers import (
+    LLMConfig,
+    LLMProvider,
+    ProviderUnavailableError,
+)
 from ospac.pipeline.data_generator import PolicyDataGenerator
 
 # Skip LLM tests in CI environment
@@ -125,45 +130,69 @@ class TestSPDXProcessor:
         assert saved_data["total"] == 2
 
 
+def _make_offline_analyzer() -> LicenseAnalyzer:
+    """Build an analyzer with no usable LLM provider, without any network access."""
+    analyzer = LicenseAnalyzer()
+    analyzer.llm_provider = None
+    return analyzer
+
+
+class _StubProvider(LLMProvider):
+    """Minimal concrete provider to exercise LLMProvider base class behavior."""
+
+    async def analyze_license(self, license_id, license_text):
+        return self._get_fallback_analysis(license_id)
+
+    async def extract_compatibility_rules(self, license_id, analysis):
+        return self._get_default_compatibility_rules(license_id, analysis)
+
+
 class TestLicenseAnalyzer:
     """Test the LicenseAnalyzer class."""
 
-    @skip_llm_tests
     @pytest.mark.asyncio
-    async def test_get_fallback_analysis(self):
-        """Test fallback analysis when LLM is not available."""
-        analyzer = LicenseAnalyzer()
-        analyzer.agent = None  # Ensure no agent
+    async def test_fallback_analysis_fails_closed(self):
+        """Fallback analysis must deny permissions, not grant them."""
+        analyzer = _make_offline_analyzer()
 
         analysis = await analyzer.analyze_license("MIT", "MIT License text")
 
         assert analysis["license_id"] == "MIT"
-        assert analysis["category"] == "permissive"
-        assert analysis["permissions"]["commercial_use"] is True
+        assert analysis["category"] == "unknown"
+        assert analysis["permissions"]["commercial_use"] is False
+        assert analysis["permissions"]["modification"] is False
+        assert analysis["permissions"]["distribution"] is False
         assert analysis["conditions"]["include_license"] is True
 
-    @skip_llm_tests
     @pytest.mark.asyncio
-    async def test_analyze_gpl_fallback(self):
-        """Test GPL license analysis fallback."""
-        analyzer = LicenseAnalyzer()
-        analyzer.agent = None
+    async def test_fallback_never_claims_permissive(self):
+        """No license, NonCommercial ones included, may fall back to permissive."""
+        analyzer = _make_offline_analyzer()
 
-        analysis = await analyzer.analyze_license("GPL-3.0", "GPL text")
+        for license_id in ["CC-BY-NC-3.0-IGO", "GPL-3.0", "Apache-2.0", "CC0-1.0"]:
+            analysis = await analyzer.analyze_license(license_id, "some text")
+            assert analysis["category"] != "permissive"
+            assert analysis["category"] == "unknown"
+            assert analysis["permissions"]["commercial_use"] is False
 
-        assert analysis["license_id"] == "GPL-3.0"
-        assert analysis["category"] == "copyleft_strong"
-        assert analysis["conditions"]["disclose_source"] is True
-        assert analysis["conditions"]["same_license"] is True
-        # Fallback analysis returns basic compatibility info
-        assert "compatibility" in analysis
+    @pytest.mark.asyncio
+    async def test_fallback_records_are_counted(self):
+        """Every fallback analysis must be tracked so runs can fail closed."""
+        analyzer = _make_offline_analyzer()
+        assert analyzer.fallback_count == 0
 
-    @skip_llm_tests
+        await analyzer.analyze_license("MIT", "MIT text")
+        await analyzer.analyze_license("GPL-3.0", "GPL text")
+        # Same license twice must not double-count
+        await analyzer.analyze_license("MIT", "MIT text")
+
+        assert analyzer.fallback_count == 2
+        assert analyzer.fallback_licenses == {"MIT", "GPL-3.0"}
+
     @pytest.mark.asyncio
     async def test_extract_compatibility_rules(self):
         """Test extracting compatibility rules."""
-        analyzer = LicenseAnalyzer()
-        analyzer.agent = None
+        analyzer = _make_offline_analyzer()
 
         analysis = {"category": "permissive"}
         rules = await analyzer.extract_compatibility_rules("MIT", analysis)
@@ -171,12 +200,21 @@ class TestLicenseAnalyzer:
         assert rules["static_linking"]["compatible_with"] == ["category:any"]
         assert rules["contamination_effect"] == "none"
 
-    @skip_llm_tests
+    @pytest.mark.asyncio
+    async def test_compatibility_rules_unknown_category_requires_review(self):
+        """Unknown category must not default to compatible-with-anything."""
+        analyzer = _make_offline_analyzer()
+
+        rules = await analyzer.extract_compatibility_rules("Whatever-1.0", {"category": "unknown"})
+
+        assert rules["static_linking"]["compatible_with"] == []
+        assert rules["static_linking"]["requires_review"] == ["category:any"]
+        assert rules["contamination_effect"] == "unknown"
+
     @pytest.mark.asyncio
     async def test_batch_analyze(self):
         """Test batch analysis of licenses."""
-        analyzer = LicenseAnalyzer()
-        analyzer.agent = None
+        analyzer = _make_offline_analyzer()
 
         licenses = [
             {"id": "MIT", "text": "MIT text"},
@@ -189,6 +227,130 @@ class TestLicenseAnalyzer:
         assert results[0]["license_id"] == "MIT"
         assert results[1]["license_id"] == "GPL-3.0"
         assert "compatibility_rules" in results[0]
+
+
+class TestProviderUnavailability:
+    """Requesting an unavailable provider must fail loudly, not fall back."""
+
+    def _patch_import_failure(self, package_name):
+        """Simulate a missing package without uninstalling anything."""
+        import builtins
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == package_name:
+                raise ImportError(f"No module named '{package_name}'")
+            return real_import(name, *args, **kwargs)
+
+        return patch("builtins.__import__", side_effect=fake_import)
+
+    def test_missing_openai_package_raises(self):
+        """Missing openai package must raise a clear error, not return fallback data."""
+        with self._patch_import_failure("openai"):
+            with pytest.raises(ProviderUnavailableError, match="OpenAI package not installed"):
+                LicenseAnalyzer(provider="openai", require_provider=True)
+
+    def test_missing_anthropic_package_raises(self):
+        """Missing anthropic package must raise a clear error."""
+        with self._patch_import_failure("anthropic"):
+            with pytest.raises(ProviderUnavailableError, match="Anthropic package not installed"):
+                LicenseAnalyzer(provider="claude", require_provider=True)
+
+    def test_missing_ollama_package_raises(self):
+        """Missing ollama package must raise a clear error."""
+        with self._patch_import_failure("ollama"):
+            with pytest.raises(ProviderUnavailableError, match="Ollama package not installed"):
+                LicenseAnalyzer(provider="ollama", require_provider=True)
+
+    def test_missing_openai_api_key_raises(self, monkeypatch):
+        """Installed package but missing API key must also fail the preflight."""
+        pytest.importorskip("openai")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        with pytest.raises(ProviderUnavailableError, match="OPENAI_API_KEY"):
+            LicenseAnalyzer(provider="openai", require_provider=True)
+
+    def test_without_require_provider_degrades_to_no_provider(self):
+        """Library callers that did not demand a provider keep the old soft behavior."""
+        with self._patch_import_failure("openai"):
+            analyzer = LicenseAnalyzer(provider="openai")
+
+        assert analyzer.llm_provider is None
+
+    def test_provider_fallback_fails_closed_and_is_counted(self):
+        """Base provider fallback must under-permit and be recorded."""
+        provider = _StubProvider(LLMConfig(provider="stub", model="stub-model"))
+
+        analysis = provider._get_fallback_analysis("CC-BY-NC-3.0-IGO")
+
+        assert analysis["category"] == "unknown"
+        assert analysis["permissions"]["commercial_use"] is False
+        assert analysis["permissions"]["distribution"] is False
+        assert analysis["permissions"]["modification"] is False
+        assert provider.fallback_count == 1
+        assert provider.fallback_licenses == {"CC-BY-NC-3.0-IGO"}
+
+
+class TestGenerateFallbackGate:
+    """ospac data generate must not exit zero if fallback records were written."""
+
+    def _make_fake_generator_class(self, fallback_licenses, captured_kwargs):
+        class FakeAnalyzer:
+            pass
+
+        FakeAnalyzer.fallback_licenses = set(fallback_licenses)
+        FakeAnalyzer.fallback_count = len(fallback_licenses)
+
+        class FakeGenerator:
+            def __init__(self, output_dir=None, **kwargs):
+                captured_kwargs.update(kwargs)
+                self.output_dir = output_dir
+                self.llm_analyzer = FakeAnalyzer()
+
+            async def generate_all_data(self, **kwargs):
+                return {
+                    "total_licenses": 3,
+                    "output_directory": str(self.output_dir),
+                    "categories": {"permissive": 2, "unknown": 1},
+                    "validation": {"is_valid": True},
+                }
+
+        return FakeGenerator
+
+    def _invoke_generate(self, monkeypatch, tmp_path, fallback_licenses):
+        from click.testing import CliRunner
+        from ospac.cli import commands as cli_commands
+
+        captured_kwargs = {}
+        fake_cls = self._make_fake_generator_class(fallback_licenses, captured_kwargs)
+        monkeypatch.setattr(cli_commands, "PolicyDataGenerator", fake_cls)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli_commands.cli,
+            ["data", "generate", "--output-dir", str(tmp_path),
+             "--use-llm", "--llm-provider", "openai"],
+        )
+        return result, captured_kwargs
+
+    def test_generate_fails_when_fallback_records_written(self, monkeypatch, tmp_path):
+        """Any fallback record must be reported and fail the run."""
+        result, _ = self._invoke_generate(
+            monkeypatch, tmp_path, {"CC-BY-NC-3.0-IGO", "atc-game"}
+        )
+
+        assert result.exit_code != 0
+        assert "fallback" in result.output.lower()
+        assert "CC-BY-NC-3.0-IGO" in result.output
+
+    def test_generate_succeeds_without_fallback_records(self, monkeypatch, tmp_path):
+        """A clean LLM run exits zero and reports zero fallbacks."""
+        result, captured_kwargs = self._invoke_generate(monkeypatch, tmp_path, set())
+
+        assert result.exit_code == 0
+        assert "No fallback records" in result.output
+        # --use-llm must demand a working provider (preflight, fail loudly)
+        assert captured_kwargs.get("require_provider") is True
 
 
 class TestPolicyDataGenerator:

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -292,9 +292,12 @@ class TestPolicyRuntime:
         result = runtime.check_compatibility("MIT", "GPL-3.0")
         assert result.is_compliant is False
 
-        # Two permissive licenses do not trigger the rule
+        # Two permissive licenses do not trigger the rule. This policy says nothing about
+        # permissive licenses, so the result is "needs review" rather than compliant: an
+        # unmatched evaluation is an unanswered question, not an approval.
         result = runtime.check_compatibility("MIT", "Apache-2.0")
-        assert result.is_compliant is True
+        assert result.violations == []
+        assert result.needs_review is True
 
     def test_check_compatibility_unknown_license_contributes_no_type(self, temp_dir):
         """Test licenses missing from the dataset contribute no type and do not raise."""
@@ -320,8 +323,11 @@ class TestPolicyRuntime:
 
         runtime = PolicyRuntime(str(temp_dir))
 
+        # The unknown license contributes no type, so the copyleft rule cannot fire and
+        # nothing raises. Nothing matches either, so the answer is "needs review".
         result = runtime.check_compatibility("Not-A-Real-License-1.0", "MIT")
-        assert result.is_compliant is True
+        assert result.violations == []
+        assert result.needs_review is True
 
     def test_check_compatibility_gpl2_apache_still_incompatible(self):
         """Regression: GPL-2.0 and Apache-2.0 stay incompatible under the default policy."""

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -292,12 +292,13 @@ class TestPolicyRuntime:
         result = runtime.check_compatibility("MIT", "GPL-3.0")
         assert result.is_compliant is False
 
-        # Two permissive licenses do not trigger the rule. This policy says nothing about
-        # permissive licenses, so the result is "needs review" rather than compliant: an
-        # unmatched evaluation is an unanswered question, not an approval.
+        # Two permissive licenses do not trigger the rule, and a compatibility question
+        # answers "no known conflict" when no conflict rule matches. The review default
+        # belongs to permission questions; applying it here made every license read as
+        # incompatible with itself.
         result = runtime.check_compatibility("MIT", "Apache-2.0")
         assert result.violations == []
-        assert result.needs_review is True
+        assert result.is_compliant is True
 
     def test_check_compatibility_unknown_license_contributes_no_type(self, temp_dir):
         """Test licenses missing from the dataset contribute no type and do not raise."""
@@ -324,10 +325,11 @@ class TestPolicyRuntime:
         runtime = PolicyRuntime(str(temp_dir))
 
         # The unknown license contributes no type, so the copyleft rule cannot fire and
-        # nothing raises. Nothing matches either, so the answer is "needs review".
+        # nothing raises. No conflict rule matches, so no conflict is known. The CLI adds
+        # an unverified-license warning for ids the dataset cannot resolve.
         result = runtime.check_compatibility("Not-A-Real-License-1.0", "MIT")
         assert result.violations == []
-        assert result.needs_review is True
+        assert result.is_compliant is True
 
     def test_check_compatibility_gpl2_apache_still_incompatible(self):
         """Regression: GPL-2.0 and Apache-2.0 stay incompatible under the default policy."""

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -451,7 +451,7 @@ class TestRestrictionSemanticsRules:
             properties={"commercial_use": False},
         )
         assert any(
-            "type 'permissive' contradicts properties.commercial_use false" in e
+            "properties.commercial_use false requires type 'noncommercial'" in e
             for e in errors
         )
 
@@ -545,3 +545,65 @@ class TestDeprecatedAliasConsistency:
             assert records[license_id]["type"] == "copyleft_weak", (
                 f"{license_id} should be copyleft_weak, got {records[license_id]['type']}"
             )
+
+
+class TestDatasetPipelineReproducibility:
+    """
+    Every record in the shipped dataset must be exactly what the generation pipeline
+    produces for it. Repairs that existed only as hand-edited JSON were silently
+    reverted by the next regeneration: the ShareAlike retypes survived on disk while
+    the pipeline would have written permissive back over them.
+    """
+
+    def test_pipeline_reproduces_every_shipped_record(self):
+        import json
+
+        from ospac.pipeline.data_generator import PolicyDataGenerator as G
+
+        data_dir = Path(__file__).parent.parent / "ospac" / "data" / "licenses" / "json"
+        not_reproduced = []
+        for path in sorted(data_dir.glob("*.json")):
+            record = json.loads(path.read_text())["license"]
+            analysis = {
+                "license_id": record["id"],
+                "name": record.get("name", ""),
+                "category": record["type"],
+                "permissions": dict(record["properties"]),
+                "conditions": dict(record["requirements"]),
+            }
+            analysis = G._apply_known_corrections(G, record["id"], analysis)
+            analysis = G._apply_identifier_restrictions(G, record["id"], analysis)
+            obligations, key_requirements = G._derive_obligations(
+                G, record["id"], analysis["category"],
+                analysis["conditions"], analysis["permissions"])
+
+            if (analysis["category"] != record["type"]
+                    or analysis["permissions"] != record["properties"]
+                    or analysis["conditions"] != record["requirements"]
+                    or obligations != record["obligations"]
+                    or key_requirements != record["key_requirements"]):
+                not_reproduced.append(record["id"])
+
+        assert not_reproduced == [], (
+            "the pipeline would rewrite these records differently on regeneration, so "
+            "their current values are hand edits that will silently revert: "
+            + ", ".join(not_reproduced[:10])
+        )
+
+    def test_restricted_categories_are_populated(self):
+        import json
+
+        data_dir = Path(__file__).parent.parent / "ospac" / "data" / "licenses" / "json"
+        types = {}
+        for path in data_dir.glob("*.json"):
+            record = json.loads(path.read_text())["license"]
+            types.setdefault(record["type"], []).append(record["id"])
+
+        # The identifier states these restrictions, so the categories cannot be empty.
+        assert "CC-BY-NC-4.0" in types.get("noncommercial", [])
+        assert "Aladdin" in types.get("noncommercial", [])
+        assert "CC-BY-ND-4.0" in types.get("no_derivatives", [])
+        assert "CC-BY-SA-4.0" in types.get("copyleft_weak", [])
+        assert "SSPL-1.0" in types.get("network_copyleft", [])
+        assert "BUSL-1.1" in types.get("source_available", [])
+        assert "EUPL-1.2" in types.get("copyleft_strong", [])

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -249,6 +249,7 @@ class TestSharedDataValidation:
         assert KNOWN_LICENSES["GPL-3.0-only"]["type"] == "copyleft_strong"
         assert "spdx_id" in REQUIRED_TOP_FIELDS
         assert "permissive" in VALID_TYPES
+        assert "noncommercial" in VALID_TYPES
         assert "derivative" in VALID_CONTAMINATION
 
     def test_validate_license_known_good_record(self):
@@ -301,6 +302,195 @@ class TestSharedDataValidation:
         errors, warnings = validate_license("MIT", record)
         assert errors == []
         assert warnings == []
+
+
+class TestRestrictionSemanticsRules:
+    """
+    NC / ND / SA restrictions are derivable from the SPDX identifier or the
+    license name, so the validator enforces them deterministically. A silent
+    generation failure once wrote permissive defaults (commercial_use True,
+    modification True, same_license False) into every Creative Commons
+    NonCommercial, NoDerivatives and ShareAlike record and nothing caught it.
+    """
+
+    @staticmethod
+    def _record(license_id, name, lic_type="permissive", properties=None, requirements=None):
+        """A structurally valid record with overridable fields under test."""
+        props = {
+            "commercial_use": True,
+            "distribution": True,
+            "modification": True,
+            "patent_grant": False,
+            "private_use": True,
+        }
+        props.update(properties or {})
+        reqs = {
+            "disclose_source": False,
+            "include_license": True,
+            "include_copyright": True,
+            "same_license": False,
+            "network_use_disclosure": False,
+            "state_changes": False,
+        }
+        reqs.update(requirements or {})
+        return {
+            "id": license_id,
+            "name": name,
+            "type": lic_type,
+            "spdx_id": license_id,
+            "properties": props,
+            "requirements": reqs,
+            "limitations": {"liability": True, "warranty": True, "trademark_use": False},
+            "compatibility": {
+                "static_linking": {
+                    "compatible_with": ["Apache-2.0"],
+                    "incompatible_with": [],
+                    "requires_review": [],
+                },
+                "dynamic_linking": {
+                    "compatible_with": ["Apache-2.0"],
+                    "incompatible_with": [],
+                    "requires_review": [],
+                },
+                "contamination_effect": "none",
+            },
+            "obligations": ["Include the license text"],
+            "key_requirements": ["Include copyright notice"],
+            "spdx_metadata": {
+                "is_osi_approved": False,
+                "is_fsf_libre": False,
+                "is_deprecated": False,
+            },
+        }
+
+    @classmethod
+    def _errors(cls, license_id, name, **kwargs):
+        from ospac.utils.data_validation import validate_license
+
+        errors, _ = validate_license(license_id, cls._record(license_id, name, **kwargs))
+        return errors
+
+    def test_noncommercial_id_with_commercial_use_true_is_error(self):
+        errors = self._errors(
+            "CC-BY-NC-4.0",
+            "Creative Commons Attribution Non Commercial 4.0 International",
+        )
+        assert any(
+            "NonCommercial license must have properties.commercial_use false" in e
+            for e in errors
+        )
+
+    def test_noncommercial_id_with_commercial_use_false_passes(self):
+        errors = self._errors(
+            "CC-BY-NC-4.0",
+            "Creative Commons Attribution Non Commercial 4.0 International",
+            lic_type="noncommercial",
+            properties={"commercial_use": False},
+        )
+        assert errors == []
+
+    def test_noncommercial_name_without_nc_component_is_matched(self):
+        """NCGL-UK-2.0 has no NC component but its name says Non-Commercial."""
+        errors = self._errors("NCGL-UK-2.0", "Non-Commercial Government Licence")
+        assert any(
+            "NonCommercial license must have properties.commercial_use false" in e
+            for e in errors
+        )
+
+    def test_noderivatives_id_with_modification_true_is_error(self):
+        errors = self._errors(
+            "CC-BY-ND-3.0-IGO",
+            "Creative Commons Attribution No Derivatives 3.0 IGO",
+        )
+        assert any(
+            "NoDerivatives license must have properties.modification false" in e
+            for e in errors
+        )
+
+    def test_noderivatives_id_with_modification_false_passes(self):
+        errors = self._errors(
+            "CC-BY-ND-3.0-IGO",
+            "Creative Commons Attribution No Derivatives 3.0 IGO",
+            lic_type="proprietary",
+            properties={"modification": False},
+        )
+        assert errors == []
+
+    def test_sharealike_id_with_same_license_false_is_error(self):
+        errors = self._errors(
+            "CC-BY-SA-4.0",
+            "Creative Commons Attribution Share Alike 4.0 International",
+        )
+        assert any(
+            "ShareAlike license must have requirements.same_license true" in e
+            for e in errors
+        )
+
+    def test_sharealike_id_with_same_license_true_passes(self):
+        errors = self._errors(
+            "CC-BY-SA-4.0",
+            "Creative Commons Attribution Share Alike 4.0 International",
+            lic_type="copyleft_strong",
+            requirements={"same_license": True, "disclose_source": True},
+        )
+        assert errors == []
+
+    def test_combined_nc_sa_id_reports_both_violations(self):
+        errors = self._errors(
+            "CC-BY-NC-SA-4.0",
+            "Creative Commons Attribution Non Commercial Share Alike 4.0 International",
+        )
+        assert any("NonCommercial license" in e for e in errors)
+        assert any("ShareAlike license" in e for e in errors)
+
+    def test_noncommercial_typed_permissive_is_inconsistent(self):
+        """commercial_use false and type permissive contradict each other."""
+        errors = self._errors(
+            "CC-BY-NC-4.0",
+            "Creative Commons Attribution Non Commercial 4.0 International",
+            properties={"commercial_use": False},
+        )
+        assert any(
+            "type 'permissive' contradicts properties.commercial_use false" in e
+            for e in errors
+        )
+
+    def test_commercial_use_false_with_noncommercial_type_passes_consistency(self):
+        errors = self._errors(
+            "PolyForm-Noncommercial-1.0.0",
+            "PolyForm Noncommercial License 1.0.0",
+            lic_type="noncommercial",
+            properties={"commercial_use": False},
+        )
+        assert errors == []
+
+    def test_public_domain_dedications_are_not_matched(self):
+        """CC0-1.0 and CC-PDDC must not trip the NC / ND / SA rules."""
+        errors = self._errors(
+            "CC0-1.0",
+            "Creative Commons Zero v1.0 Universal",
+            lic_type="public_domain",
+        )
+        assert errors == []
+
+        errors = self._errors(
+            "CC-PDDC",
+            "Creative Commons Public Domain Dedication and Certification",
+            lic_type="public_domain",
+        )
+        assert errors == []
+
+    def test_incidental_letters_in_id_are_not_matched(self):
+        """Ids that merely contain the letters must not match the components."""
+        for license_id, name in [
+            ("NCSA", "University of Illinois/NCSA Open Source License"),
+            ("NASA-1.3", "NASA Open Source Agreement 1.3"),
+            ("HPND", "Historical Permission Notice and Disclaimer"),
+            ("SAX-PD", "Sax Public Domain Notice"),
+            ("NCL", "NCL Source Code License"),
+        ]:
+            errors = self._errors(license_id, name)
+            assert errors == [], f"{license_id} wrongly flagged: {errors}"
 
 
 class TestDeprecatedAliasConsistency:


### PR DESCRIPTION
Clears the three items #66 left open. None of them needed deferring, and one was actively misleading.

## An explicit approval could be reported as `allow`

A rule that states no action falls back to `ALLOW`, and the aggregate ranked `ALLOW` above `APPROVE`. So one actionless rule made the whole evaluation report `allow` even when another rule explicitly approved the licenses:

```console
$ ospac evaluate -l MIT -d commercial -p mixed_policy.yaml
{
  "action": "allow",
  "message": "Evaluated 2 rules",     # ...but 2 rules matched, and one approved
  "requirements": ["Include attribution", "MIT: Retain copyright notices", ...]
}
```

This matters because it contradicts what the field is documented to mean. The published docs say `allow` means nothing matched, and recommend treating it as a policy bug:

> Treat `allow` and `approve` as distinct. `approve` means a rule matched and permitted it; `allow` means nothing matched at all. The second is frequently a policy bug

So a correct policy that mixes an explicit `approve` rule with an actionless one reported the value that CI is told to fail on. Anyone following the documented recipe would have hit a spurious failure.

Between `ALLOW` and `APPROVE` neither is more restrictive, so the ranking between them was arbitrary. The more informative one now wins.

Verified unchanged:

| Case | Result |
|:--|:--|
| explicit `approve` + actionless rule | `approve` (was `allow`) |
| `deny` present | `deny` |
| `flag_for_review` vs `approve` | `flag_for_review` |
| nothing matches | `allow` with `No policies matched` |

Tests assert the restrictive actions still dominate, and that input order does not change the outcome.

## LGPLLR was strong copyleft

I deferred this in #66 as needing a legal reading. That was the wrong call, because the disagreement is provable from the dataset without weighing the licence text:

```
requirements identical to LGPL-2.1 : True
limitations identical              : True
properties identical               : True
contamination_effect identical     : True

LGPLLR type   : copyleft_strong
LGPL-2.1 type : copyleft_weak
```

Every structured field matches `LGPL-2.1`, so classifying it differently was inconsistent on the dataset's own terms. It is also, by name and design, the *lesser* licence for linguistic resources. `LGPLLR` now receives the same treatment as every other LGPL identifier: `flag_for_review` on desktop and server, `deny` on mobile.

Corrected in the record and `index.json`, added to the pipeline correction table so regeneration keeps it, and pinned in the validator spot checks as a deliberate decision.

## Coverage now actually runs

`pytest-cov` was installed on the runner and `coverage.xml` was handed to Codecov, but no `--cov` flag was ever passed, so the file was never written and the upload quietly did nothing with `fail_ci_if_error: false` swallowing the error.

That is the mechanism that let coverage pointing at the `osslili` package survive unnoticed, and how an earlier README could claim full test coverage: the number was never measurable.

The test job now measures `ospac` with terminal and XML reports. `codecov.yml` marks the project and patch statuses `informational`, so coverage is reported and commented on but **can never fail a pull request**. That was my only real hesitation about enabling it, and it is a config line rather than a decision. Enforcing a target stays a separate choice.

Coverage measures **54% in CI**, which is the figure Codecov will report.

Worth noting: it reads ~64% on a developer machine that has the optional LLM SDKs installed, because the pipeline modules then take import branches the runner does not. `data_generator.py` alone accounts for 185 fewer missed lines locally. The CI number is the one to trust, and quoting the local one would have repeated the old README's unverifiable coverage claim.

Weakest areas are the LLM pipeline modules, which the runner barely exercises since `[llm]` is not installed there.

## Verification

- 113 tests pass
- Validators report 733 files, 732 clean, 1 warning, 0 errors
- `LGPLLR` and `LGPL-2.1` now receive identical treatment on every template
- No deprecated alias disagrees with its canonical form
- Coverage runs and writes `coverage.xml`, which is already gitignored

## Note on merging

`release.yml` fires on push to `main` and this bumps `1.3.0` to `1.3.1`, so merging tags a release and publishes to PyPI automatically.
