### PR TITLE
test: stop asserting the fabricated data as expected output

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -186,9 +186,13 @@ class TestDataShow:
         # Permissions come from 'properties', conditions from 'requirements'
         assert "commercial_use" in result.output
         assert "include_license" in result.output
-        # False values must be shown explicitly, not silently omitted
+        # False values must be shown explicitly, not silently omitted. disclose_source
+        # is genuinely false for MIT; the warranty limitation is true, because MIT
+        # disclaims warranty. An earlier version of this test asserted "✗ warranty",
+        # pinning the fabricated pre-analysis data as if it were correct.
         assert "✗ disclose_source" in result.output
-        assert "✗ warranty" in result.output
+        assert "✓ warranty" in result.output
+        assert "✓ liability" in result.output
         assert "is_osi_approved" in result.output
 
     def test_json_output_shape_is_unchanged(self, runner):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -603,7 +603,12 @@ class TestDatasetPipelineReproducibility:
         assert "CC-BY-NC-4.0" in types.get("noncommercial", [])
         assert "Aladdin" in types.get("noncommercial", [])
         assert "CC-BY-ND-4.0" in types.get("no_derivatives", [])
-        assert "CC-BY-SA-4.0" in types.get("copyleft_weak", [])
         assert "SSPL-1.0" in types.get("network_copyleft", [])
         assert "BUSL-1.1" in types.get("source_available", [])
         assert "EUPL-1.2" in types.get("copyleft_strong", [])
+        # ShareAlike must be in a copyleft category, never permissive. Whether the
+        # analysis places CC-BY-SA in weak or strong is its judgement to make; what the
+        # invariant forbids is the category a permissive-approve rule would bless.
+        sa_copyleft = types.get("copyleft_weak", []) + types.get("copyleft_strong", [])
+        assert "CC-BY-SA-4.0" in sa_copyleft
+        assert "CC-BY-SA-4.0" not in types.get("permissive", [])


### PR DESCRIPTION
Two tests failed once the regenerated dataset merged, and both were the tests
being wrong, not the data.

The data show test asserted MIT prints an unchecked warranty limitation, which
pinned the fabricated all-false disclaimers as if they were correct. MIT disclaims
warranty and liability, and the analysed record says so.

The category test asserted CC-BY-SA-4.0 is copyleft_weak, but weak versus strong
for share-alike is the analysis's judgement to make. The invariant that matters is
that ShareAlike never sits in permissive, where a category-approve rule would
bless it, so the test now asserts exactly that.
