### PR TITLE
fix(pipeline): coerce the category from the record's final booleans

### DIFF
--- a/ospac/pipeline/data_generator.py
+++ b/ospac/pipeline/data_generator.py
@@ -402,10 +402,12 @@ class PolicyDataGenerator:
         return restrictions
 
     def _apply_identifier_restrictions(self, license_id: str, analysis: Dict) -> Dict:
-        """Force the terms an identifier states outright, whatever the analysis returned."""
+        """
+        Force the terms the identifier states outright, then coerce the category to be
+        honest about the record's final booleans. No early return when the identifier has
+        no markers: the coercion must also cover restrictions only the analysis reports.
+        """
         restrictions = self._identifier_restrictions(license_id, analysis.get("name", ""))
-        if not restrictions:
-            return analysis
 
         result = dict(analysis)
         if "commercial_use" in restrictions or "modification" in restrictions:
@@ -417,18 +419,22 @@ class PolicyDataGenerator:
             result["conditions"] = dict(result.get("conditions") or {})
             result["conditions"]["same_license"] = restrictions["same_license"]
 
-        # The category must be honest about the restriction, whatever the analysis said,
-        # because policy rules match on it. NonCommercial dominates the other markers, and
-        # is forced regardless of the incoming category so a model classifying CC-BY-NC-SA
-        # as copyleft cannot bypass the noncommercial deny rules. ShareAlike and
-        # NoDerivatives only lift a record out of permissive: a stronger category already
-        # expresses the restriction. Leaving these as hand edits in the data was the
-        # original mistake; a regeneration silently reverted them.
-        if restrictions.get("commercial_use") is False:
+        # The category must be honest about the restriction, because policy rules match on
+        # it. The coercion reads the record's final booleans, not only the
+        # identifier-derived ones: the first real analysis run returned modification false
+        # for two Adobe licenses while calling them permissive, which the identifier says
+        # nothing about, and only the validator caught the contradiction. NonCommercial
+        # dominates and is forced regardless of the incoming category, so a model
+        # classifying CC-BY-NC-SA as copyleft cannot bypass the noncommercial deny rules.
+        # ShareAlike and NoDerivatives only lift a record out of permissive: a stronger
+        # category already expresses the restriction.
+        permissions = result.get("permissions") or {}
+        conditions = result.get("conditions") or {}
+        if permissions.get("commercial_use") is False:
             result["category"] = "noncommercial"
-        elif restrictions.get("same_license") is True and result.get("category") == "permissive":
+        elif conditions.get("same_license") is True and result.get("category") == "permissive":
             result["category"] = "copyleft_weak"
-        if restrictions.get("modification") is False and result.get("category") == "permissive":
+        if permissions.get("modification") is False and result.get("category") == "permissive":
             result["category"] = "no_derivatives"
 
         return result

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -463,3 +463,43 @@ class TestPolicyDataGenerator:
         assert report["missing_obligations"] == 1
         assert report["is_valid"] is False
         assert len(report["validation_errors"]) > 0
+
+class TestAnalysisCategoryCoercion:
+    """
+    The category coercion must read the record's final booleans, not only the
+    identifier-derived restrictions. The first real analysis run returned
+    modification false for Adobe-Glyph while calling it permissive; the identifier
+    carries no ND marker, so the record shipped to validation with a contradiction.
+    """
+
+    def _coerce(self, license_id, name, category, permissions, conditions):
+        from ospac.pipeline.data_generator import PolicyDataGenerator
+
+        analysis = {"license_id": license_id, "name": name, "category": category,
+                    "permissions": permissions, "conditions": conditions}
+        return PolicyDataGenerator._apply_identifier_restrictions(
+            PolicyDataGenerator, license_id, analysis)["category"]
+
+    def test_model_reported_no_modification_is_coerced(self):
+        assert self._coerce(
+            "Adobe-Glyph", "Adobe Glyph List License", "permissive",
+            {"commercial_use": True, "modification": False}, {},
+        ) == "no_derivatives"
+
+    def test_model_reported_noncommercial_is_coerced(self):
+        assert self._coerce(
+            "Some-License", "Some License", "permissive",
+            {"commercial_use": False, "modification": True}, {},
+        ) == "noncommercial"
+
+    def test_model_reported_share_alike_is_coerced(self):
+        assert self._coerce(
+            "Some-License", "Some License", "permissive",
+            {"commercial_use": True, "modification": True}, {"same_license": True},
+        ) == "copyleft_weak"
+
+    def test_genuinely_permissive_record_is_untouched(self):
+        assert self._coerce(
+            "MIT", "MIT License", "permissive",
+            {"commercial_use": True, "modification": True}, {"same_license": False},
+        ) == "permissive"


### PR DESCRIPTION
The honest-type coercion only read identifier-derived restrictions, so a
restriction the model itself reported did not retype the record. The first real
analysis run returned modification false for Adobe-Glyph and Adobe-Utopia while
calling both permissive; the identifiers carry no ND marker, so the records went
to validation as contradictions and failed the run. The coercion now reads the
final permissions and conditions, wherever they came from, so a record that
forbids modification, commercial use or relicensing can never ship in a category
that policy rules treat as unrestricted.
