### PR TITLE
fix: unblock the full regeneration

### DIFF
--- a/.github/workflows/spdx-sync.yml
+++ b/.github/workflows/spdx-sync.yml
@@ -140,9 +140,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: generated-data-${{ github.run_id }}
-          path: |
-            ospac/data/licenses/json/
-            ospac/data/index.json
+          path: ospac/data/
           retention-days: 14
 
       - name: Corpus quality gate

--- a/ospac/data/index.json
+++ b/ospac/data/index.json
@@ -72,21 +72,21 @@
       "category": "copyleft_strong",
       "file": "licenses/json/AGPL-1.0-only.json",
       "is_deprecated": false,
-      "obligations_count": 4
+      "obligations_count": 5
     },
     "AGPL-1.0-or-later": {
       "name": "Affero General Public License v1.0 or later",
       "category": "copyleft_strong",
       "file": "licenses/json/AGPL-1.0-or-later.json",
       "is_deprecated": false,
-      "obligations_count": 4
+      "obligations_count": 5
     },
     "AGPL-1.0": {
       "name": "Affero General Public License v1.0",
       "category": "copyleft_strong",
       "file": "licenses/json/AGPL-1.0.json",
       "is_deprecated": true,
-      "obligations_count": 4
+      "obligations_count": 5
     },
     "AGPL-3.0-only": {
       "name": "GNU Affero General Public License v3.0 only",
@@ -107,7 +107,7 @@
       "category": "copyleft_strong",
       "file": "licenses/json/AGPL-3.0.json",
       "is_deprecated": true,
-      "obligations_count": 4
+      "obligations_count": 5
     },
     "ALGLIB-Documentation": {
       "name": "ALGLIB Documentation License",

--- a/ospac/data/licenses/json/AGPL-1.0-only.json
+++ b/ospac/data/licenses/json/AGPL-1.0-only.json
@@ -18,7 +18,7 @@
       "include_notice": false,
       "state_changes": false,
       "same_license": true,
-      "network_use_disclosure": false
+      "network_use_disclosure": true
     },
     "limitations": {
       "liability": false,
@@ -55,11 +55,13 @@
       "Retain copyright notices",
       "Include license text",
       "Provide or offer access to complete source code",
-      "Distribute modifications under the same license"
+      "Distribute modifications under the same license",
+      "Make source available to users interacting over a network"
     ],
     "key_requirements": [
       "Attribution required",
-      "Combined works must be released under the same license"
+      "Combined works must be released under the same license",
+      "Network use triggers source-disclosure obligation"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/AGPL-1.0-or-later.json
+++ b/ospac/data/licenses/json/AGPL-1.0-or-later.json
@@ -18,7 +18,7 @@
       "include_notice": false,
       "state_changes": false,
       "same_license": true,
-      "network_use_disclosure": false
+      "network_use_disclosure": true
     },
     "limitations": {
       "liability": false,
@@ -55,11 +55,13 @@
       "Retain copyright notices",
       "Include license text",
       "Provide or offer access to complete source code",
-      "Distribute modifications under the same license"
+      "Distribute modifications under the same license",
+      "Make source available to users interacting over a network"
     ],
     "key_requirements": [
       "Attribution required",
-      "Combined works must be released under the same license"
+      "Combined works must be released under the same license",
+      "Network use triggers source-disclosure obligation"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/AGPL-1.0.json
+++ b/ospac/data/licenses/json/AGPL-1.0.json
@@ -18,7 +18,7 @@
       "include_notice": false,
       "state_changes": false,
       "same_license": true,
-      "network_use_disclosure": false
+      "network_use_disclosure": true
     },
     "limitations": {
       "liability": false,
@@ -55,11 +55,13 @@
       "Retain copyright notices",
       "Include license text",
       "Provide or offer access to complete source code",
-      "Distribute modifications under the same license"
+      "Distribute modifications under the same license",
+      "Make source available to users interacting over a network"
     ],
     "key_requirements": [
       "Attribution required",
-      "Combined works must be released under the same license"
+      "Combined works must be released under the same license",
+      "Network use triggers source-disclosure obligation"
     ],
     "spdx_metadata": {
       "is_osi_approved": false,

--- a/ospac/data/licenses/json/AGPL-3.0.json
+++ b/ospac/data/licenses/json/AGPL-3.0.json
@@ -18,7 +18,7 @@
       "include_notice": false,
       "state_changes": false,
       "same_license": true,
-      "network_use_disclosure": false
+      "network_use_disclosure": true
     },
     "limitations": {
       "liability": false,
@@ -55,11 +55,13 @@
       "Retain copyright notices",
       "Include license text",
       "Provide or offer access to complete source code",
-      "Distribute modifications under the same license"
+      "Distribute modifications under the same license",
+      "Make source available to users interacting over a network"
     ],
     "key_requirements": [
       "Attribution required",
-      "Combined works must be released under the same license"
+      "Combined works must be released under the same license",
+      "Network use triggers source-disclosure obligation"
     ],
     "spdx_metadata": {
       "is_osi_approved": true,

--- a/ospac/pipeline/data_generator.py
+++ b/ospac/pipeline/data_generator.py
@@ -105,9 +105,22 @@ _KNOWN_OVERRIDES: Dict[str, Dict] = {
         "category": "copyleft_weak",
         "conditions": {"disclose_source": True, "same_license": True},
     },
-    # AGPL §13 requires network-use disclosure; LLM omits this condition
-    "AGPL-3.0-only":     {"conditions": {"network_use_disclosure": True}},
-    "AGPL-3.0-or-later": {"conditions": {"network_use_disclosure": True}},
+    # AGPL is strong copyleft plus the network clause, not one instead of the other.
+    # Models reasonably answer network_copyleft, which would soften commercial
+    # distribution from deny to review, so the category is pinned. All spellings carry
+    # the network-use disclosure condition, including AGPL-1.0's own clause 2(d).
+    "AGPL-3.0-only":     {"category": "copyleft_strong",
+                          "conditions": {"network_use_disclosure": True}},
+    "AGPL-3.0-or-later": {"category": "copyleft_strong",
+                          "conditions": {"network_use_disclosure": True}},
+    "AGPL-3.0":          {"category": "copyleft_strong",
+                          "conditions": {"network_use_disclosure": True}},
+    "AGPL-1.0":          {"category": "copyleft_strong",
+                          "conditions": {"network_use_disclosure": True}},
+    "AGPL-1.0-only":     {"category": "copyleft_strong",
+                          "conditions": {"network_use_disclosure": True}},
+    "AGPL-1.0-or-later": {"category": "copyleft_strong",
+                          "conditions": {"network_use_disclosure": True}},
     # Apache-2.0 requires documenting changes made to original files
     "Apache-2.0": {"conditions": {"state_changes": True}},
     # CC0 is a full public domain waiver, with no copyright or license text requirements

--- a/scripts/corpus_quality.py
+++ b/scripts/corpus_quality.py
@@ -38,6 +38,13 @@ LEGACY_FALLBACK_REQUIREMENTS = {
     "include_notice": False, "state_changes": False, "same_license": False,
     "network_use_disclosure": False,
 }
+# The fabricated records never carried real disclaimer analysis, so their limitations
+# were uniformly false. A genuinely permissive license can legitimately match the
+# property and requirement templates, but real analysis reports the disclaimers, so
+# limitations distinguish fabricated from coincidentally similar.
+LEGACY_FALLBACK_LIMITATIONS = {
+    "liability": False, "warranty": False, "trademark_use": False,
+}
 
 # Fields a person reads to make a decision. These must not be templated corpus-wide.
 DECISION_FIELDS = {
@@ -96,7 +103,8 @@ def run(data_dir, strict):
         1 for r in records
         if r.get("type") == "permissive"
         and r.get("properties") == LEGACY_FALLBACK_PROPERTIES
-        and r.get("requirements") == LEGACY_FALLBACK_REQUIREMENTS)
+        and r.get("requirements") == LEGACY_FALLBACK_REQUIREMENTS
+        and r.get("limitations") == LEGACY_FALLBACK_LIMITATIONS)
     unknown = sum(1 for r in records if r.get("type") == "unknown")
 
     print()


### PR DESCRIPTION
The first full analysis run of all 733 licenses was rejected by two guards, one
rightly and one wrongly.

The corpus gate flagged 51 records as carrying the fabricated-fallback fingerprint.
All 51 were genuinely analysed: they are simple permissive licenses whose property
and requirement booleans legitimately coincide with the old template, while their
disclaimers and per-license notes show real analysis. The fabricated records never
carried disclaimer analysis, so their limitations were uniformly false; adding
limitations to the fingerprint separates fabricated from coincidentally similar.

The per-record validator rejected AGPL-3.0-only, which the model classified as
network_copyleft against the spot check's copyleft_strong. The model's taxonomy is
defensible, but AGPL is strong copyleft plus the network clause, not one instead of
the other, and the network_copyleft category would soften commercial distribution
from deny to review. The whole AGPL family is now pinned copyleft_strong with the
network-use disclosure condition, including AGPL-1.0's own clause 2(d), and the
four records the new pins change are updated so the pipeline reproduces the shipped
data exactly.

The review artifact now uploads the whole data directory rather than only the
license records and index, so the regenerated compatibility tree can be inspected
too.

Verified against the rejected run's artifact: the regenerated corpus passes the
tightened gate with 396 distinct compatibility blocks and zero fabricated records,
while the currently shipped corpus still fails it.
