### PR TITLE
docs: describe the tool that exists after 1.4.1

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -64,16 +64,30 @@ $ ospac evaluate -l GPL-3.0 -d mobile
     "action": "deny",
     "severity": "error",
     "message": "Evaluated 1 rules",
-    "requirements": [],
+    "requirements": [
+      "GPL-3.0: Retain copyright notices",
+      "GPL-3.0: Include license text",
+      "GPL-3.0: Provide or offer access to complete source code",
+      "GPL-3.0: Distribute modifications under the same license"
+    ],
     "remediation": "Replace with MIT, Apache-2.0, or BSD licensed alternative"
+  },
+  "per_license": {
+    "GPL-3.0": {
+      "action": "deny",
+      "message": "Evaluated 2 rules"
+    }
   },
   "using_default_policy": true
 }
 ```
 
-`action` is one of `approve`, `deny`, or `flag_for_review`. When several rules match, the
-results are aggregated and the most severe action wins, reported under the synthetic
-`rule_id` of `aggregate`. `using_default_policy` tells you whether the decision came from
+`action` is one of `approve`, `deny`, or `flag_for_review`. Each license is evaluated
+independently and the verdicts aggregate with the most severe action winning, reported
+under the synthetic `rule_id` of `aggregate`; `per_license` attributes the outcome, so in
+a mixed set you can see which license drove a denial. A license that matches no rule
+comes back `flag_for_review` on its own, so one permissive license cannot answer for the
+others. `using_default_policy` tells you whether the decision came from
 your policy or the bundled one, worth asserting on in CI.
 
 Linking context matters for weak copyleft, where the same license is fine dynamically and
@@ -105,16 +119,23 @@ $ ospac check GPL-2.0 Apache-2.0
   "license2": "Apache-2.0",
   "context": "general",
   "compatible": false,
+  "requires_review": false,
   "violations": [
     {
       "rule_id": "aggregate",
-      "message": "Evaluated 1 rules",
+      "message": "Evaluated 2 rules",
       "severity": "error"
     }
   ],
+  "warnings": [],
   "using_default_policy": true
 }
 ```
+
+`compatible: false` with `requires_review: true` means a human needs to look, not that a
+conflict is known. When no conflict rule matches at all, the answer is "no known
+conflicts", so a license is always compatible with itself, and a license id that does not
+resolve in the dataset adds a warning rather than reading as a clean pass.
 
 GPL-2.0 and Apache-2.0 are the canonical incompatible pair. Apache's patent termination
 clause is an additional restriction GPL-2.0 does not permit. Text output is more readable
@@ -235,11 +256,9 @@ $ ospac data show MIT -f json
 }
 ```
 
-{: .warning }
-> `-f text` is currently broken. It reads field names from the pre-1.2.0 schema
-> (`category`, `permissions`, `conditions`), which the JSON dataset no longer uses, so it
-> prints `Category: None` and empty Permissions and Conditions sections. The data is
-> fine, only this formatter is stale. Use `-f json` or `-f yaml`.
+`-f text` prints a human-readable summary: type, permissions, conditions, limitations,
+obligations and SPDX metadata, with false values shown explicitly (`✗`) rather than
+omitted, and a marker when the identifier is deprecated.
 
 License IDs are validated before use, so a path-traversal attempt in the ID is rejected
 rather than resolved. An unknown ID exits non-zero and lists a sample of valid IDs.
@@ -257,7 +276,7 @@ ospac data generate [-o DIR] [--use-llm] [--llm-provider P] [--llm-model M]
 | Option | Effect |
 |:--|:--|
 | `-o, --output-dir` | Where to write. Default `data`. CI passes `ospac/data` to regenerate in place. |
-| `--use-llm` | Enable LLM analysis of license texts. Off by default. |
+| `--use-llm` | Required. Without a provider every record would be a fail-closed placeholder, so the command refuses to run rather than fabricate a dataset. |
 | `--llm-provider` | `openai`, `claude`, or `ollama`. |
 | `--llm-model` | Model name, if you want something other than the provider default. |
 | `--llm-api-key` | API key. Prefer the provider's environment variable. |
@@ -283,15 +302,21 @@ ospac data download-spdx [-o DIR] [--force]
 
 ### data validate
 
-{: .warning }
-> This subcommand is currently broken for the shipped dataset. It only looks for
-> `licenses/spdx/*.yaml`, the pre-1.2.0 YAML layout, which is no longer distributed, so it
-> exits with `✗ SPDX directory not found`. Use the repository's validator instead, which
-> is what CI runs:
->
-> ```bash
-> python scripts/validate_data.py --data-dir ospac/data
-> ```
->
-> That script checks every record against the current JSON schema and reports errors
-> and warnings separately, with a `--strict` flag to fail on warnings.
+Validates every record in a dataset against the schema and its semantic invariants,
+including the restriction rules: a NonCommercial identifier must not permit commercial
+use, NoDerivatives must not permit modification, ShareAlike must carry the same-license
+requirement, and a type must not contradict the record's own booleans.
+
+```
+ospac data validate [-d DIR] [--strict]
+```
+
+Defaults to the packaged data directory. Errors exit non-zero; `--strict` fails on
+warnings too. The same rules back `scripts/validate_data.py`, the maintainer script CI
+runs, so the two cannot disagree.
+
+Per-record validation cannot notice that a whole dataset is templated, which is how
+years of fabricated records once shipped with every record individually well formed.
+`scripts/corpus_quality.py` covers that: it fails a dataset whose decision fields are
+uniform across the corpus or whose records match a known fallback fingerprint, and runs
+in CI on full regenerations.

--- a/docs/dataset.md
+++ b/docs/dataset.md
@@ -104,19 +104,19 @@ the file on disk has the extra nesting level.
       "network_use_disclosure": false
     },
     "limitations": {
-      "liability": false,
-      "warranty": false,
+      "liability": true,
+      "warranty": true,
       "trademark_use": false
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": ["category:any"],
+        "compatible_with": ["category:permissive", "Apache-2.0", "BSD-3-Clause", "Zlib"],
         "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": { "...": "same shape" },
       "contamination_effect": "none",
-      "notes": "Permissive license with minimal restrictions"
+      "notes": "MIT license is permissive and does not impose restrictions on the licensing of combined works."
     },
     "obligations": [
       "Retain copyright notices",
@@ -128,7 +128,7 @@ the file on disk has the extra nesting level.
       "is_fsf_libre": true,
       "is_deprecated": false
     },
-    "generated": "2026-08-01T03:04:52.211970",
+    "generated": "2026-08-12T08:41:12.418762",
     "spdx_list_version": "e4c1f27"
   }
 }
@@ -139,7 +139,7 @@ the file on disk has the extra nesting level.
 | `type` | Family: `permissive`, `copyleft_weak`, `copyleft_strong`, `network_copyleft`, `noncommercial`, `no_derivatives`, `source_available`, `proprietary`, `public_domain`, `unknown`. Policy rules match on this via `license_type`. `noncommercial` and `no_derivatives` exist because those restrictions contradict `permissive`, and policy rules that approve by category would otherwise bless them. |
 | `properties` | What the license lets you do. |
 | `requirements` | Conditions you must satisfy. The booleans here drive `obligations`. |
-| `limitations` | What the license withholds: warranty, liability, trademark grant. |
+| `limitations` | Disclaimer analysis: `liability: true` means the license disclaims liability, which is standard for OSS. `trademark_use: true` means trademark use is restricted. |
 | `compatibility` | Per-linking-context rules. `category:any` means compatible with every family. |
 | `contamination_effect` | How far copyleft reaches: `none`, `file`, `library`, `project`. |
 | `obligations` | Human-readable duties, derived from `requirements`. |
@@ -175,17 +175,25 @@ the result reaches you as a released version.
 `.github/workflows/spdx-sync.yml` runs at 02:00 UTC on the first of each month, and can also
 be triggered manually with `workflow_dispatch`. It does this:
 
-1. **Check upstream.** Fetch SPDX `licenses.json`, diff the license IDs against the files in
+1. **Preflight.** Construct the LLM provider before anything else, so a missing package
+   or API key fails the job immediately instead of producing fabricated records.
+2. **Check upstream.** Fetch SPDX `licenses.json`, diff the license IDs against the files in
    `ospac/data/licenses/json/`, and find both genuinely new IDs and existing records whose
    `is_deprecated` flag is now stale. If neither exists, the run stops here.
-2. **Generate.** Run `ospac data generate --output-dir ospac/data --use-llm --llm-provider openai --force`.
+3. **Generate.** Run `ospac data generate --output-dir ospac/data --use-llm --llm-provider openai --force`.
    Only new licenses are analyzed; existing records are left alone unless
-   `--force-reprocess` is passed.
-3. **Validate.** Run `python scripts/validate_data.py --data-dir ospac/data`, which checks
-   every record for structural completeness and semantic correctness and spot-checks
-   well-known licenses. Errors fail the run.
-4. **Bump the patch version** in `pyproject.toml`.
-5. **Open a pull request** labelled `data,automated`, with a body summarising the SPDX
+   `--force-reprocess` is passed. A record that had to fall back instead of being analyzed
+   is deleted and fails the run, so a partly fabricated dataset cannot continue.
+4. **Validate.** Run `python scripts/validate_data.py --data-dir ospac/data`, which checks
+   every record for structural completeness, the restriction invariants, and spot-checks
+   of well-known licenses. Errors fail the run.
+5. **Upload the dataset as an artifact**, so a rejected run can still be reviewed record
+   by record.
+6. **Corpus quality gate**, on full regenerations: fail if decision fields are uniform
+   across the corpus or any record matches a known fallback fingerprint, which is the
+   failure mode per-record validation cannot see.
+7. **Bump the patch version** in `pyproject.toml`.
+8. **Open a pull request** labelled `data,automated`, with a body summarising the SPDX
    version, new license IDs, and deprecation flags changed, then enable auto-merge.
 
 So dataset changes arrive as reviewable pull requests with a diff you can read. The commit
@@ -212,8 +220,11 @@ an obligation looks wrong, the underlying boolean is wrong.
 **Known misclassifications are overridden.** A correction table pins fields that LLMs
 repeatedly got wrong for well-known licenses. Apache-2.0 is the motivating case: it was
 classified as copyleft with `same_license` and `disclose_source` set, which is simply false
-and would have denied Apache-2.0 across copyleft policy rules. The table also covers
-MPL-2.0 and CC0-1.0.
+and would have denied Apache-2.0 across copyleft policy rules. The table now pins
+roughly forty licenses, including the LGPL and AGPL families, EPL, CDDL, EUPL, OSL, SSPL,
+BUSL, Elastic, Parity, Aladdin and the CERN-OHL variants, and a deterministic layer
+derives every restriction the identifier or name states outright: NC, ND and SA
+components, Non-Profit and Reciprocal naming. The model cannot override either.
 
 The design assumption is that the LLM is a useful first pass over hundreds of license texts and not
 an authority. Validation, deterministic derivation, human PR review, and the correction
@@ -254,8 +265,8 @@ the output files.
 $ python scripts/validate_data.py --data-dir ospac/data
 ────────────────────────────────────────────────────────────
   Total files  : 733
-  Clean        : 732
-  Warnings     : 1
+  Clean        : 728
+  Warnings     : 5
   Errors       : 0
 
   PASS (strict=False)
@@ -264,5 +275,6 @@ $ python scripts/validate_data.py --data-dir ospac/data
 Warnings do not fail the exit code unless you pass `--strict`; errors always do. `--json`
 gives machine-readable output for a CI annotation.
 
-Prefer this over `ospac data validate`, which still expects the pre-1.2.0 YAML layout and
-fails against the shipped dataset.
+`ospac data validate` runs the same rules from the installed package, so either entry
+point gives the same verdict. For the corpus-level check that catches templated datasets,
+run `scripts/corpus_quality.py`, described under the monthly pipeline above.


### PR DESCRIPTION
The site still warned that data show -f text and data validate are broken, both
fixed two releases ago, and every example block showed the fabricated pre-analysis
data: MIT with no warranty disclaimer, template compatibility notes, check output
without requires_review, evaluate output without per_license.

Refresh the examples from real runs against the analysed dataset, describe the
per-license evaluation and no-known-conflict check semantics, document that data
generate now requires a provider, add the preflight, fallback gate, artifact and
corpus quality steps to the pipeline description, clarify that limitations record
disclaimer analysis, and update the correction-table description to the forty-odd
pins plus the deterministic identifier layer.
