### PR TITLE
fix: derive the compatibility lists instead of asking a model for them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to OSPAC (Open Source Policy as Code) will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.2] - 2026-08-12
+
+### Fixed
+
+**The record-level compatibility lists were model-generated and systematically wrong**
+- 540 of 733 records typed permissive or public domain declared themselves incompatible
+  with GPL or strong copyleft, which inverts how permissive licensing works: permissive
+  code can be incorporated into copyleft works, and that is the point of it. MPL-2.0
+  claimed incompatibility with the GPL it is expressly designed to combine with, and
+  pairs disagreed with each other, BSD-3-Clause calling GPL-3.0 incompatible while
+  GPL-3.0 called BSD-3-Clause compatible.
+- The policy engine was unaffected: `ospac check` answers from rules and was correct
+  throughout. The wrong lists were served raw in every record, and read by
+  `License.is_compatible_with`.
+- Compatibility between categories is a derivable fact, so it is now derived from the
+  record's final category plus a table of known license-level exceptions, applied on
+  every path that writes a record and pinned by the reproducibility test. The model
+  contributes only the prose notes. All 733 blocks rebuilt; the known exceptions,
+  GPL-2.0 with Apache-2.0, GPL-2.0 with GPL-3.0, and 4-clause BSD with any GPL, land in
+  both records of each pair so the claims stay symmetric.
+- Tests now assert no permissive record claims copyleft incompatibility beyond the
+  exception table, that pairwise claims never contradict each other, and that the known
+  pairs are mutually incompatible.
+
+**`License.is_compatible_with` never matched category entries**
+- Dataset entries use `category:<type>` specifiers, but the method compared the other
+  license's bare type against them, so category entries never matched and most lists
+  were silently inert. It also consulted `compatible_with` before `incompatible_with`,
+  which would have let a category match hide a named exception once the lists worked.
+  Category specifiers and `category:any` now resolve, and incompatibility is checked
+  first.
+
 ## [1.4.0] - 2026-08-11
 
 Clears the three items 1.3.0 left open, and repairs a licence dataset that had

--- a/docs/dataset.md
+++ b/docs/dataset.md
@@ -110,7 +110,7 @@ the file on disk has the extra nesting level.
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": ["category:permissive", "Apache-2.0", "BSD-3-Clause", "Zlib"],
+        "compatible_with": ["category:any"],
         "incompatible_with": [],
         "requires_review": []
       },
@@ -140,7 +140,7 @@ the file on disk has the extra nesting level.
 | `properties` | What the license lets you do. |
 | `requirements` | Conditions you must satisfy. The booleans here drive `obligations`. |
 | `limitations` | Disclaimer analysis: `liability: true` means the license disclaims liability, which is standard for OSS. `trademark_use: true` means trademark use is restricted. |
-| `compatibility` | Per-linking-context rules. `category:any` means compatible with every family. |
+| `compatibility` | Per-linking-context rules, derived from the record's category plus a table of known license-level exceptions such as GPL-2.0 with Apache-2.0. Entries are license ids or `category:<type>` specifiers; `category:any` means compatible with every family. Only the prose `notes` come from the analysis. |
 | `contamination_effect` | How far copyleft reaches: `none`, `file`, `library`, `project`. |
 | `obligations` | Human-readable duties, derived from `requirements`. |
 | `spdx_metadata` | Upstream flags, including `is_deprecated`. |

--- a/ospac/data/licenses/json/0BSD.json
+++ b/ospac/data/licenses/json/0BSD.json
@@ -28,24 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/3D-Slicer-1.0.json
+++ b/ospac/data/licenses/json/3D-Slicer-1.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/AAL.json
+++ b/ospac/data/licenses/json/AAL.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "AAL is permissive and does not impose viral effects on combined works."

--- a/ospac/data/licenses/json/ADSL.json
+++ b/ospac/data/licenses/json/ADSL.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "ADSL is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/AFL-1.1.json
+++ b/ospac/data/licenses/json/AFL-1.1.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/AFL-1.2.json
+++ b/ospac/data/licenses/json/AFL-1.2.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/AFL-2.0.json
+++ b/ospac/data/licenses/json/AFL-2.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/AFL-2.1.json
+++ b/ospac/data/licenses/json/AFL-2.1.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/AFL-3.0.json
+++ b/ospac/data/licenses/json/AFL-3.0.json
@@ -28,32 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/AGPL-1.0-only.json
+++ b/ospac/data/licenses/json/AGPL-1.0-only.json
@@ -28,26 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "AGPL-1.0-only",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong",
-          "AGPL-3.0-only",
-          "GPL-3.0-only"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "AGPL-1.0-only",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong",
-          "AGPL-3.0-only",
-          "GPL-3.0-only"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "AGPL-1.0-only has a strong copyleft requirement, affecting the entire combined work."

--- a/ospac/data/licenses/json/AGPL-1.0-or-later.json
+++ b/ospac/data/licenses/json/AGPL-1.0-or-later.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "AGPL-1.0-or-later",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "AGPL-1.0-or-later",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "Any use of AGPL-1.0-or-later-licensed components requires the entire combined work to be licensed under AGPL-1.0-or-later."

--- a/ospac/data/licenses/json/AGPL-1.0.json
+++ b/ospac/data/licenses/json/AGPL-1.0.json
@@ -28,22 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "AGPL-1.0",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "AGPL-1.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "AGPL-1.0 requires that any derivative work or combined work that uses AGPL-1.0 components must also be licensed under AGPL-1.0."

--- a/ospac/data/licenses/json/AGPL-3.0-only.json
+++ b/ospac/data/licenses/json/AGPL-3.0-only.json
@@ -28,25 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "AGPL-3.0-only",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "AGPL-3.0",
-          "GPL-3.0",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "AGPL-3.0-only",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "AGPL-3.0",
-          "GPL-3.0",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "Any use of AGPL-3.0-only licensed components in a combined work requires the entire work to be licensed under AGPL-3.0-only."

--- a/ospac/data/licenses/json/AGPL-3.0-or-later.json
+++ b/ospac/data/licenses/json/AGPL-3.0-or-later.json
@@ -28,33 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "AGPL-3.0-or-later",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "GPL-2.0",
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "AGPL-3.0-or-later",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "GPL-2.0",
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "Using AGPL-3.0-or-later components requires the entire work to be licensed under AGPL-3.0-or-later."

--- a/ospac/data/licenses/json/AGPL-3.0.json
+++ b/ospac/data/licenses/json/AGPL-3.0.json
@@ -28,25 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "AGPL-3.0",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong",
-          "AGPL-3.0",
-          "GPL-3.0"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "AGPL-3.0",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "AGPL-3.0",
-          "GPL-3.0",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "Using AGPL-3.0 components in any form requires the entire work to be licensed under AGPL-3.0."

--- a/ospac/data/licenses/json/ALGLIB-Documentation.json
+++ b/ospac/data/licenses/json/ALGLIB-Documentation.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/AMD-newlib.json
+++ b/ospac/data/licenses/json/AMD-newlib.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "AMD-newlib is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/AMDPLPA.json
+++ b/ospac/data/licenses/json/AMDPLPA.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "AMDPLPA is a permissive license, allowing for broad compatibility with other permissive licenses."

--- a/ospac/data/licenses/json/AML-glslang.json
+++ b/ospac/data/licenses/json/AML-glslang.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "AML-glslang is permissive, allowing for broad compatibility without viral effects."

--- a/ospac/data/licenses/json/AML.json
+++ b/ospac/data/licenses/json/AML.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/AMPAS.json
+++ b/ospac/data/licenses/json/AMPAS.json
@@ -28,25 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/ANTLR-PD-fallback.json
+++ b/ospac/data/licenses/json/ANTLR-PD-fallback.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/ANTLR-PD.json
+++ b/ospac/data/licenses/json/ANTLR-PD.json
@@ -28,28 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/APAFML.json
+++ b/ospac/data/licenses/json/APAFML.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "APAFML is a permissive license, allowing for broad compatibility without imposing restrictions on the combined work."

--- a/ospac/data/licenses/json/APL-1.0.json
+++ b/ospac/data/licenses/json/APL-1.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/APSL-1.0.json
+++ b/ospac/data/licenses/json/APSL-1.0.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/APSL-1.1.json
+++ b/ospac/data/licenses/json/APSL-1.1.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "APSL-1.1",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "APSL-1.1",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "APSL-1.1 allows linking with permissive and weak copyleft licenses, but modifications to APSL-1.1 code must remain under APSL-1.1."

--- a/ospac/data/licenses/json/APSL-1.2.json
+++ b/ospac/data/licenses/json/APSL-1.2.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/APSL-2.0.json
+++ b/ospac/data/licenses/json/APSL-2.0.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "APSL-2.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "APSL-2.0",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "APSL-2.0 allows linking with permissive and weak copyleft licenses, but modifications to APSL-2.0 components must remain under APSL-2.0."

--- a/ospac/data/licenses/json/ASWF-Digital-Assets-1.0.json
+++ b/ospac/data/licenses/json/ASWF-Digital-Assets-1.0.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "ASWF-Digital-Assets-1.0 is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/ASWF-Digital-Assets-1.1.json
+++ b/ospac/data/licenses/json/ASWF-Digital-Assets-1.1.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Abstyles.json
+++ b/ospac/data/licenses/json/Abstyles.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Abstyles is a permissive license with no viral effect on linked code."

--- a/ospac/data/licenses/json/AdaCore-doc.json
+++ b/ospac/data/licenses/json/AdaCore-doc.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "AdaCore-doc is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/Adobe-2006.json
+++ b/ospac/data/licenses/json/Adobe-2006.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Adobe-Display-PostScript.json
+++ b/ospac/data/licenses/json/Adobe-Display-PostScript.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Adobe-Display-PostScript is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/Adobe-Glyph.json
+++ b/ospac/data/licenses/json/Adobe-Glyph.json
@@ -27,37 +27,17 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "compatible_with": [],
+        "incompatible_with": [],
         "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
+          "category:any"
         ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "compatible_with": [],
+        "incompatible_with": [],
         "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
+          "category:any"
         ]
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Adobe-Utopia.json
+++ b/ospac/data/licenses/json/Adobe-Utopia.json
@@ -27,37 +27,17 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "compatible_with": [],
+        "incompatible_with": [],
         "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
+          "category:any"
         ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "compatible_with": [],
+        "incompatible_with": [],
         "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
+          "category:any"
         ]
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Advanced-Cryptics-Dictionary.json
+++ b/ospac/data/licenses/json/Advanced-Cryptics-Dictionary.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Advanced-Cryptics-Dictionary is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/Afmparse.json
+++ b/ospac/data/licenses/json/Afmparse.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Afmparse is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/Aladdin.json
+++ b/ospac/data/licenses/json/Aladdin.json
@@ -27,26 +27,18 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
-        ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "contamination_effect": "none",
       "notes": "Aladdin license is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/Apache-1.0.json
+++ b/ospac/data/licenses/json/Apache-1.0.json
@@ -28,38 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "Apache-1.0",
-          "MIT",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "Public Domain",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-2.0",
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "Apache-1.0",
-          "MIT",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "Public Domain",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-2.0",
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Apache-1.1.json
+++ b/ospac/data/licenses/json/Apache-1.1.json
@@ -28,33 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "BSD-2-Clause",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL",
-          "AGPL"
-        ],
-        "requires_review": [
-          "LGPL"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "BSD-2-Clause",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL",
-          "AGPL"
-        ],
-        "requires_review": [
-          "LGPL"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Apache-1.1 is permissive and does not impose restrictions on the licensing of combined works."

--- a/ospac/data/licenses/json/Apache-2.0.json
+++ b/ospac/data/licenses/json/Apache-2.0.json
@@ -28,37 +28,23 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Apache-2.0"
+          "category:any"
         ],
         "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
+          "GPL-2.0",
+          "GPL-2.0-only"
         ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Apache-2.0"
+          "category:any"
         ],
         "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
+          "GPL-2.0",
+          "GPL-2.0-only"
         ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Apache-2.0 is a permissive license, allowing for broad compatibility with other licenses."

--- a/ospac/data/licenses/json/App-s2p.json
+++ b/ospac/data/licenses/json/App-s2p.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Arphic-1999.json
+++ b/ospac/data/licenses/json/Arphic-1999.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Arphic-1999 is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/Artistic-1.0-Perl.json
+++ b/ospac/data/licenses/json/Artistic-1.0-Perl.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Artistic-1.0-cl8.json
+++ b/ospac/data/licenses/json/Artistic-1.0-cl8.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Artistic-1.0.json
+++ b/ospac/data/licenses/json/Artistic-1.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Artistic-2.0.json
+++ b/ospac/data/licenses/json/Artistic-2.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Artistic-dist.json
+++ b/ospac/data/licenses/json/Artistic-dist.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Artistic-dist license is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/Aspell-RU.json
+++ b/ospac/data/licenses/json/Aspell-RU.json
@@ -28,40 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "Public Domain",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "Public Domain",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/BOLA-1.1.json
+++ b/ospac/data/licenses/json/BOLA-1.1.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/BSD-1-Clause.json
+++ b/ospac/data/licenses/json/BSD-1-Clause.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/BSD-2-Clause-Darwin.json
+++ b/ospac/data/licenses/json/BSD-2-Clause-Darwin.json
@@ -28,39 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0",
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0",
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "The BSD-2-Clause-Darwin license is permissive and does not impose restrictions on the licensing of combined works."

--- a/ospac/data/licenses/json/BSD-2-Clause-FreeBSD.json
+++ b/ospac/data/licenses/json/BSD-2-Clause-FreeBSD.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/BSD-2-Clause-NetBSD.json
+++ b/ospac/data/licenses/json/BSD-2-Clause-NetBSD.json
@@ -28,35 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "SPDX:MIT",
-          "SPDX:Apache-2.0",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "SPDX:GPL-3.0",
-          "SPDX:AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "SPDX:LGPL-2.1",
-          "SPDX:LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "SPDX:MIT",
-          "SPDX:Apache-2.0",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "SPDX:GPL-3.0",
-          "SPDX:AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "SPDX:LGPL-2.1",
-          "SPDX:LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "The BSD-2-Clause-NetBSD license is permissive and does not impose restrictions on the licensing of derivative works."

--- a/ospac/data/licenses/json/BSD-2-Clause-Patent.json
+++ b/ospac/data/licenses/json/BSD-2-Clause-Patent.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "The BSD-2-Clause-Patent license is permissive and does not impose viral effects on derivative works."

--- a/ospac/data/licenses/json/BSD-2-Clause-Views.json
+++ b/ospac/data/licenses/json/BSD-2-Clause-Views.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "The BSD-2-Clause-Views license is permissive and does not impose restrictions on the licensing of combined works."

--- a/ospac/data/licenses/json/BSD-2-Clause-first-lines.json
+++ b/ospac/data/licenses/json/BSD-2-Clause-first-lines.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "The BSD-2-Clause-first-lines license is permissive and does not impose restrictions on the licensing of combined works."

--- a/ospac/data/licenses/json/BSD-2-Clause-pkgconf-disclaimer.json
+++ b/ospac/data/licenses/json/BSD-2-Clause-pkgconf-disclaimer.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "The BSD-2-Clause-pkgconf-disclaimer license is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/BSD-2-Clause.json
+++ b/ospac/data/licenses/json/BSD-2-Clause.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "The BSD-2-Clause license is permissive and does not impose restrictions on the licensing of combined works."

--- a/ospac/data/licenses/json/BSD-3-Clause-Attribution.json
+++ b/ospac/data/licenses/json/BSD-3-Clause-Attribution.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/BSD-3-Clause-Clear.json
+++ b/ospac/data/licenses/json/BSD-3-Clause-Clear.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "The BSD-3-Clause-Clear license is permissive and does not impose restrictions on the licensing of combined works."

--- a/ospac/data/licenses/json/BSD-3-Clause-HP.json
+++ b/ospac/data/licenses/json/BSD-3-Clause-HP.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "The BSD-3-Clause-HP license is permissive and does not impose viral effects on combined works."

--- a/ospac/data/licenses/json/BSD-3-Clause-LBNL.json
+++ b/ospac/data/licenses/json/BSD-3-Clause-LBNL.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "The BSD-3-Clause-LBNL license is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/BSD-3-Clause-Modification.json
+++ b/ospac/data/licenses/json/BSD-3-Clause-Modification.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "The BSD-3-Clause-Modification license is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/BSD-3-Clause-No-Military-License.json
+++ b/ospac/data/licenses/json/BSD-3-Clause-No-Military-License.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "The BSD-3-Clause-No-Military-License is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/BSD-3-Clause-No-Nuclear-License-2014.json
+++ b/ospac/data/licenses/json/BSD-3-Clause-No-Nuclear-License-2014.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/BSD-3-Clause-No-Nuclear-License.json
+++ b/ospac/data/licenses/json/BSD-3-Clause-No-Nuclear-License.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "The BSD-3-Clause-No-Nuclear-License is permissive and does not impose a viral effect on linked code."

--- a/ospac/data/licenses/json/BSD-3-Clause-No-Nuclear-Warranty.json
+++ b/ospac/data/licenses/json/BSD-3-Clause-No-Nuclear-Warranty.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "The BSD-3-Clause-No-Nuclear-Warranty license is permissive and does not impose restrictions on the licensing of combined works."

--- a/ospac/data/licenses/json/BSD-3-Clause-Open-MPI.json
+++ b/ospac/data/licenses/json/BSD-3-Clause-Open-MPI.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "The BSD-3-Clause-Open-MPI license is permissive and does not impose a viral effect on linked code."

--- a/ospac/data/licenses/json/BSD-3-Clause-Sun.json
+++ b/ospac/data/licenses/json/BSD-3-Clause-Sun.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "The BSD-3-Clause-Sun license is permissive and does not impose restrictions on the licensing of combined works."

--- a/ospac/data/licenses/json/BSD-3-Clause-Tso.json
+++ b/ospac/data/licenses/json/BSD-3-Clause-Tso.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "The BSD-3-Clause-Tso license is permissive and does not impose restrictions on the licensing of combined works."

--- a/ospac/data/licenses/json/BSD-3-Clause-acpica.json
+++ b/ospac/data/licenses/json/BSD-3-Clause-acpica.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "The BSD-3-Clause-acpica license is permissive and does not impose viral effects on combined works."

--- a/ospac/data/licenses/json/BSD-3-Clause-flex.json
+++ b/ospac/data/licenses/json/BSD-3-Clause-flex.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "The BSD-3-Clause-flex license is permissive and does not impose a viral effect on combined works."

--- a/ospac/data/licenses/json/BSD-3-Clause.json
+++ b/ospac/data/licenses/json/BSD-3-Clause.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/BSD-4-Clause-Shortened.json
+++ b/ospac/data/licenses/json/BSD-4-Clause-Shortened.json
@@ -28,37 +28,31 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "category:permissive"
+          "category:any"
         ],
         "incompatible_with": [
+          "GPL-2.0",
+          "GPL-2.0-only",
+          "GPL-2.0-or-later",
           "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
+          "GPL-3.0-only",
+          "GPL-3.0-or-later"
         ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "category:permissive"
+          "category:any"
         ],
         "incompatible_with": [
+          "GPL-2.0",
+          "GPL-2.0-only",
+          "GPL-2.0-or-later",
           "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
+          "GPL-3.0-only",
+          "GPL-3.0-or-later"
         ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "The BSD-4-Clause-Shortened license is permissive and does not impose restrictions on the licensing of combined works."

--- a/ospac/data/licenses/json/BSD-4-Clause-UC.json
+++ b/ospac/data/licenses/json/BSD-4-Clause-UC.json
@@ -28,20 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "GPL-2.0",
+          "GPL-2.0-only",
+          "GPL-2.0-or-later",
+          "GPL-3.0",
+          "GPL-3.0-only",
+          "GPL-3.0-or-later"
         ],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "GPL-2.0",
+          "GPL-2.0-only",
+          "GPL-2.0-or-later",
+          "GPL-3.0",
+          "GPL-3.0-only",
+          "GPL-3.0-or-later"
         ],
         "requires_review": []
       },

--- a/ospac/data/licenses/json/BSD-4-Clause.json
+++ b/ospac/data/licenses/json/BSD-4-Clause.json
@@ -28,37 +28,31 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "category:permissive"
+          "category:any"
         ],
         "incompatible_with": [
+          "GPL-2.0",
+          "GPL-2.0-only",
+          "GPL-2.0-or-later",
           "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
+          "GPL-3.0-only",
+          "GPL-3.0-or-later"
         ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "category:permissive"
+          "category:any"
         ],
         "incompatible_with": [
+          "GPL-2.0",
+          "GPL-2.0-only",
+          "GPL-2.0-or-later",
           "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
+          "GPL-3.0-only",
+          "GPL-3.0-or-later"
         ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "The BSD-4-Clause license is permissive and does not impose restrictions on the licensing of combined works."

--- a/ospac/data/licenses/json/BSD-4.3RENO.json
+++ b/ospac/data/licenses/json/BSD-4.3RENO.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "BSD-4.3RENO is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/BSD-4.3TAHOE.json
+++ b/ospac/data/licenses/json/BSD-4.3TAHOE.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/BSD-Advertising-Acknowledgement.json
+++ b/ospac/data/licenses/json/BSD-Advertising-Acknowledgement.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/BSD-Attribution-HPND-disclaimer.json
+++ b/ospac/data/licenses/json/BSD-Attribution-HPND-disclaimer.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strict"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strict"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/BSD-Inferno-Nettverk.json
+++ b/ospac/data/licenses/json/BSD-Inferno-Nettverk.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/BSD-Mark-Modifications.json
+++ b/ospac/data/licenses/json/BSD-Mark-Modifications.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/BSD-Protection.json
+++ b/ospac/data/licenses/json/BSD-Protection.json
@@ -28,31 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL",
-          "AGPL"
-        ],
-        "requires_review": [
-          "LGPL"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL",
-          "AGPL"
-        ],
-        "requires_review": [
-          "LGPL"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "The BSD-Protection license is permissive and does not impose viral effects on combined works."

--- a/ospac/data/licenses/json/BSD-Source-Code.json
+++ b/ospac/data/licenses/json/BSD-Source-Code.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "ISC",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "ISC",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "BSD-Source-Code license is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/BSD-Source-beginning-file.json
+++ b/ospac/data/licenses/json/BSD-Source-beginning-file.json
@@ -28,39 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "The BSD-Source-beginning-file license is permissive and does not impose a viral effect on linked code."

--- a/ospac/data/licenses/json/BSD-Systemics-W3Works.json
+++ b/ospac/data/licenses/json/BSD-Systemics-W3Works.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/BSD-Systemics.json
+++ b/ospac/data/licenses/json/BSD-Systemics.json
@@ -28,39 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "BSD-Systemics is permissive and does not impose viral licensing effects."

--- a/ospac/data/licenses/json/BSL-1.0.json
+++ b/ospac/data/licenses/json/BSL-1.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/BUSL-1.1.json
+++ b/ospac/data/licenses/json/BUSL-1.1.json
@@ -27,28 +27,20 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
-        ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
-      "contamination_effect": "module",
+      "contamination_effect": "unknown",
       "notes": "BUSL-1.1 allows for linking with permissive licenses but requires modifications to remain under BUSL-1.1."
     },
     "obligations": [

--- a/ospac/data/licenses/json/Baekmuk.json
+++ b/ospac/data/licenses/json/Baekmuk.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strict"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strict"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Bahyph.json
+++ b/ospac/data/licenses/json/Bahyph.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Bahyph is a permissive license, allowing for broad compatibility with other permissive licenses."

--- a/ospac/data/licenses/json/Barr.json
+++ b/ospac/data/licenses/json/Barr.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Beerware.json
+++ b/ospac/data/licenses/json/Beerware.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/BitTorrent-1.0.json
+++ b/ospac/data/licenses/json/BitTorrent-1.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/BitTorrent-1.1.json
+++ b/ospac/data/licenses/json/BitTorrent-1.1.json
@@ -28,38 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Bitstream-Charter.json
+++ b/ospac/data/licenses/json/Bitstream-Charter.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Bitstream-Vera.json
+++ b/ospac/data/licenses/json/Bitstream-Vera.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/BlueOak-1.0.0.json
+++ b/ospac/data/licenses/json/BlueOak-1.0.0.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Boehm-GC-without-fee.json
+++ b/ospac/data/licenses/json/Boehm-GC-without-fee.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Boehm-GC-without-fee is permissive and does not impose a viral effect on linked code."

--- a/ospac/data/licenses/json/Boehm-GC.json
+++ b/ospac/data/licenses/json/Boehm-GC.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Boehm-GC is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/Borceux.json
+++ b/ospac/data/licenses/json/Borceux.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Brian-Gladman-2-Clause.json
+++ b/ospac/data/licenses/json/Brian-Gladman-2-Clause.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Brian-Gladman-3-Clause-no-conversion.json
+++ b/ospac/data/licenses/json/Brian-Gladman-3-Clause-no-conversion.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Brian-Gladman-3-Clause.json
+++ b/ospac/data/licenses/json/Brian-Gladman-3-Clause.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Buddy.json
+++ b/ospac/data/licenses/json/Buddy.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Bugroff.json
+++ b/ospac/data/licenses/json/Bugroff.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Bugroff is a permissive license with no viral effect on linked code."

--- a/ospac/data/licenses/json/C-UDA-1.0.json
+++ b/ospac/data/licenses/json/C-UDA-1.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/CAL-1.0-Combined-Work-Exception.json
+++ b/ospac/data/licenses/json/CAL-1.0-Combined-Work-Exception.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "CAL-1.0-Combined-Work-Exception is permissive and does not impose a viral effect on combined works."

--- a/ospac/data/licenses/json/CAL-1.0.json
+++ b/ospac/data/licenses/json/CAL-1.0.json
@@ -28,25 +28,41 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "CAL-1.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "CAL-1.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
-      "contamination_effect": "module",
+      "contamination_effect": "full",
       "notes": "CAL-1.0 allows linking with permissive and weak copyleft licenses, but modified files must remain under CAL-1.0."
     },
     "obligations": [

--- a/ospac/data/licenses/json/CAPEC-tou.json
+++ b/ospac/data/licenses/json/CAPEC-tou.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/CATOSL-1.1.json
+++ b/ospac/data/licenses/json/CATOSL-1.1.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/CC-BY-1.0.json
+++ b/ospac/data/licenses/json/CC-BY-1.0.json
@@ -28,20 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/CC-BY-2.0.json
+++ b/ospac/data/licenses/json/CC-BY-2.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/CC-BY-2.5-AU.json
+++ b/ospac/data/licenses/json/CC-BY-2.5-AU.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strict"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strict"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/CC-BY-2.5.json
+++ b/ospac/data/licenses/json/CC-BY-2.5.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/CC-BY-3.0-AT.json
+++ b/ospac/data/licenses/json/CC-BY-3.0-AT.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/CC-BY-3.0-AU.json
+++ b/ospac/data/licenses/json/CC-BY-3.0-AU.json
@@ -28,20 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/CC-BY-3.0-DE.json
+++ b/ospac/data/licenses/json/CC-BY-3.0-DE.json
@@ -28,20 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/CC-BY-3.0-IGO.json
+++ b/ospac/data/licenses/json/CC-BY-3.0-IGO.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/CC-BY-3.0-NL.json
+++ b/ospac/data/licenses/json/CC-BY-3.0-NL.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/CC-BY-3.0-US.json
+++ b/ospac/data/licenses/json/CC-BY-3.0-US.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/CC-BY-3.0.json
+++ b/ospac/data/licenses/json/CC-BY-3.0.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/CC-BY-4.0.json
+++ b/ospac/data/licenses/json/CC-BY-4.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/CC-BY-NC-1.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-1.0.json
@@ -27,26 +27,18 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "GPL",
-          "AGPL"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "GPL",
-          "AGPL"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "contamination_effect": "none",
       "notes": "CC-BY-NC-1.0 is a noncommercial license, which generally allows for compatibility with permissive licenses but is incompatible with copyleft licenses."

--- a/ospac/data/licenses/json/CC-BY-NC-2.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-2.0.json
@@ -27,23 +27,18 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "contamination_effect": "none",
       "notes": "CC-BY-NC-2.0 is a noncommercial license, which generally allows use with permissive licenses but is incompatible with copyleft licenses."

--- a/ospac/data/licenses/json/CC-BY-NC-2.5.json
+++ b/ospac/data/licenses/json/CC-BY-NC-2.5.json
@@ -27,25 +27,20 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
-      "contamination_effect": "full",
+      "contamination_effect": "none",
       "notes": "Using CC-BY-NC-2.5 components in a project generally requires the entire project to be noncommercial and under the same license."
     },
     "obligations": [

--- a/ospac/data/licenses/json/CC-BY-NC-3.0-DE.json
+++ b/ospac/data/licenses/json/CC-BY-NC-3.0-DE.json
@@ -27,25 +27,20 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
-      "contamination_effect": "full",
+      "contamination_effect": "none",
       "notes": "Using CC-BY-NC-3.0-DE components in a project requires the entire project to be noncommercial and under the same license."
     },
     "obligations": [

--- a/ospac/data/licenses/json/CC-BY-NC-3.0-IGO.json
+++ b/ospac/data/licenses/json/CC-BY-NC-3.0-IGO.json
@@ -27,23 +27,18 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "contamination_effect": "none",
       "notes": "CC-BY-NC-3.0-IGO is noncommercial and generally compatible with permissive licenses."

--- a/ospac/data/licenses/json/CC-BY-NC-3.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-3.0.json
@@ -27,23 +27,18 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "contamination_effect": "none",
       "notes": "CC-BY-NC-3.0 is a noncommercial license, which generally allows use with permissive licenses without imposing restrictions on the entire work."

--- a/ospac/data/licenses/json/CC-BY-NC-4.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-4.0.json
@@ -27,26 +27,18 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "GPL",
-          "AGPL"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "GPL",
-          "AGPL"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "contamination_effect": "none",
       "notes": "CC-BY-NC-4.0 is a noncommercial license, which limits its compatibility with commercial licenses."

--- a/ospac/data/licenses/json/CC-BY-NC-ND-1.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-ND-1.0.json
@@ -27,26 +27,20 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
-      "contamination_effect": "full",
+      "contamination_effect": "none",
       "notes": "CC-BY-NC-ND-1.0 does not allow for commercial use or derivative works, which limits compatibility with many licenses."
     },
     "obligations": [

--- a/ospac/data/licenses/json/CC-BY-NC-ND-2.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-ND-2.0.json
@@ -27,26 +27,20 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
-      "contamination_effect": "full",
+      "contamination_effect": "none",
       "notes": "Using CC-BY-NC-ND-2.0 components in a project requires the entire work to be under the same license due to the no derivatives clause."
     },
     "obligations": [

--- a/ospac/data/licenses/json/CC-BY-NC-ND-2.5.json
+++ b/ospac/data/licenses/json/CC-BY-NC-ND-2.5.json
@@ -27,26 +27,20 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
-      "contamination_effect": "full",
+      "contamination_effect": "none",
       "notes": "CC-BY-NC-ND-2.5 does not allow for derivatives, which affects compatibility with copyleft licenses."
     },
     "obligations": [

--- a/ospac/data/licenses/json/CC-BY-NC-ND-3.0-DE.json
+++ b/ospac/data/licenses/json/CC-BY-NC-ND-3.0-DE.json
@@ -27,26 +27,20 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_weak"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_weak"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
-      "contamination_effect": "full",
+      "contamination_effect": "none",
       "notes": "Using CC-BY-NC-ND-3.0-DE components in a project requires the entire work to be under the same license."
     },
     "obligations": [

--- a/ospac/data/licenses/json/CC-BY-NC-ND-3.0-IGO.json
+++ b/ospac/data/licenses/json/CC-BY-NC-ND-3.0-IGO.json
@@ -27,24 +27,18 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "contamination_effect": "none",
       "notes": "The CC-BY-NC-ND-3.0-IGO license does not allow for commercial use or derivative works, making it compatible primarily with permissive licenses."

--- a/ospac/data/licenses/json/CC-BY-NC-ND-3.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-ND-3.0.json
@@ -27,26 +27,20 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_weak"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_weak"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
-      "contamination_effect": "full",
+      "contamination_effect": "none",
       "notes": "CC-BY-NC-ND-3.0 does not allow for commercial use or derivative works, which limits compatibility with many licenses."
     },
     "obligations": [

--- a/ospac/data/licenses/json/CC-BY-NC-ND-4.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-ND-4.0.json
@@ -27,26 +27,20 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
-      "contamination_effect": "full",
+      "contamination_effect": "none",
       "notes": "Using CC-BY-NC-ND-4.0 components in a project requires the entire work to be under the same license."
     },
     "obligations": [

--- a/ospac/data/licenses/json/CC-BY-NC-SA-1.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-SA-1.0.json
@@ -27,25 +27,20 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
-      "contamination_effect": "full",
+      "contamination_effect": "none",
       "notes": "Using CC-BY-NC-SA-1.0 components in a project requires the entire work to be under the same license due to its noncommercial nature."
     },
     "obligations": [

--- a/ospac/data/licenses/json/CC-BY-NC-SA-2.0-DE.json
+++ b/ospac/data/licenses/json/CC-BY-NC-SA-2.0-DE.json
@@ -27,25 +27,20 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
-      "contamination_effect": "derivative",
+      "contamination_effect": "none",
       "notes": "Using CC-BY-NC-SA-2.0-DE components in a project requires that all derivative works remain under the same license."
     },
     "obligations": [

--- a/ospac/data/licenses/json/CC-BY-NC-SA-2.0-FR.json
+++ b/ospac/data/licenses/json/CC-BY-NC-SA-2.0-FR.json
@@ -27,25 +27,20 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:strong_copyleft"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:strong_copyleft"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
-      "contamination_effect": "module",
+      "contamination_effect": "none",
       "notes": "The CC-BY-NC-SA-2.0-FR license requires that modifications to the licensed work remain under the same license, but does not impose this requirement on the entire combined work."
     },
     "obligations": [

--- a/ospac/data/licenses/json/CC-BY-NC-SA-2.0-UK.json
+++ b/ospac/data/licenses/json/CC-BY-NC-SA-2.0-UK.json
@@ -27,25 +27,20 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
-      "contamination_effect": "derivative",
+      "contamination_effect": "none",
       "notes": "Using CC-BY-NC-SA-2.0-UK components in a project requires that all derivative works also be licensed under the same terms."
     },
     "obligations": [

--- a/ospac/data/licenses/json/CC-BY-NC-SA-2.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-SA-2.0.json
@@ -27,26 +27,20 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
-      "contamination_effect": "full",
+      "contamination_effect": "none",
       "notes": "Using CC-BY-NC-SA-2.0 components in a project requires the entire work to be under the same license."
     },
     "obligations": [

--- a/ospac/data/licenses/json/CC-BY-NC-SA-2.5.json
+++ b/ospac/data/licenses/json/CC-BY-NC-SA-2.5.json
@@ -27,25 +27,20 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
-      "contamination_effect": "derivative",
+      "contamination_effect": "none",
       "notes": "Using CC-BY-NC-SA-2.5 components in a project may require the entire derivative work to be licensed under the same terms."
     },
     "obligations": [

--- a/ospac/data/licenses/json/CC-BY-NC-SA-3.0-DE.json
+++ b/ospac/data/licenses/json/CC-BY-NC-SA-3.0-DE.json
@@ -27,25 +27,20 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
-      "contamination_effect": "derivative",
+      "contamination_effect": "none",
       "notes": "Using CC-BY-NC-SA-3.0-DE components in a project requires that all derivative works also be licensed under the same terms."
     },
     "obligations": [

--- a/ospac/data/licenses/json/CC-BY-NC-SA-3.0-IGO.json
+++ b/ospac/data/licenses/json/CC-BY-NC-SA-3.0-IGO.json
@@ -27,25 +27,20 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
-      "contamination_effect": "derivative",
+      "contamination_effect": "none",
       "notes": "Using CC-BY-NC-SA-3.0-IGO components in a project may require the entire derivative work to be licensed under the same terms."
     },
     "obligations": [

--- a/ospac/data/licenses/json/CC-BY-NC-SA-3.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-SA-3.0.json
@@ -27,25 +27,20 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
-      "contamination_effect": "derivative",
+      "contamination_effect": "none",
       "notes": "CC-BY-NC-SA-3.0 requires that derivative works remain under the same license."
     },
     "obligations": [

--- a/ospac/data/licenses/json/CC-BY-NC-SA-4.0.json
+++ b/ospac/data/licenses/json/CC-BY-NC-SA-4.0.json
@@ -27,25 +27,20 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
-      "contamination_effect": "derivative",
+      "contamination_effect": "none",
       "notes": "CC-BY-NC-SA-4.0 requires that derivative works remain under the same license."
     },
     "obligations": [

--- a/ospac/data/licenses/json/CC-BY-ND-1.0.json
+++ b/ospac/data/licenses/json/CC-BY-ND-1.0.json
@@ -27,26 +27,20 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
-      "contamination_effect": "full",
+      "contamination_effect": "none",
       "notes": "CC-BY-ND-1.0 prohibits derivatives, which affects compatibility with copyleft licenses."
     },
     "obligations": [

--- a/ospac/data/licenses/json/CC-BY-ND-2.0.json
+++ b/ospac/data/licenses/json/CC-BY-ND-2.0.json
@@ -27,26 +27,20 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
-      "contamination_effect": "full",
+      "contamination_effect": "none",
       "notes": "CC-BY-ND-2.0 prohibits derivatives, which affects compatibility with copyleft licenses."
     },
     "obligations": [

--- a/ospac/data/licenses/json/CC-BY-ND-2.5.json
+++ b/ospac/data/licenses/json/CC-BY-ND-2.5.json
@@ -27,26 +27,20 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
-      "contamination_effect": "full",
+      "contamination_effect": "none",
       "notes": "CC-BY-ND-2.5 prohibits derivatives, which affects compatibility with copyleft licenses."
     },
     "obligations": [

--- a/ospac/data/licenses/json/CC-BY-ND-3.0-DE.json
+++ b/ospac/data/licenses/json/CC-BY-ND-3.0-DE.json
@@ -27,28 +27,20 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft",
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
           "category:any"
-        ],
-        "requires_review": []
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft",
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
           "category:any"
-        ],
-        "requires_review": []
+        ]
       },
-      "contamination_effect": "full",
+      "contamination_effect": "none",
       "notes": "CC-BY-ND-3.0-DE does not allow derivatives, which affects compatibility with copyleft licenses."
     },
     "obligations": [

--- a/ospac/data/licenses/json/CC-BY-ND-3.0.json
+++ b/ospac/data/licenses/json/CC-BY-ND-3.0.json
@@ -27,26 +27,20 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
-      "contamination_effect": "full",
+      "contamination_effect": "none",
       "notes": "CC-BY-ND-3.0 prohibits derivatives, which affects compatibility with copyleft licenses."
     },
     "obligations": [

--- a/ospac/data/licenses/json/CC-BY-ND-4.0.json
+++ b/ospac/data/licenses/json/CC-BY-ND-4.0.json
@@ -27,26 +27,20 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
-      "contamination_effect": "full",
+      "contamination_effect": "none",
       "notes": "CC-BY-ND-4.0 prohibits derivatives, thus any combined work must be licensed under CC-BY-ND-4.0."
     },
     "obligations": [

--- a/ospac/data/licenses/json/CC-BY-SA-1.0.json
+++ b/ospac/data/licenses/json/CC-BY-SA-1.0.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "CC-BY-SA-1.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "CC-BY-SA-1.0",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "derivative",
       "notes": "CC-BY-SA-1.0 requires derivative works to be licensed under the same terms."

--- a/ospac/data/licenses/json/CC-BY-SA-2.0-UK.json
+++ b/ospac/data/licenses/json/CC-BY-SA-2.0-UK.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "CC-BY-SA-2.0-UK",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "CC-BY-SA-2.0-UK",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "derivative",
       "notes": "All derivative works must be licensed under CC-BY-SA-2.0-UK."

--- a/ospac/data/licenses/json/CC-BY-SA-2.0.json
+++ b/ospac/data/licenses/json/CC-BY-SA-2.0.json
@@ -28,25 +28,31 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "CC-BY-SA-2.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "CC-BY-SA-2.0",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
-      "contamination_effect": "module",
+      "contamination_effect": "derivative",
       "notes": "CC-BY-SA-2.0 requires that modifications to the CC-BY-SA-2.0 licensed components remain under the same license."
     },
     "obligations": [

--- a/ospac/data/licenses/json/CC-BY-SA-2.1-JP.json
+++ b/ospac/data/licenses/json/CC-BY-SA-2.1-JP.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "CC-BY-SA-2.1-JP",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "CC-BY-SA-2.1-JP",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "derivative",
       "notes": "CC-BY-SA-2.1-JP requires derivative works to be licensed under the same terms."

--- a/ospac/data/licenses/json/CC-BY-SA-2.5.json
+++ b/ospac/data/licenses/json/CC-BY-SA-2.5.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "CC-BY-SA-2.5",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "CC-BY-SA-2.5",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "Using CC-BY-SA-2.5-licensed components in a project requires the entire work to be licensed under CC-BY-SA-2.5."

--- a/ospac/data/licenses/json/CC-BY-SA-3.0-AT.json
+++ b/ospac/data/licenses/json/CC-BY-SA-3.0-AT.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "CC-BY-SA-3.0-AT",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "CC-BY-SA-3.0-AT",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "CC-BY-SA-3.0-AT requires that any derivative works be licensed under the same terms."

--- a/ospac/data/licenses/json/CC-BY-SA-3.0-DE.json
+++ b/ospac/data/licenses/json/CC-BY-SA-3.0-DE.json
@@ -28,22 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "CC-BY-SA-3.0-DE",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "CC-BY-SA-3.0-DE",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "Using CC-BY-SA-3.0-DE components in a project requires the entire work to be licensed under CC-BY-SA-3.0-DE."

--- a/ospac/data/licenses/json/CC-BY-SA-3.0-IGO.json
+++ b/ospac/data/licenses/json/CC-BY-SA-3.0-IGO.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "CC-BY-SA-3.0-IGO",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "CC-BY-SA-3.0-IGO",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "derivative",
       "notes": "CC-BY-SA-3.0-IGO requires derivative works to be licensed under the same terms."

--- a/ospac/data/licenses/json/CC-BY-SA-3.0.json
+++ b/ospac/data/licenses/json/CC-BY-SA-3.0.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "CC-BY-SA-3.0",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "CC-BY-SA-3.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "Any combined work that includes CC-BY-SA-3.0 components must be licensed under CC-BY-SA-3.0."

--- a/ospac/data/licenses/json/CC-BY-SA-4.0.json
+++ b/ospac/data/licenses/json/CC-BY-SA-4.0.json
@@ -28,22 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "CC-BY-SA-4.0",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "CC-BY-SA-4.0",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "Using CC-BY-SA-4.0 components in a project requires the entire work to be licensed under CC-BY-SA-4.0."

--- a/ospac/data/licenses/json/CC-PDDC.json
+++ b/ospac/data/licenses/json/CC-PDDC.json
@@ -28,24 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft",
-          "category:strong_copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft",
-          "category:strong_copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/CC-PDM-1.0.json
+++ b/ospac/data/licenses/json/CC-PDM-1.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strict"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strict"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/CC-SA-1.0.json
+++ b/ospac/data/licenses/json/CC-SA-1.0.json
@@ -28,25 +28,31 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "CC-SA-1.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "CC-SA-1.0",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
-      "contamination_effect": "module",
+      "contamination_effect": "derivative",
       "notes": "CC-SA-1.0 allows for linking with permissive and weak copyleft licenses, but modifications must remain under the same license."
     },
     "obligations": [

--- a/ospac/data/licenses/json/CC0-1.0.json
+++ b/ospac/data/licenses/json/CC0-1.0.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/CDDL-1.0.json
+++ b/ospac/data/licenses/json/CDDL-1.0.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "CDDL-1.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "CDDL-1.0",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "CDDL-1.0 allows linking with permissive and weak copyleft licenses, but modified files must remain under CDDL-1.0."

--- a/ospac/data/licenses/json/CDDL-1.1.json
+++ b/ospac/data/licenses/json/CDDL-1.1.json
@@ -28,36 +28,28 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "CDDL-1.1",
+          "category:permissive",
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
         ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "CDDL-1.1",
+          "category:permissive",
+          "category:public_domain",
+          "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
+          "category:copyleft_strong",
+          "category:network_copyleft"
         ]
       },
       "contamination_effect": "module",

--- a/ospac/data/licenses/json/CDL-1.0.json
+++ b/ospac/data/licenses/json/CDL-1.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/CDLA-Permissive-1.0.json
+++ b/ospac/data/licenses/json/CDLA-Permissive-1.0.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "CDLA-Permissive-1.0 is a permissive license with no viral effect on linked code."

--- a/ospac/data/licenses/json/CDLA-Permissive-2.0.json
+++ b/ospac/data/licenses/json/CDLA-Permissive-2.0.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "CDLA-Permissive-2.0 is a permissive license with no viral effect on linked code."

--- a/ospac/data/licenses/json/CDLA-Sharing-1.0.json
+++ b/ospac/data/licenses/json/CDLA-Sharing-1.0.json
@@ -28,24 +28,31 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "CDLA-Sharing-1.0",
+          "category:permissive",
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "CDLA-Sharing-1.0",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
-      "contamination_effect": "none",
+      "contamination_effect": "module",
       "notes": "CDLA-Sharing-1.0 is permissive and does not impose viral effects on linked code."
     },
     "obligations": [

--- a/ospac/data/licenses/json/CECILL-1.0.json
+++ b/ospac/data/licenses/json/CECILL-1.0.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "CECILL-1.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "CECILL-1.0",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "When statically linking, only the modified module must remain under CECILL-1.0."

--- a/ospac/data/licenses/json/CECILL-1.1.json
+++ b/ospac/data/licenses/json/CECILL-1.1.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "CECILL-1.1",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "CECILL-1.1",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "Static linking requires that only the modified files/modules remain under CECILL-1.1, while dynamic linking allows for broader compatibility."

--- a/ospac/data/licenses/json/CECILL-2.0.json
+++ b/ospac/data/licenses/json/CECILL-2.0.json
@@ -28,36 +28,28 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "CECILL-2.0",
+          "category:permissive",
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
         ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "CECILL-2.0",
+          "category:permissive",
+          "category:public_domain",
+          "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
+          "category:copyleft_strong",
+          "category:network_copyleft"
         ]
       },
       "contamination_effect": "module",

--- a/ospac/data/licenses/json/CECILL-2.1.json
+++ b/ospac/data/licenses/json/CECILL-2.1.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "CECILL-2.1",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "CECILL-2.1",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "Static linking requires that the modified files remain under CECILL-2.1, while dynamic linking allows for broader compatibility."

--- a/ospac/data/licenses/json/CECILL-B.json
+++ b/ospac/data/licenses/json/CECILL-B.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "CECILL-B",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "CECILL-B",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "When statically linking with CECILL-B, only the modified files must remain under the same license."

--- a/ospac/data/licenses/json/CECILL-C.json
+++ b/ospac/data/licenses/json/CECILL-C.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "CECILL-C",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "CECILL-C",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "Static linking may require the modified module to remain under CECILL-C, while dynamic linking is more permissive."

--- a/ospac/data/licenses/json/CERN-OHL-1.1.json
+++ b/ospac/data/licenses/json/CERN-OHL-1.1.json
@@ -28,28 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/CERN-OHL-1.2.json
+++ b/ospac/data/licenses/json/CERN-OHL-1.2.json
@@ -28,35 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "CERN-OHL-1.2 is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/CERN-OHL-P-2.0.json
+++ b/ospac/data/licenses/json/CERN-OHL-P-2.0.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "CERN-OHL-P-2.0 is a permissive license, allowing for broad compatibility without viral effects."

--- a/ospac/data/licenses/json/CERN-OHL-S-2.0.json
+++ b/ospac/data/licenses/json/CERN-OHL-S-2.0.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "CERN-OHL-S-2.0",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "CERN-OHL-S-2.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "Using CERN-OHL-S-2.0 components in a project requires the entire combined work to be licensed under CERN-OHL-S-2.0."

--- a/ospac/data/licenses/json/CERN-OHL-W-2.0.json
+++ b/ospac/data/licenses/json/CERN-OHL-W-2.0.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "CERN-OHL-W-2.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "CERN-OHL-W-2.0",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "CERN-OHL-W-2.0 allows linking with permissive and weak copyleft licenses, but modified files must remain under the same license."

--- a/ospac/data/licenses/json/CFITSIO.json
+++ b/ospac/data/licenses/json/CFITSIO.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/CMU-Mach-nodoc.json
+++ b/ospac/data/licenses/json/CMU-Mach-nodoc.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "CMU-Mach-nodoc is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/CMU-Mach.json
+++ b/ospac/data/licenses/json/CMU-Mach.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/CNRI-Jython.json
+++ b/ospac/data/licenses/json/CNRI-Jython.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "CNRI-Jython is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/CNRI-Python-GPL-Compatible.json
+++ b/ospac/data/licenses/json/CNRI-Python-GPL-Compatible.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/CNRI-Python.json
+++ b/ospac/data/licenses/json/CNRI-Python.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "The CNRI-Python license is permissive and does not impose a viral effect on combined works."

--- a/ospac/data/licenses/json/COIL-1.0.json
+++ b/ospac/data/licenses/json/COIL-1.0.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "COIL-1.0 is a permissive license, allowing for broad compatibility without imposing restrictions on the licensing of combined works."

--- a/ospac/data/licenses/json/CPAL-1.0.json
+++ b/ospac/data/licenses/json/CPAL-1.0.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "CPAL-1.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "CPAL-1.0",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "CPAL-1.0 allows linking with permissive and weak copyleft licenses, but modifications to CPAL-1.0 components must remain under CPAL-1.0."

--- a/ospac/data/licenses/json/CPL-1.0.json
+++ b/ospac/data/licenses/json/CPL-1.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/CPOL-1.02.json
+++ b/ospac/data/licenses/json/CPOL-1.02.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "CPOL-1.02 is permissive and does not impose viral effects on combined works."

--- a/ospac/data/licenses/json/CUA-OPL-1.0.json
+++ b/ospac/data/licenses/json/CUA-OPL-1.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Caldera-no-preamble.json
+++ b/ospac/data/licenses/json/Caldera-no-preamble.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Caldera.json
+++ b/ospac/data/licenses/json/Caldera.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Caldera is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/Catharon.json
+++ b/ospac/data/licenses/json/Catharon.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Catharon is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/ClArtistic.json
+++ b/ospac/data/licenses/json/ClArtistic.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "ClArtistic license is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/Clips.json
+++ b/ospac/data/licenses/json/Clips.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Community-Spec-1.0.json
+++ b/ospac/data/licenses/json/Community-Spec-1.0.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Community-Spec-1.0 is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/Condor-1.1.json
+++ b/ospac/data/licenses/json/Condor-1.1.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Cornell-Lossless-JPEG.json
+++ b/ospac/data/licenses/json/Cornell-Lossless-JPEG.json
@@ -28,25 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Cronyx.json
+++ b/ospac/data/licenses/json/Cronyx.json
@@ -28,39 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0",
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0",
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Cronyx license is permissive and does not impose viral effects on combined works."

--- a/ospac/data/licenses/json/Crossword.json
+++ b/ospac/data/licenses/json/Crossword.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Crossword license is permissive and does not impose viral effects on combined works."

--- a/ospac/data/licenses/json/CryptoSwift.json
+++ b/ospac/data/licenses/json/CryptoSwift.json
@@ -28,41 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "ISC",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "ISC",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "CryptoSwift's permissive license allows for broad compatibility with other permissive licenses without imposing restrictions."

--- a/ospac/data/licenses/json/CrystalStacker.json
+++ b/ospac/data/licenses/json/CrystalStacker.json
@@ -28,25 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Cube.json
+++ b/ospac/data/licenses/json/Cube.json
@@ -28,39 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0",
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0",
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Cube license is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/D-FSL-1.0.json
+++ b/ospac/data/licenses/json/D-FSL-1.0.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "D-FSL-1.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "D-FSL-1.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "D-FSL-1.0 has a strong copyleft nature, requiring the entire combined work to be licensed under D-FSL-1.0."

--- a/ospac/data/licenses/json/DEC-3-Clause.json
+++ b/ospac/data/licenses/json/DEC-3-Clause.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/DL-DE-BY-2.0.json
+++ b/ospac/data/licenses/json/DL-DE-BY-2.0.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "DL-DE-BY-2.0 is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/DL-DE-ZERO-2.0.json
+++ b/ospac/data/licenses/json/DL-DE-ZERO-2.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strict"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strict"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/DOC.json
+++ b/ospac/data/licenses/json/DOC.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "DOC license is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/DRL-1.0.json
+++ b/ospac/data/licenses/json/DRL-1.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/DRL-1.1.json
+++ b/ospac/data/licenses/json/DRL-1.1.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/DSDP.json
+++ b/ospac/data/licenses/json/DSDP.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "DSDP is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/DocBook-DTD.json
+++ b/ospac/data/licenses/json/DocBook-DTD.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "DocBook-DTD is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/DocBook-Schema.json
+++ b/ospac/data/licenses/json/DocBook-Schema.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "DocBook-Schema is permissive and does not impose viral licensing effects."

--- a/ospac/data/licenses/json/DocBook-Stylesheet.json
+++ b/ospac/data/licenses/json/DocBook-Stylesheet.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/DocBook-XML.json
+++ b/ospac/data/licenses/json/DocBook-XML.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "DocBook-XML is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/Dotseqn.json
+++ b/ospac/data/licenses/json/Dotseqn.json
@@ -27,22 +27,18 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "contamination_effect": "none",
       "notes": "Dotseqn is a permissive license, allowing for broad compatibility without viral effects."

--- a/ospac/data/licenses/json/ECL-1.0.json
+++ b/ospac/data/licenses/json/ECL-1.0.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/ECL-2.0.json
+++ b/ospac/data/licenses/json/ECL-2.0.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "ECL-2.0 is a permissive license, allowing for broad compatibility with other permissive licenses."

--- a/ospac/data/licenses/json/EFL-1.0.json
+++ b/ospac/data/licenses/json/EFL-1.0.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "EFL-1.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "EFL-1.0",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "EFL-1.0 allows linking with permissive and weak copyleft licenses, but modified files must remain under EFL-1.0."

--- a/ospac/data/licenses/json/EFL-2.0.json
+++ b/ospac/data/licenses/json/EFL-2.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/EPICS.json
+++ b/ospac/data/licenses/json/EPICS.json
@@ -28,29 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/EPL-1.0.json
+++ b/ospac/data/licenses/json/EPL-1.0.json
@@ -28,25 +28,31 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "EPL-1.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "EPL-1.0",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
-      "contamination_effect": "none",
+      "contamination_effect": "module",
       "notes": "EPL-1.0 is a permissive license, allowing for broad compatibility without viral effects."
     },
     "obligations": [

--- a/ospac/data/licenses/json/EPL-2.0.json
+++ b/ospac/data/licenses/json/EPL-2.0.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "EPL-2.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "EPL-2.0",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "EPL-2.0 allows for linking with permissive and weak copyleft licenses, but modifications to EPL-2.0 code must remain under EPL-2.0."

--- a/ospac/data/licenses/json/ESA-PL-permissive-2.4.json
+++ b/ospac/data/licenses/json/ESA-PL-permissive-2.4.json
@@ -28,27 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
-        "requires_review": [
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/ESA-PL-strong-copyleft-2.4.json
+++ b/ospac/data/licenses/json/ESA-PL-strong-copyleft-2.4.json
@@ -28,22 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "ESA-PL-strong-copyleft-2.4",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "ESA-PL-strong-copyleft-2.4",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "Using ESA-PL-strong-copyleft-2.4-licensed components in a project requires the entire combined work to be licensed under ESA-PL-strong-copyleft-2.4."

--- a/ospac/data/licenses/json/ESA-PL-weak-copyleft-2.4.json
+++ b/ospac/data/licenses/json/ESA-PL-weak-copyleft-2.4.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "ESA-PL-weak-copyleft-2.4",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "ESA-PL-weak-copyleft-2.4",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "Only the modified files/modules must remain under the ESA-PL-weak-copyleft-2.4 license."

--- a/ospac/data/licenses/json/EUDatagrid.json
+++ b/ospac/data/licenses/json/EUDatagrid.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/EUPL-1.0.json
+++ b/ospac/data/licenses/json/EUPL-1.0.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "EUPL-1.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "EUPL-1.0",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "EUPL-1.0 allows linking with permissive and weak copyleft licenses, but modified files must remain under EUPL-1.0."

--- a/ospac/data/licenses/json/EUPL-1.1.json
+++ b/ospac/data/licenses/json/EUPL-1.1.json
@@ -28,25 +28,41 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "EUPL-1.1",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "EUPL-1.1",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
-      "contamination_effect": "module",
+      "contamination_effect": "full",
       "notes": "EUPL-1.1 allows linking with permissive and weak copyleft licenses, but modifications must remain under EUPL-1.1."
     },
     "obligations": [

--- a/ospac/data/licenses/json/EUPL-1.2.json
+++ b/ospac/data/licenses/json/EUPL-1.2.json
@@ -28,25 +28,41 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "EUPL-1.2",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "EUPL-1.2",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
-      "contamination_effect": "module",
+      "contamination_effect": "full",
       "notes": "EUPL-1.2 allows linking with permissive and weak copyleft licenses, but modified files must remain under EUPL-1.2."
     },
     "obligations": [

--- a/ospac/data/licenses/json/Elastic-2.0.json
+++ b/ospac/data/licenses/json/Elastic-2.0.json
@@ -27,28 +27,20 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "GPL",
-          "AGPL"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
-        ],
-        "incompatible_with": [
-          "GPL",
-          "AGPL"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
-      "contamination_effect": "none",
+      "contamination_effect": "unknown",
       "notes": "Elastic-2.0 is permissive and does not impose viral effects on linked code."
     },
     "obligations": [

--- a/ospac/data/licenses/json/Entessa.json
+++ b/ospac/data/licenses/json/Entessa.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/ErlPL-1.1.json
+++ b/ospac/data/licenses/json/ErlPL-1.1.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Eurosym.json
+++ b/ospac/data/licenses/json/Eurosym.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/FBM.json
+++ b/ospac/data/licenses/json/FBM.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strict"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strict"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/FDK-AAC.json
+++ b/ospac/data/licenses/json/FDK-AAC.json
@@ -28,35 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "FDK-AAC is permissive and does not impose viral effects on combined works."

--- a/ospac/data/licenses/json/FSFAP-no-warranty-disclaimer.json
+++ b/ospac/data/licenses/json/FSFAP-no-warranty-disclaimer.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/FSFAP.json
+++ b/ospac/data/licenses/json/FSFAP.json
@@ -28,25 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/FSFUL.json
+++ b/ospac/data/licenses/json/FSFUL.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "FSFUL is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/FSFULLR.json
+++ b/ospac/data/licenses/json/FSFULLR.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/FSFULLRSD.json
+++ b/ospac/data/licenses/json/FSFULLRSD.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/FSFULLRWD.json
+++ b/ospac/data/licenses/json/FSFULLRWD.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/FSL-1.1-ALv2.json
+++ b/ospac/data/licenses/json/FSL-1.1-ALv2.json
@@ -27,23 +27,18 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
-        ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "contamination_effect": "none",
       "notes": "FSL-1.1-ALv2 is permissive and does not impose restrictions on linking."

--- a/ospac/data/licenses/json/FSL-1.1-MIT.json
+++ b/ospac/data/licenses/json/FSL-1.1-MIT.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/FTL.json
+++ b/ospac/data/licenses/json/FTL.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Fair.json
+++ b/ospac/data/licenses/json/Fair.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Fair license is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/Ferguson-Twofish.json
+++ b/ospac/data/licenses/json/Ferguson-Twofish.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Frameworx-1.0.json
+++ b/ospac/data/licenses/json/Frameworx-1.0.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "Frameworx-1.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "Frameworx-1.0",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "Static linking requires that only the modified files remain under the Frameworx-1.0 license."

--- a/ospac/data/licenses/json/FreeBSD-DOC.json
+++ b/ospac/data/licenses/json/FreeBSD-DOC.json
@@ -28,34 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/FreeImage.json
+++ b/ospac/data/licenses/json/FreeImage.json
@@ -28,39 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "FreeImage is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/Furuseth.json
+++ b/ospac/data/licenses/json/Furuseth.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/GCR-docs.json
+++ b/ospac/data/licenses/json/GCR-docs.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "GCR-docs is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/GD.json
+++ b/ospac/data/licenses/json/GD.json
@@ -28,39 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0",
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0",
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "GD license is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/GFDL-1.1-invariants-only.json
+++ b/ospac/data/licenses/json/GFDL-1.1-invariants-only.json
@@ -28,22 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GFDL-1.1-invariants-only",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GFDL-1.1-invariants-only",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "Any work that uses GFDL-1.1-invariants-only licensed components must be licensed under the same terms."

--- a/ospac/data/licenses/json/GFDL-1.1-invariants-or-later.json
+++ b/ospac/data/licenses/json/GFDL-1.1-invariants-or-later.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "GFDL-1.1-invariants-or-later",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "GFDL-1.1-invariants-or-later",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "Any combined work must be licensed under GFDL-1.1-invariants-or-later."

--- a/ospac/data/licenses/json/GFDL-1.1-no-invariants-only.json
+++ b/ospac/data/licenses/json/GFDL-1.1-no-invariants-only.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "GFDL-1.1-no-invariants-only",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "GFDL-1.1-no-invariants-only",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "All derivative works must be licensed under GFDL-1.1-no-invariants-only when using linked components."

--- a/ospac/data/licenses/json/GFDL-1.1-no-invariants-or-later.json
+++ b/ospac/data/licenses/json/GFDL-1.1-no-invariants-or-later.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GFDL-1.1-no-invariants-or-later",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "GFDL-1.1-no-invariants-or-later",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "All derivative works must be licensed under GFDL-1.1-no-invariants-or-later."

--- a/ospac/data/licenses/json/GFDL-1.1-only.json
+++ b/ospac/data/licenses/json/GFDL-1.1-only.json
@@ -28,22 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GFDL-1.1-only",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GFDL-1.1-only",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "Using GFDL-1.1-only components in a project requires the entire work to be licensed under GFDL-1.1-only."

--- a/ospac/data/licenses/json/GFDL-1.1-or-later.json
+++ b/ospac/data/licenses/json/GFDL-1.1-or-later.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GFDL-1.1-or-later",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "GFDL-1.1-or-later",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "GFDL-1.1-or-later has a strong copyleft effect, requiring the entire combined work to be licensed under the same terms."

--- a/ospac/data/licenses/json/GFDL-1.1.json
+++ b/ospac/data/licenses/json/GFDL-1.1.json
@@ -28,28 +28,38 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GFDL-1.1",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
         "requires_review": [
-          "GPL-2.0",
-          "GPL-3.0"
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
         ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "GFDL-1.1",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
         "requires_review": [
-          "GPL-2.0",
-          "GPL-3.0"
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
         ]
       },
       "contamination_effect": "full",

--- a/ospac/data/licenses/json/GFDL-1.2-invariants-only.json
+++ b/ospac/data/licenses/json/GFDL-1.2-invariants-only.json
@@ -28,22 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GFDL-1.2-invariants-only",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GFDL-1.2-invariants-only",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "GFDL-1.2-invariants-only has a strong copyleft effect, requiring the entire combined work to be licensed under the same terms."

--- a/ospac/data/licenses/json/GFDL-1.2-invariants-or-later.json
+++ b/ospac/data/licenses/json/GFDL-1.2-invariants-or-later.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GFDL-1.2-invariants-or-later",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "GFDL-1.2-invariants-or-later",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "Using GFDL-1.2-invariants-or-later licensed components in a project requires the entire combined work to be licensed under the same terms."

--- a/ospac/data/licenses/json/GFDL-1.2-no-invariants-only.json
+++ b/ospac/data/licenses/json/GFDL-1.2-no-invariants-only.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "GFDL-1.2-no-invariants-only",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "GFDL-1.2-no-invariants-only",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "All derivative works must be licensed under GFDL-1.2-no-invariants-only when using components licensed under this license."

--- a/ospac/data/licenses/json/GFDL-1.2-no-invariants-or-later.json
+++ b/ospac/data/licenses/json/GFDL-1.2-no-invariants-or-later.json
@@ -28,25 +28,38 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GFDL-1.2-no-invariants-or-later",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
         "requires_review": [
-          "category:any"
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
         ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GFDL-1.2-no-invariants-or-later",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
         "requires_review": [
-          "category:copyleft_weak"
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
         ]
       },
       "contamination_effect": "full",

--- a/ospac/data/licenses/json/GFDL-1.2-only.json
+++ b/ospac/data/licenses/json/GFDL-1.2-only.json
@@ -28,22 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GFDL-1.2-only",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GFDL-1.2-only",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "GFDL-1.2-only has a strong copyleft requirement, meaning any combined work must be licensed under GFDL-1.2-only."

--- a/ospac/data/licenses/json/GFDL-1.2-or-later.json
+++ b/ospac/data/licenses/json/GFDL-1.2-or-later.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GFDL-1.2-or-later",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "GFDL-1.2-or-later",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "GFDL-1.2-or-later has a strong copyleft effect, requiring the entire combined work to be licensed under GFDL or a compatible license."

--- a/ospac/data/licenses/json/GFDL-1.2.json
+++ b/ospac/data/licenses/json/GFDL-1.2.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GFDL-1.2",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GFDL-1.2",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "GFDL-1.2 has a strong copyleft requirement, meaning any combined work must be licensed under GFDL-1.2."

--- a/ospac/data/licenses/json/GFDL-1.3-invariants-only.json
+++ b/ospac/data/licenses/json/GFDL-1.3-invariants-only.json
@@ -28,22 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GFDL-1.3-invariants-only",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GFDL-1.3-invariants-only",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "GFDL-1.3-invariants-only has a strong copyleft effect, requiring the entire combined work to be licensed under the same terms."

--- a/ospac/data/licenses/json/GFDL-1.3-invariants-or-later.json
+++ b/ospac/data/licenses/json/GFDL-1.3-invariants-or-later.json
@@ -28,22 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "GFDL-1.3-invariants-or-later",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "GFDL-1.3-invariants-or-later",
           "category:permissive",
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:public_domain"
         ],
-        "incompatible_with": [],
-        "requires_review": []
+        "incompatible_with": [
+          "category:proprietary"
+        ],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "Static linking with GFDL-1.3-invariants-or-later licensed components requires the entire combined work to be under the same license."

--- a/ospac/data/licenses/json/GFDL-1.3-no-invariants-only.json
+++ b/ospac/data/licenses/json/GFDL-1.3-no-invariants-only.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "GFDL-1.3-no-invariants-only",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "GFDL-1.3-no-invariants-only",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "All derivative works must be licensed under GFDL-1.3-no-invariants-only when using components licensed under this license."

--- a/ospac/data/licenses/json/GFDL-1.3-no-invariants-or-later.json
+++ b/ospac/data/licenses/json/GFDL-1.3-no-invariants-or-later.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GFDL-1.3-no-invariants-or-later",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "GFDL-1.3-no-invariants-or-later",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "All derivative works must be licensed under GFDL-1.3-no-invariants-or-later when linking statically."

--- a/ospac/data/licenses/json/GFDL-1.3-only.json
+++ b/ospac/data/licenses/json/GFDL-1.3-only.json
@@ -28,22 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GFDL-1.3-only",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GFDL-1.3-only",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "GFDL-1.3-only has a strong copyleft requirement, meaning that any combined work must be licensed under GFDL-1.3-only."

--- a/ospac/data/licenses/json/GFDL-1.3-or-later.json
+++ b/ospac/data/licenses/json/GFDL-1.3-or-later.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GFDL-1.3-or-later",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "GFDL-1.3-or-later",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "GFDL-1.3-or-later has a strong copyleft effect, requiring the entire combined work to be licensed under GFDL or a compatible license."

--- a/ospac/data/licenses/json/GFDL-1.3.json
+++ b/ospac/data/licenses/json/GFDL-1.3.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GFDL-1.3",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GFDL-1.3",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "GFDL-1.3 has a strong copyleft requirement, meaning any combined work must be licensed under GFDL-1.3."

--- a/ospac/data/licenses/json/GL2PS.json
+++ b/ospac/data/licenses/json/GL2PS.json
@@ -28,36 +28,28 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "GL2PS",
+          "category:permissive",
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
         ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "GL2PS",
+          "category:permissive",
+          "category:public_domain",
+          "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
+          "category:copyleft_strong",
+          "category:network_copyleft"
         ]
       },
       "contamination_effect": "module",

--- a/ospac/data/licenses/json/GLWTPL.json
+++ b/ospac/data/licenses/json/GLWTPL.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "GLWTPL is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/GPL-1.0+.json
+++ b/ospac/data/licenses/json/GPL-1.0+.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GPL-1.0+",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GPL-1.0+",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "Any combined work that includes GPL-1.0+ licensed components must be licensed under GPL-1.0+."

--- a/ospac/data/licenses/json/GPL-1.0-only.json
+++ b/ospac/data/licenses/json/GPL-1.0-only.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GPL-1.0-only",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GPL-1.0-only",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "Any code that uses GPL-1.0-only components must also be licensed under GPL-1.0-only."

--- a/ospac/data/licenses/json/GPL-1.0-or-later.json
+++ b/ospac/data/licenses/json/GPL-1.0-or-later.json
@@ -28,23 +28,38 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GPL-1.0-or-later",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GPL-1.0-or-later",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
         "requires_review": [
-          "category:copyleft_weak"
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
         ]
       },
       "contamination_effect": "full",

--- a/ospac/data/licenses/json/GPL-1.0.json
+++ b/ospac/data/licenses/json/GPL-1.0.json
@@ -28,31 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "GPL-1.0",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "GPL-2.0",
-          "GPL-3.0",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "GPL-1.0",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "GPL-2.0",
-          "GPL-3.0",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "Any code that uses GPL-1.0 components must also be licensed under GPL-1.0."

--- a/ospac/data/licenses/json/GPL-2.0+.json
+++ b/ospac/data/licenses/json/GPL-2.0+.json
@@ -28,31 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "GPL-2.0+",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "GPL-2.0+",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "Any code that uses GPL-2.0+ components must also be licensed under GPL-2.0+."

--- a/ospac/data/licenses/json/GPL-2.0-only.json
+++ b/ospac/data/licenses/json/GPL-2.0-only.json
@@ -28,23 +28,51 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GPL-2.0-only",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary",
+          "Apache-2.0",
+          "BSD-4-Clause",
+          "BSD-4-Clause-Shortened",
+          "BSD-4-Clause-UC",
+          "GPL-3.0",
+          "GPL-3.0-only"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GPL-2.0-only",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary",
+          "Apache-2.0",
+          "BSD-4-Clause",
+          "BSD-4-Clause-Shortened",
+          "BSD-4-Clause-UC",
+          "GPL-3.0",
+          "GPL-3.0-only"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "Any combined work that includes GPL-2.0-only licensed code must be licensed under GPL-2.0-only."

--- a/ospac/data/licenses/json/GPL-2.0-or-later.json
+++ b/ospac/data/licenses/json/GPL-2.0-or-later.json
@@ -28,31 +28,45 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "GPL-2.0-or-later",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
+          "category:proprietary",
+          "BSD-4-Clause",
+          "BSD-4-Clause-Shortened",
+          "BSD-4-Clause-UC"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "GPL-2.0-or-later",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
+          "category:proprietary",
+          "BSD-4-Clause",
+          "BSD-4-Clause-Shortened",
+          "BSD-4-Clause-UC"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "Using GPL-2.0-or-later licensed components in a project requires the entire project to be licensed under GPL-2.0-or-later."

--- a/ospac/data/licenses/json/GPL-2.0-with-GCC-exception.json
+++ b/ospac/data/licenses/json/GPL-2.0-with-GCC-exception.json
@@ -28,36 +28,38 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "GPL-2.0-with-GCC-exception",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
         "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
         ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "GPL-2.0-with-GCC-exception",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
         "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
         ]
       },
       "contamination_effect": "full",

--- a/ospac/data/licenses/json/GPL-2.0-with-autoconf-exception.json
+++ b/ospac/data/licenses/json/GPL-2.0-with-autoconf-exception.json
@@ -28,31 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "GPL-2.0-with-autoconf-exception",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "GPL-2.0-with-autoconf-exception",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "The GPL-2.0-with-autoconf-exception requires that any combined work remains under the GPL-2.0 license."

--- a/ospac/data/licenses/json/GPL-2.0-with-bison-exception.json
+++ b/ospac/data/licenses/json/GPL-2.0-with-bison-exception.json
@@ -28,28 +28,38 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "GPL-2.0-with-bison-exception",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
+          "category:proprietary"
         ],
         "requires_review": [
-          "category:copyleft_strong"
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
         ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "GPL-2.0-with-bison-exception",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
+          "category:proprietary"
         ],
         "requires_review": [
-          "category:copyleft_strong"
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
         ]
       },
       "contamination_effect": "full",

--- a/ospac/data/licenses/json/GPL-2.0-with-classpath-exception.json
+++ b/ospac/data/licenses/json/GPL-2.0-with-classpath-exception.json
@@ -28,35 +28,31 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "GPL-2.0-with-classpath-exception",
+          "category:permissive",
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "GPL-2.0",
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "GPL-2.0-with-classpath-exception",
+          "category:permissive",
+          "category:public_domain",
+          "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "GPL-2.0",
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
-      "contamination_effect": "none",
+      "contamination_effect": "module",
       "notes": "The GPL-2.0-with-classpath-exception allows for compatibility with permissive licenses without imposing copyleft requirements."
     },
     "obligations": [

--- a/ospac/data/licenses/json/GPL-2.0-with-font-exception.json
+++ b/ospac/data/licenses/json/GPL-2.0-with-font-exception.json
@@ -28,27 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "GPL-2.0-with-font-exception",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "GPL-2.0",
-          "GPL-3.0",
-          "AGPL-3.0"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "GPL-2.0-with-font-exception",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "GPL-2.0",
-          "GPL-3.0",
-          "AGPL-3.0"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "Using GPL-2.0-with-font-exception components in a project requires the entire project to be licensed under GPL-2.0-with-font-exception."

--- a/ospac/data/licenses/json/GPL-2.0.json
+++ b/ospac/data/licenses/json/GPL-2.0.json
@@ -28,36 +28,50 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "GPL-2.0",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
+          "category:proprietary",
+          "Apache-2.0",
+          "BSD-4-Clause",
+          "BSD-4-Clause-Shortened",
+          "BSD-4-Clause-UC",
           "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
+          "GPL-3.0-only"
         ],
         "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
         ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "GPL-2.0",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
+          "category:proprietary",
+          "Apache-2.0",
+          "BSD-4-Clause",
+          "BSD-4-Clause-Shortened",
+          "BSD-4-Clause-UC",
           "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
+          "GPL-3.0-only"
         ],
         "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
         ]
       },
       "contamination_effect": "full",

--- a/ospac/data/licenses/json/GPL-3.0+.json
+++ b/ospac/data/licenses/json/GPL-3.0+.json
@@ -28,28 +28,38 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GPL-3.0+",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
         "requires_review": [
-          "GPL-2.0",
-          "AGPL-3.0"
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
         ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "GPL-3.0+",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
         "requires_review": [
-          "GPL-2.0",
-          "AGPL-3.0"
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
         ]
       },
       "contamination_effect": "full",

--- a/ospac/data/licenses/json/GPL-3.0-only.json
+++ b/ospac/data/licenses/json/GPL-3.0-only.json
@@ -28,23 +28,49 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GPL-3.0-only",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary",
+          "BSD-4-Clause",
+          "BSD-4-Clause-Shortened",
+          "BSD-4-Clause-UC",
+          "GPL-2.0",
+          "GPL-2.0-only"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GPL-3.0-only",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary",
+          "BSD-4-Clause",
+          "BSD-4-Clause-Shortened",
+          "BSD-4-Clause-UC",
+          "GPL-2.0",
+          "GPL-2.0-only"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "Any combined work that includes GPL-3.0-only licensed components must be licensed under GPL-3.0-only."

--- a/ospac/data/licenses/json/GPL-3.0-or-later.json
+++ b/ospac/data/licenses/json/GPL-3.0-or-later.json
@@ -28,23 +28,45 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GPL-3.0-or-later",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary",
+          "BSD-4-Clause",
+          "BSD-4-Clause-Shortened",
+          "BSD-4-Clause-UC"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GPL-3.0-or-later",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary",
+          "BSD-4-Clause",
+          "BSD-4-Clause-Shortened",
+          "BSD-4-Clause-UC"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "Using GPL-3.0-or-later licensed components in a project requires the entire combined work to be licensed under GPL-3.0-or-later."

--- a/ospac/data/licenses/json/GPL-3.0-with-GCC-exception.json
+++ b/ospac/data/licenses/json/GPL-3.0-with-GCC-exception.json
@@ -28,36 +28,38 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "GPL-3.0-with-GCC-exception",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
         "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
         ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "GPL-3.0-with-GCC-exception",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
         "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
         ]
       },
       "contamination_effect": "full",

--- a/ospac/data/licenses/json/GPL-3.0-with-autoconf-exception.json
+++ b/ospac/data/licenses/json/GPL-3.0-with-autoconf-exception.json
@@ -28,36 +28,38 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "GPL-3.0-with-autoconf-exception",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
         "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
         ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "GPL-3.0-with-autoconf-exception",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
         "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
         ]
       },
       "contamination_effect": "full",

--- a/ospac/data/licenses/json/GPL-3.0.json
+++ b/ospac/data/licenses/json/GPL-3.0.json
@@ -28,23 +28,49 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GPL-3.0",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary",
+          "BSD-4-Clause",
+          "BSD-4-Clause-Shortened",
+          "BSD-4-Clause-UC",
+          "GPL-2.0",
+          "GPL-2.0-only"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "GPL-3.0",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary",
+          "BSD-4-Clause",
+          "BSD-4-Clause-Shortened",
+          "BSD-4-Clause-UC",
+          "GPL-2.0",
+          "GPL-2.0-only"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "Any combined work that includes GPL-3.0-licensed components must be licensed under GPL-3.0."

--- a/ospac/data/licenses/json/Game-Programming-Gems.json
+++ b/ospac/data/licenses/json/Game-Programming-Gems.json
@@ -28,25 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Giftware.json
+++ b/ospac/data/licenses/json/Giftware.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Giftware license is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/Glide.json
+++ b/ospac/data/licenses/json/Glide.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "Glide",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "Glide",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "When using Glide-licensed components, only the modified files/modules must remain under the same license."

--- a/ospac/data/licenses/json/Glulxe.json
+++ b/ospac/data/licenses/json/Glulxe.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Glulxe is permissive and does not impose restrictions on the licensing of combined works."

--- a/ospac/data/licenses/json/Graphics-Gems.json
+++ b/ospac/data/licenses/json/Graphics-Gems.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Graphics-Gems license is permissive and does not impose viral effects on combined works."

--- a/ospac/data/licenses/json/Gutmann.json
+++ b/ospac/data/licenses/json/Gutmann.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "The Gutmann license is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/HDF5.json
+++ b/ospac/data/licenses/json/HDF5.json
@@ -28,39 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "HDF5 is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/HIDAPI.json
+++ b/ospac/data/licenses/json/HIDAPI.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/HP-1986.json
+++ b/ospac/data/licenses/json/HP-1986.json
@@ -28,25 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/HP-1989.json
+++ b/ospac/data/licenses/json/HP-1989.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/HPND-DEC.json
+++ b/ospac/data/licenses/json/HPND-DEC.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "HPND-DEC is permissive and does not impose viral effects on combined works."

--- a/ospac/data/licenses/json/HPND-Fenneberg-Livingston.json
+++ b/ospac/data/licenses/json/HPND-Fenneberg-Livingston.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/HPND-INRIA-IMAG.json
+++ b/ospac/data/licenses/json/HPND-INRIA-IMAG.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "HPND-INRIA-IMAG is a permissive license with no viral effect on linked code."

--- a/ospac/data/licenses/json/HPND-Intel.json
+++ b/ospac/data/licenses/json/HPND-Intel.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/HPND-Kevlin-Henney.json
+++ b/ospac/data/licenses/json/HPND-Kevlin-Henney.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "HPND-Kevlin-Henney is a permissive license with no viral effect."

--- a/ospac/data/licenses/json/HPND-MIT-disclaimer.json
+++ b/ospac/data/licenses/json/HPND-MIT-disclaimer.json
@@ -28,41 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "HPND-MIT-disclaimer is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/HPND-Markus-Kuhn.json
+++ b/ospac/data/licenses/json/HPND-Markus-Kuhn.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/HPND-Netrek.json
+++ b/ospac/data/licenses/json/HPND-Netrek.json
@@ -28,36 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "ISC",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "ISC",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/HPND-Pbmplus.json
+++ b/ospac/data/licenses/json/HPND-Pbmplus.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/HPND-SMC.json
+++ b/ospac/data/licenses/json/HPND-SMC.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "HPND-SMC is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/HPND-UC-export-US.json
+++ b/ospac/data/licenses/json/HPND-UC-export-US.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/HPND-UC.json
+++ b/ospac/data/licenses/json/HPND-UC.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/HPND-doc-sell.json
+++ b/ospac/data/licenses/json/HPND-doc-sell.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/HPND-doc.json
+++ b/ospac/data/licenses/json/HPND-doc.json
@@ -28,20 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/HPND-export-US-acknowledgement.json
+++ b/ospac/data/licenses/json/HPND-export-US-acknowledgement.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "HPND-export-US-acknowledgement is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/HPND-export-US-modify.json
+++ b/ospac/data/licenses/json/HPND-export-US-modify.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "HPND-export-US-modify is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/HPND-export-US.json
+++ b/ospac/data/licenses/json/HPND-export-US.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/HPND-export2-US.json
+++ b/ospac/data/licenses/json/HPND-export2-US.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/HPND-merchantability-variant.json
+++ b/ospac/data/licenses/json/HPND-merchantability-variant.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/HPND-sell-MIT-disclaimer-xserver.json
+++ b/ospac/data/licenses/json/HPND-sell-MIT-disclaimer-xserver.json
@@ -28,45 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "Public Domain",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "Public Domain",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "HPND-sell-MIT-disclaimer-xserver is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/HPND-sell-regexpr.json
+++ b/ospac/data/licenses/json/HPND-sell-regexpr.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "HPND-sell-regexpr is permissive and does not impose viral effects on combined works."

--- a/ospac/data/licenses/json/HPND-sell-variant-MIT-disclaimer-rev.json
+++ b/ospac/data/licenses/json/HPND-sell-variant-MIT-disclaimer-rev.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/HPND-sell-variant-MIT-disclaimer.json
+++ b/ospac/data/licenses/json/HPND-sell-variant-MIT-disclaimer.json
@@ -28,20 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/HPND-sell-variant-critical-systems.json
+++ b/ospac/data/licenses/json/HPND-sell-variant-critical-systems.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "HPND-sell-variant-critical-systems is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/HPND-sell-variant.json
+++ b/ospac/data/licenses/json/HPND-sell-variant.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "HPND-sell-variant is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/HPND.json
+++ b/ospac/data/licenses/json/HPND.json
@@ -28,43 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "HPND is a permissive license, allowing for broad compatibility without viral effects."

--- a/ospac/data/licenses/json/HTMLTIDY.json
+++ b/ospac/data/licenses/json/HTMLTIDY.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "HTMLTIDY's permissive license allows for broad compatibility without imposing restrictions on derivative works."

--- a/ospac/data/licenses/json/HaskellReport.json
+++ b/ospac/data/licenses/json/HaskellReport.json
@@ -28,25 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Hippocratic-2.1.json
+++ b/ospac/data/licenses/json/Hippocratic-2.1.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Hippocratic-2.1 is permissive and does not impose viral effects on combined works."

--- a/ospac/data/licenses/json/IBM-pibs.json
+++ b/ospac/data/licenses/json/IBM-pibs.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/ICU.json
+++ b/ospac/data/licenses/json/ICU.json
@@ -28,38 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "LGPL-2.1",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "LGPL-2.1",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/IEC-Code-Components-EULA.json
+++ b/ospac/data/licenses/json/IEC-Code-Components-EULA.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/IJG-short.json
+++ b/ospac/data/licenses/json/IJG-short.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "IJG-short license is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/IJG.json
+++ b/ospac/data/licenses/json/IJG.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/IPA.json
+++ b/ospac/data/licenses/json/IPA.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/IPL-1.0.json
+++ b/ospac/data/licenses/json/IPL-1.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/ISC-Veillard.json
+++ b/ospac/data/licenses/json/ISC-Veillard.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/ISC.json
+++ b/ospac/data/licenses/json/ISC.json
@@ -28,41 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "ISC license is permissive and does not impose restrictions on the licensing of combined works."

--- a/ospac/data/licenses/json/ISO-permission.json
+++ b/ospac/data/licenses/json/ISO-permission.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/ImageMagick.json
+++ b/ospac/data/licenses/json/ImageMagick.json
@@ -28,35 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "ImageMagick's permissive license allows for broad compatibility with other permissive licenses without imposing viral effects."

--- a/ospac/data/licenses/json/Imlib2.json
+++ b/ospac/data/licenses/json/Imlib2.json
@@ -28,36 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Info-ZIP.json
+++ b/ospac/data/licenses/json/Info-ZIP.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Informatica.json
+++ b/ospac/data/licenses/json/Informatica.json
@@ -27,25 +27,18 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft",
-          "category:strong_copyleft"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:strong_copyleft"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "contamination_effect": "none",
       "notes": "Informatica-licensed components can be used with permissive licenses without imposing restrictions."

--- a/ospac/data/licenses/json/Inner-Net-2.0.json
+++ b/ospac/data/licenses/json/Inner-Net-2.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/InnoSetup.json
+++ b/ospac/data/licenses/json/InnoSetup.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL",
-          "AGPL",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL",
-          "AGPL",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Intel-ACPI.json
+++ b/ospac/data/licenses/json/Intel-ACPI.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Intel.json
+++ b/ospac/data/licenses/json/Intel.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Interbase-1.0.json
+++ b/ospac/data/licenses/json/Interbase-1.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/JPL-image.json
+++ b/ospac/data/licenses/json/JPL-image.json
@@ -28,24 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/JPNIC.json
+++ b/ospac/data/licenses/json/JPNIC.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "JPNIC license is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/JSON.json
+++ b/ospac/data/licenses/json/JSON.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "JSON license is permissive and does not impose viral effects on combined works."

--- a/ospac/data/licenses/json/Jam.json
+++ b/ospac/data/licenses/json/Jam.json
@@ -28,39 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0",
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0",
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Jam license is permissive and does not impose viral effects on combined works."

--- a/ospac/data/licenses/json/JasPer-2.0.json
+++ b/ospac/data/licenses/json/JasPer-2.0.json
@@ -28,28 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Kastrup.json
+++ b/ospac/data/licenses/json/Kastrup.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Kazlib.json
+++ b/ospac/data/licenses/json/Kazlib.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Kazlib is a permissive license, allowing for broad compatibility with other permissive licenses without imposing viral effects."

--- a/ospac/data/licenses/json/Knuth-CTAN.json
+++ b/ospac/data/licenses/json/Knuth-CTAN.json
@@ -27,26 +27,18 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL",
-          "AGPL"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL",
-          "AGPL"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "contamination_effect": "none",
       "notes": "Knuth-CTAN license allows use with permissive licenses without imposing restrictions."

--- a/ospac/data/licenses/json/LAL-1.2.json
+++ b/ospac/data/licenses/json/LAL-1.2.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "LAL-1.2",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "LAL-1.2",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "LAL-1.2 has a strong copyleft nature, requiring the entire combined work to be licensed under LAL-1.2."

--- a/ospac/data/licenses/json/LAL-1.3.json
+++ b/ospac/data/licenses/json/LAL-1.3.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "LAL-1.3",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "LAL-1.3",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "LAL-1.3 has a strong copyleft nature, requiring the entire combined work to be licensed under LAL-1.3."

--- a/ospac/data/licenses/json/LGPL-2.0+.json
+++ b/ospac/data/licenses/json/LGPL-2.0+.json
@@ -28,27 +28,31 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "LGPL-2.0+",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak",
           "LGPL-2.0+",
-          "GPL-2.0"
+          "category:permissive",
+          "category:public_domain",
+          "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
-      "contamination_effect": "derivative",
+      "contamination_effect": "module",
       "notes": "Static linking requires derivative works to be licensed under LGPL-2.0+."
     },
     "obligations": [

--- a/ospac/data/licenses/json/LGPL-2.0-only.json
+++ b/ospac/data/licenses/json/LGPL-2.0-only.json
@@ -28,39 +28,31 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "LGPL-2.0-only",
+          "category:permissive",
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": [
-          "GPL-2.0",
-          "category:copyleft_weak"
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
         ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "GPL-2.0",
+          "LGPL-2.0-only",
+          "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
+        ],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
         ]
       },
-      "contamination_effect": "none",
+      "contamination_effect": "module",
       "notes": "LGPL-2.0-only allows linking with permissive licenses without imposing the same license on the entire work."
     },
     "obligations": [

--- a/ospac/data/licenses/json/LGPL-2.0-or-later.json
+++ b/ospac/data/licenses/json/LGPL-2.0-or-later.json
@@ -28,37 +28,31 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "LGPL-2.0-or-later",
+          "category:permissive",
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "GPL-2.0",
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
+          "LGPL-2.0-or-later",
           "category:permissive",
-          "LGPL-2.0",
-          "LGPL-3.0"
+          "category:public_domain",
+          "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "GPL-2.0",
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
-      "contamination_effect": "none",
+      "contamination_effect": "module",
       "notes": "LGPL-2.0-or-later allows for dynamic linking with permissive licenses without imposing copyleft requirements."
     },
     "obligations": [

--- a/ospac/data/licenses/json/LGPL-2.0.json
+++ b/ospac/data/licenses/json/LGPL-2.0.json
@@ -28,25 +28,31 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "LGPL-2.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "LGPL-2.0",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
-      "contamination_effect": "derivative",
+      "contamination_effect": "module",
       "notes": "Static linking creates a derivative work, while dynamic linking does not impose the same restrictions."
     },
     "obligations": [

--- a/ospac/data/licenses/json/LGPL-2.1+.json
+++ b/ospac/data/licenses/json/LGPL-2.1+.json
@@ -28,31 +28,31 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "LGPL-2.1+",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "GPL-2.0",
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "LGPL-2.1+",
           "category:permissive",
-          "category:copyleft_weak",
-          "LGPL-2.0",
-          "LGPL-3.0"
+          "category:public_domain",
+          "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "GPL-2.0",
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
-      "contamination_effect": "none",
+      "contamination_effect": "module",
       "notes": "LGPL-2.1+ allows for linking with permissive and weak copyleft licenses without imposing the same license on the entire work."
     },
     "obligations": [

--- a/ospac/data/licenses/json/LGPL-2.1-only.json
+++ b/ospac/data/licenses/json/LGPL-2.1-only.json
@@ -28,25 +28,31 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "LGPL-2.1-only",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "LGPL-2.1-only",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
-      "contamination_effect": "derivative",
+      "contamination_effect": "module",
       "notes": "Static linking requires that the entire derivative work remains under LGPL-2.1-only, while dynamic linking allows for more flexibility."
     },
     "obligations": [

--- a/ospac/data/licenses/json/LGPL-2.1-or-later.json
+++ b/ospac/data/licenses/json/LGPL-2.1-or-later.json
@@ -28,36 +28,31 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "LGPL-2.1-or-later",
+          "category:permissive",
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "GPL-2.0",
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
+          "LGPL-2.1-or-later",
           "category:permissive",
-          "LGPL-2.0"
+          "category:public_domain",
+          "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "GPL-2.0",
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
-      "contamination_effect": "none",
+      "contamination_effect": "module",
       "notes": "LGPL-2.1-or-later allows linking with permissive licenses without imposing the same license on the entire work."
     },
     "obligations": [

--- a/ospac/data/licenses/json/LGPL-2.1.json
+++ b/ospac/data/licenses/json/LGPL-2.1.json
@@ -28,33 +28,31 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "LGPL-2.1",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "GPL-2.0",
-          "GPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": [
-          "MPL-2.0",
-          "AGPL-3.0"
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
         ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "LGPL-2.1",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "GPL-2.0",
-          "GPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": [
-          "MPL-2.0",
-          "AGPL-3.0"
+          "category:copyleft_strong",
+          "category:network_copyleft"
         ]
       },
-      "contamination_effect": "none",
+      "contamination_effect": "module",
       "notes": "LGPL-2.1 allows for linking with both permissive and weak copyleft licenses without imposing the same license on the entire work."
     },
     "obligations": [

--- a/ospac/data/licenses/json/LGPL-3.0+.json
+++ b/ospac/data/licenses/json/LGPL-3.0+.json
@@ -28,29 +28,31 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "LGPL-3.0+",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": [
-          "MPL-2.0"
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
         ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "LGPL-3.0+",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
-      "contamination_effect": "derivative",
+      "contamination_effect": "module",
       "notes": "Static linking may impose LGPL requirements on the entire derivative work, while dynamic linking generally does not."
     },
     "obligations": [

--- a/ospac/data/licenses/json/LGPL-3.0-only.json
+++ b/ospac/data/licenses/json/LGPL-3.0-only.json
@@ -28,25 +28,31 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "LGPL-3.0-only",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "LGPL-3.0-only",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
-      "contamination_effect": "derivative",
+      "contamination_effect": "module",
       "notes": "Static linking requires that derivative works based on the LGPL-3.0-only component remain under the same license."
     },
     "obligations": [

--- a/ospac/data/licenses/json/LGPL-3.0-or-later.json
+++ b/ospac/data/licenses/json/LGPL-3.0-or-later.json
@@ -28,32 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "LGPL-3.0-or-later",
+          "category:permissive",
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "GPL-3.0-only",
-          "AGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": [
-          "MPL-2.0"
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
         ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
+          "LGPL-3.0-or-later",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "GPL-3.0-only",
-          "AGPL-3.0"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "Static linking may impose LGPL requirements on the linked code, while dynamic linking generally allows for broader compatibility."

--- a/ospac/data/licenses/json/LGPL-3.0.json
+++ b/ospac/data/licenses/json/LGPL-3.0.json
@@ -28,26 +28,31 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "LGPL-3.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "LGPL-3.0",
           "category:permissive",
-          "category:copyleft_weak",
-          "category:any"
+          "category:public_domain",
+          "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
-      "contamination_effect": "derivative",
+      "contamination_effect": "module",
       "notes": "Static linking with LGPL-3.0 components requires derivative works to be licensed under LGPL-3.0, while dynamic linking is more permissive."
     },
     "obligations": [

--- a/ospac/data/licenses/json/LGPLLR.json
+++ b/ospac/data/licenses/json/LGPLLR.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "LGPLLR",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "LGPLLR",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "Static linking requires that modifications to the LGPLLR component remain under the same license."

--- a/ospac/data/licenses/json/LOOP.json
+++ b/ospac/data/licenses/json/LOOP.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/LPD-document.json
+++ b/ospac/data/licenses/json/LPD-document.json
@@ -28,24 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/LPL-1.0.json
+++ b/ospac/data/licenses/json/LPL-1.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/LPL-1.02.json
+++ b/ospac/data/licenses/json/LPL-1.02.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/LPPL-1.0.json
+++ b/ospac/data/licenses/json/LPPL-1.0.json
@@ -27,26 +27,20 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
-        ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
-      "contamination_effect": "module",
+      "contamination_effect": "none",
       "notes": "When using LPPL-1.0 components, only the modified files must remain under the same license."
     },
     "obligations": [

--- a/ospac/data/licenses/json/LPPL-1.1.json
+++ b/ospac/data/licenses/json/LPPL-1.1.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "LPPL-1.1",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "LPPL-1.1",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "Only the modified files/modules must remain under the LPPL-1.1 license."

--- a/ospac/data/licenses/json/LPPL-1.2.json
+++ b/ospac/data/licenses/json/LPPL-1.2.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "LPPL-1.2",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "LPPL-1.2",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "Only the modified files/modules must remain under the LPPL-1.2 license."

--- a/ospac/data/licenses/json/LPPL-1.3a.json
+++ b/ospac/data/licenses/json/LPPL-1.3a.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "LPPL-1.3a",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:strong_copyleft"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "LPPL-1.3a",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:strong_copyleft"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "Only the modified files/modules must remain under the LPPL-1.3a license."

--- a/ospac/data/licenses/json/LPPL-1.3c.json
+++ b/ospac/data/licenses/json/LPPL-1.3c.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "LPPL-1.3c",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "LPPL-1.3c",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "When statically linking, only the modified files must remain under LPPL-1.3c."

--- a/ospac/data/licenses/json/LZMA-SDK-9.11-to-9.20.json
+++ b/ospac/data/licenses/json/LZMA-SDK-9.11-to-9.20.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strict"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strict"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/LZMA-SDK-9.22.json
+++ b/ospac/data/licenses/json/LZMA-SDK-9.22.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Latex2e-translated-notice.json
+++ b/ospac/data/licenses/json/Latex2e-translated-notice.json
@@ -28,20 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Latex2e.json
+++ b/ospac/data/licenses/json/Latex2e.json
@@ -28,20 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Leptonica.json
+++ b/ospac/data/licenses/json/Leptonica.json
@@ -28,41 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Leptonica's permissive license allows for broad compatibility with other permissive licenses without imposing viral effects."

--- a/ospac/data/licenses/json/LiLiQ-P-1.1.json
+++ b/ospac/data/licenses/json/LiLiQ-P-1.1.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "LiLiQ-P-1.1 is permissive and does not impose a viral effect on combined works."

--- a/ospac/data/licenses/json/LiLiQ-R-1.1.json
+++ b/ospac/data/licenses/json/LiLiQ-R-1.1.json
@@ -28,26 +28,38 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "LiLiQ-R-1.1",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
         "requires_review": [
-          "category:any"
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
         ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "LiLiQ-R-1.1",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
         "requires_review": [
-          "category:any"
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
         ]
       },
       "contamination_effect": "full",

--- a/ospac/data/licenses/json/LiLiQ-Rplus-1.1.json
+++ b/ospac/data/licenses/json/LiLiQ-Rplus-1.1.json
@@ -28,22 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "LiLiQ-Rplus-1.1",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "LiLiQ-Rplus-1.1",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "LiLiQ-Rplus-1.1 has a strong copyleft nature, requiring the entire combined work to be licensed under LiLiQ-Rplus-1.1 when linked statically."

--- a/ospac/data/licenses/json/Libpng.json
+++ b/ospac/data/licenses/json/Libpng.json
@@ -28,41 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Libpng's permissive license allows for broad compatibility without imposing restrictions on the licensing of the combined work."

--- a/ospac/data/licenses/json/Linux-OpenIB.json
+++ b/ospac/data/licenses/json/Linux-OpenIB.json
@@ -28,41 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Linux-OpenIB is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/Linux-man-pages-1-para.json
+++ b/ospac/data/licenses/json/Linux-man-pages-1-para.json
@@ -28,36 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Linux-man-pages-copyleft-2-para.json
+++ b/ospac/data/licenses/json/Linux-man-pages-copyleft-2-para.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "Linux-man-pages-copyleft-2-para",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "Linux-man-pages-copyleft-2-para",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "Only the modified files/modules must remain under the same license."

--- a/ospac/data/licenses/json/Linux-man-pages-copyleft-var.json
+++ b/ospac/data/licenses/json/Linux-man-pages-copyleft-var.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "Linux-man-pages-copyleft-var",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "Linux-man-pages-copyleft-var",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "Only the modified files/modules must remain under the Linux-man-pages-copyleft-var license."

--- a/ospac/data/licenses/json/Linux-man-pages-copyleft.json
+++ b/ospac/data/licenses/json/Linux-man-pages-copyleft.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "Linux-man-pages-copyleft",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "Linux-man-pages-copyleft",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "Using Linux-man-pages-copyleft-licensed components in a project requires the entire combined work to be licensed under the same terms."

--- a/ospac/data/licenses/json/Lucida-Bitmap-Fonts.json
+++ b/ospac/data/licenses/json/Lucida-Bitmap-Fonts.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/MIPS.json
+++ b/ospac/data/licenses/json/MIPS.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "MIPS is a permissive license, allowing for broad compatibility with other permissive licenses."

--- a/ospac/data/licenses/json/MIT-0.json
+++ b/ospac/data/licenses/json/MIT-0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/MIT-CMU.json
+++ b/ospac/data/licenses/json/MIT-CMU.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/MIT-Click.json
+++ b/ospac/data/licenses/json/MIT-Click.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/MIT-Festival.json
+++ b/ospac/data/licenses/json/MIT-Festival.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/MIT-Khronos-old.json
+++ b/ospac/data/licenses/json/MIT-Khronos-old.json
@@ -28,20 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/MIT-Modern-Variant.json
+++ b/ospac/data/licenses/json/MIT-Modern-Variant.json
@@ -28,43 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0",
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0",
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "MIT-Modern-Variant is permissive and does not impose viral effects on combined works."

--- a/ospac/data/licenses/json/MIT-STK.json
+++ b/ospac/data/licenses/json/MIT-STK.json
@@ -28,45 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "Public Domain",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "Public Domain",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "MIT-STK is a permissive license, allowing for broad compatibility without imposing restrictions on derivative works."

--- a/ospac/data/licenses/json/MIT-Wu.json
+++ b/ospac/data/licenses/json/MIT-Wu.json
@@ -28,40 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "Public Domain",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "Public Domain",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/MIT-advertising.json
+++ b/ospac/data/licenses/json/MIT-advertising.json
@@ -28,20 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/MIT-enna.json
+++ b/ospac/data/licenses/json/MIT-enna.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/MIT-feh.json
+++ b/ospac/data/licenses/json/MIT-feh.json
@@ -28,23 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/MIT-open-group.json
+++ b/ospac/data/licenses/json/MIT-open-group.json
@@ -28,20 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/MIT-testregex.json
+++ b/ospac/data/licenses/json/MIT-testregex.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/MIT.json
+++ b/ospac/data/licenses/json/MIT.json
@@ -28,38 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "MIT",
-          "Zlib",
-          "Unlicense"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "LGPL-2.1"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "MIT",
-          "Zlib",
-          "Unlicense"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "LGPL-2.1"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/MITNFA.json
+++ b/ospac/data/licenses/json/MITNFA.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/MMIXware.json
+++ b/ospac/data/licenses/json/MMIXware.json
@@ -27,28 +27,20 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft",
-          "category:strong_copyleft"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft",
-          "category:strong_copyleft"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
-      "contamination_effect": "full",
+      "contamination_effect": "none",
       "notes": "MMIXware's no_derivatives license imposes restrictions on derivative works, affecting compatibility with copyleft licenses."
     },
     "obligations": [

--- a/ospac/data/licenses/json/MMPL-1.0.1.json
+++ b/ospac/data/licenses/json/MMPL-1.0.1.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "MMPL-1.0.1",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "MMPL-1.0.1",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "When statically linking, only the modified files/modules must remain under MMPL-1.0.1."

--- a/ospac/data/licenses/json/MPEG-SSG.json
+++ b/ospac/data/licenses/json/MPEG-SSG.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/MPL-1.0.json
+++ b/ospac/data/licenses/json/MPL-1.0.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "MPL-1.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "MPL-1.0",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "MPL-1.0 allows linking with permissive and weak copyleft licenses, but modifications to MPL-1.0 code must remain under MPL-1.0."

--- a/ospac/data/licenses/json/MPL-1.1.json
+++ b/ospac/data/licenses/json/MPL-1.1.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "MPL-1.1",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "MPL-1.1",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "MPL-1.1 allows for static linking with the requirement that modifications to MPL-1.1 code remain under the same license."

--- a/ospac/data/licenses/json/MPL-2.0-no-copyleft-exception.json
+++ b/ospac/data/licenses/json/MPL-2.0-no-copyleft-exception.json
@@ -28,24 +28,31 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "MPL-2.0-no-copyleft-exception",
+          "category:permissive",
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "MPL-2.0-no-copyleft-exception",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
-      "contamination_effect": "none",
+      "contamination_effect": "module",
       "notes": "MPL-2.0-no-copyleft-exception is permissive and does not impose viral effects on linked code."
     },
     "obligations": [

--- a/ospac/data/licenses/json/MPL-2.0.json
+++ b/ospac/data/licenses/json/MPL-2.0.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "MPL-2.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "MPL-2.0",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "MPL-2.0 allows linking with permissive and weak copyleft licenses, but modifications to MPL-2.0 code must remain under MPL-2.0."

--- a/ospac/data/licenses/json/MS-LPL.json
+++ b/ospac/data/licenses/json/MS-LPL.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/MS-PL.json
+++ b/ospac/data/licenses/json/MS-PL.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/MS-RL.json
+++ b/ospac/data/licenses/json/MS-RL.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "MS-RL",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "MS-RL",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "MS-RL allows linking with permissive and weak copyleft licenses, but modified files must remain under MS-RL."

--- a/ospac/data/licenses/json/MTLL.json
+++ b/ospac/data/licenses/json/MTLL.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "MTLL is permissive and does not impose viral effects on combined works."

--- a/ospac/data/licenses/json/MVT-1.1.json
+++ b/ospac/data/licenses/json/MVT-1.1.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "MVT-1.1 is permissive and does not impose viral effects on combined works."

--- a/ospac/data/licenses/json/Mackerras-3-Clause-acknowledgment.json
+++ b/ospac/data/licenses/json/Mackerras-3-Clause-acknowledgment.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Mackerras-3-Clause.json
+++ b/ospac/data/licenses/json/Mackerras-3-Clause.json
@@ -28,28 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/MakeIndex.json
+++ b/ospac/data/licenses/json/MakeIndex.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Martin-Birgmeier.json
+++ b/ospac/data/licenses/json/Martin-Birgmeier.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "The Martin-Birgmeier license is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/McPhee-slideshow.json
+++ b/ospac/data/licenses/json/McPhee-slideshow.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Minpack.json
+++ b/ospac/data/licenses/json/Minpack.json
@@ -28,34 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
-        "requires_review": [
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Minpack is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/MirOS.json
+++ b/ospac/data/licenses/json/MirOS.json
@@ -28,45 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "Public Domain",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "LGPL-2.1",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "Public Domain",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "LGPL-2.1",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "MirOS license is permissive and does not impose restrictions on the licensing of combined works."

--- a/ospac/data/licenses/json/Motosoto.json
+++ b/ospac/data/licenses/json/Motosoto.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "Motosoto",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "Motosoto",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "Motosoto-licensed components allow linking with permissive and weak copyleft licenses, but modifications must remain under Motosoto."

--- a/ospac/data/licenses/json/MulanPSL-1.0.json
+++ b/ospac/data/licenses/json/MulanPSL-1.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/MulanPSL-2.0.json
+++ b/ospac/data/licenses/json/MulanPSL-2.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Multics.json
+++ b/ospac/data/licenses/json/Multics.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Mup.json
+++ b/ospac/data/licenses/json/Mup.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/NAIST-2003.json
+++ b/ospac/data/licenses/json/NAIST-2003.json
@@ -28,20 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/NASA-1.3.json
+++ b/ospac/data/licenses/json/NASA-1.3.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/NBPL-1.0.json
+++ b/ospac/data/licenses/json/NBPL-1.0.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "NBPL-1.0 is a permissive license with no viral effect on combined works."

--- a/ospac/data/licenses/json/NCBI-PD.json
+++ b/ospac/data/licenses/json/NCBI-PD.json
@@ -28,24 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft",
-          "category:strong_copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft",
-          "category:strong_copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/NCGL-UK-2.0.json
+++ b/ospac/data/licenses/json/NCGL-UK-2.0.json
@@ -27,28 +27,20 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "GPL",
-          "AGPL"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
-        ],
-        "incompatible_with": [
-          "GPL",
-          "AGPL"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
-      "contamination_effect": "module",
+      "contamination_effect": "none",
       "notes": "Static linking requires that the modified file/module remains under the NCGL-UK-2.0 license."
     },
     "obligations": [

--- a/ospac/data/licenses/json/NCL.json
+++ b/ospac/data/licenses/json/NCL.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/NCSA.json
+++ b/ospac/data/licenses/json/NCSA.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/NGPL.json
+++ b/ospac/data/licenses/json/NGPL.json
@@ -28,26 +28,38 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "NGPL",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
         "requires_review": [
-          "category:any"
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
         ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "NGPL",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
         "requires_review": [
-          "category:any"
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
         ]
       },
       "contamination_effect": "full",

--- a/ospac/data/licenses/json/NICTA-1.0.json
+++ b/ospac/data/licenses/json/NICTA-1.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/NIST-PD-TNT.json
+++ b/ospac/data/licenses/json/NIST-PD-TNT.json
@@ -28,24 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/NIST-PD-fallback.json
+++ b/ospac/data/licenses/json/NIST-PD-fallback.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/NIST-PD.json
+++ b/ospac/data/licenses/json/NIST-PD.json
@@ -28,24 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft",
-          "category:strong_copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft",
-          "category:strong_copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/NIST-Software.json
+++ b/ospac/data/licenses/json/NIST-Software.json
@@ -28,25 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft",
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/NLOD-1.0.json
+++ b/ospac/data/licenses/json/NLOD-1.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/NLOD-2.0.json
+++ b/ospac/data/licenses/json/NLOD-2.0.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/NLPL.json
+++ b/ospac/data/licenses/json/NLPL.json
@@ -28,23 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft",
-          "category:strong_copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:strong_copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/NOSL.json
+++ b/ospac/data/licenses/json/NOSL.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/NPL-1.0.json
+++ b/ospac/data/licenses/json/NPL-1.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/NPL-1.1.json
+++ b/ospac/data/licenses/json/NPL-1.1.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "NPL-1.1",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "NPL-1.1",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "NPL-1.1 allows static linking with permissive and weak copyleft licenses, but requires modified files to remain under NPL-1.1."

--- a/ospac/data/licenses/json/NPOSL-3.0.json
+++ b/ospac/data/licenses/json/NPOSL-3.0.json
@@ -27,26 +27,20 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
-        ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
-        ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
-      "contamination_effect": "full",
+      "contamination_effect": "none",
       "notes": "NPOSL-3.0 has a strong copyleft nature, requiring the entire combined work to be licensed under NPOSL-3.0."
     },
     "obligations": [

--- a/ospac/data/licenses/json/NRL.json
+++ b/ospac/data/licenses/json/NRL.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "NRL-licensed components can be used freely with permissive licenses without imposing restrictions."

--- a/ospac/data/licenses/json/NTIA-PD.json
+++ b/ospac/data/licenses/json/NTIA-PD.json
@@ -28,23 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft",
-          "category:strong_copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:strong_copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/NTP-0.json
+++ b/ospac/data/licenses/json/NTP-0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/NTP.json
+++ b/ospac/data/licenses/json/NTP.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Naumen.json
+++ b/ospac/data/licenses/json/Naumen.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Net-SNMP.json
+++ b/ospac/data/licenses/json/Net-SNMP.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/NetCDF.json
+++ b/ospac/data/licenses/json/NetCDF.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "NetCDF is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/Newsletr.json
+++ b/ospac/data/licenses/json/Newsletr.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Nokia.json
+++ b/ospac/data/licenses/json/Nokia.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Noweb.json
+++ b/ospac/data/licenses/json/Noweb.json
@@ -28,39 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0",
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0",
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Noweb's permissive license allows for broad compatibility with other permissive licenses without imposing restrictions."

--- a/ospac/data/licenses/json/Nunit.json
+++ b/ospac/data/licenses/json/Nunit.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/O-UDA-1.0.json
+++ b/ospac/data/licenses/json/O-UDA-1.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/OAR.json
+++ b/ospac/data/licenses/json/OAR.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "OAR license is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/OCCT-PL.json
+++ b/ospac/data/licenses/json/OCCT-PL.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "OCCT-PL",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "OCCT-PL",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "Static linking requires that only the modified files/modules remain under the OCCT-PL license."

--- a/ospac/data/licenses/json/OCLC-2.0.json
+++ b/ospac/data/licenses/json/OCLC-2.0.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "OCLC-2.0 is a permissive license, allowing for broad compatibility without imposing viral effects."

--- a/ospac/data/licenses/json/ODC-By-1.0.json
+++ b/ospac/data/licenses/json/ODC-By-1.0.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/ODbL-1.0.json
+++ b/ospac/data/licenses/json/ODbL-1.0.json
@@ -28,25 +28,31 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "ODbL-1.0",
+          "category:permissive",
+          "category:public_domain"
         ],
-        "incompatible_with": [
+        "incompatible_with": [],
+        "requires_review": [
           "category:copyleft_weak",
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "ODbL-1.0",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
-      "contamination_effect": "full",
+      "contamination_effect": "module",
       "notes": "Using ODbL-1.0-licensed components in a project requires the entire work to be licensed under ODbL-1.0."
     },
     "obligations": [

--- a/ospac/data/licenses/json/OFFIS.json
+++ b/ospac/data/licenses/json/OFFIS.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/OFL-1.0-RFN.json
+++ b/ospac/data/licenses/json/OFL-1.0-RFN.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/OFL-1.0-no-RFN.json
+++ b/ospac/data/licenses/json/OFL-1.0-no-RFN.json
@@ -28,23 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/OFL-1.0.json
+++ b/ospac/data/licenses/json/OFL-1.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/OFL-1.1-RFN.json
+++ b/ospac/data/licenses/json/OFL-1.1-RFN.json
@@ -28,24 +28,31 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "OFL-1.1-RFN",
+          "category:permissive",
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "OFL-1.1-RFN",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
-      "contamination_effect": "none",
+      "contamination_effect": "module",
       "notes": "OFL-1.1-RFN is permissive and does not impose viral effects on linked code."
     },
     "obligations": [

--- a/ospac/data/licenses/json/OFL-1.1-no-RFN.json
+++ b/ospac/data/licenses/json/OFL-1.1-no-RFN.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/OFL-1.1.json
+++ b/ospac/data/licenses/json/OFL-1.1.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/OGC-1.0.json
+++ b/ospac/data/licenses/json/OGC-1.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/OGDL-Taiwan-1.0.json
+++ b/ospac/data/licenses/json/OGDL-Taiwan-1.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/OGL-Canada-2.0.json
+++ b/ospac/data/licenses/json/OGL-Canada-2.0.json
@@ -28,20 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/OGL-UK-1.0.json
+++ b/ospac/data/licenses/json/OGL-UK-1.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/OGL-UK-2.0.json
+++ b/ospac/data/licenses/json/OGL-UK-2.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/OGL-UK-3.0.json
+++ b/ospac/data/licenses/json/OGL-UK-3.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/OGTSL.json
+++ b/ospac/data/licenses/json/OGTSL.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/OLDAP-1.1.json
+++ b/ospac/data/licenses/json/OLDAP-1.1.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/OLDAP-1.2.json
+++ b/ospac/data/licenses/json/OLDAP-1.2.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/OLDAP-1.3.json
+++ b/ospac/data/licenses/json/OLDAP-1.3.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/OLDAP-1.4.json
+++ b/ospac/data/licenses/json/OLDAP-1.4.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/OLDAP-2.0.1.json
+++ b/ospac/data/licenses/json/OLDAP-2.0.1.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/OLDAP-2.0.json
+++ b/ospac/data/licenses/json/OLDAP-2.0.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/OLDAP-2.1.json
+++ b/ospac/data/licenses/json/OLDAP-2.1.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/OLDAP-2.2.1.json
+++ b/ospac/data/licenses/json/OLDAP-2.2.1.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/OLDAP-2.2.2.json
+++ b/ospac/data/licenses/json/OLDAP-2.2.2.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/OLDAP-2.2.json
+++ b/ospac/data/licenses/json/OLDAP-2.2.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/OLDAP-2.3.json
+++ b/ospac/data/licenses/json/OLDAP-2.3.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/OLDAP-2.4.json
+++ b/ospac/data/licenses/json/OLDAP-2.4.json
@@ -28,39 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0",
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0",
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "OLDAP-2.4 is permissive and does not impose viral effects on combined works."

--- a/ospac/data/licenses/json/OLDAP-2.5.json
+++ b/ospac/data/licenses/json/OLDAP-2.5.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/OLDAP-2.6.json
+++ b/ospac/data/licenses/json/OLDAP-2.6.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/OLDAP-2.7.json
+++ b/ospac/data/licenses/json/OLDAP-2.7.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "OLDAP-2.7 is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/OLDAP-2.8.json
+++ b/ospac/data/licenses/json/OLDAP-2.8.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/OLFL-1.3.json
+++ b/ospac/data/licenses/json/OLFL-1.3.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/OML.json
+++ b/ospac/data/licenses/json/OML.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "OML is permissive and does not impose viral effects on combined works."

--- a/ospac/data/licenses/json/OPL-1.0.json
+++ b/ospac/data/licenses/json/OPL-1.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/OPL-UK-3.0.json
+++ b/ospac/data/licenses/json/OPL-UK-3.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/OPUBL-1.0.json
+++ b/ospac/data/licenses/json/OPUBL-1.0.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "OPUBL-1.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "OPUBL-1.0",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "OPUBL-1.0 allows linking with permissive and weak copyleft licenses, but modified files must remain under OPUBL-1.0."

--- a/ospac/data/licenses/json/OSC-1.0.json
+++ b/ospac/data/licenses/json/OSC-1.0.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "OSC-1.0 is a permissive license, allowing for broad compatibility without viral effects."

--- a/ospac/data/licenses/json/OSET-PL-2.1.json
+++ b/ospac/data/licenses/json/OSET-PL-2.1.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "OSET-PL-2.1",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "OSET-PL-2.1",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "Only the modified files/modules must remain under the OSET-PL-2.1 license."

--- a/ospac/data/licenses/json/OSL-1.0.json
+++ b/ospac/data/licenses/json/OSL-1.0.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "OSL-1.0",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "OSL-1.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "Using OSL-1.0-licensed components in a combined work requires the entire work to be licensed under OSL-1.0."

--- a/ospac/data/licenses/json/OSL-1.1.json
+++ b/ospac/data/licenses/json/OSL-1.1.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "OSL-1.1",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "OSL-1.1",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "OSL-1.1 has a strong copyleft nature, requiring the entire combined work to be licensed under OSL-1.1."

--- a/ospac/data/licenses/json/OSL-2.0.json
+++ b/ospac/data/licenses/json/OSL-2.0.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "OSL-2.0",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "OSL-2.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "Using OSL-2.0-licensed components in a combined work requires the entire work to be licensed under OSL-2.0."

--- a/ospac/data/licenses/json/OSL-2.1.json
+++ b/ospac/data/licenses/json/OSL-2.1.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "OSL-2.1",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "OSL-2.1",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "OSL-2.1 has a strong copyleft nature, requiring the entire combined work to be licensed under OSL-2.1."

--- a/ospac/data/licenses/json/OSL-3.0.json
+++ b/ospac/data/licenses/json/OSL-3.0.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "OSL-3.0",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "OSL-3.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "OSL-3.0 has a strong copyleft nature, requiring the entire combined work to be licensed under OSL-3.0."

--- a/ospac/data/licenses/json/OSSP.json
+++ b/ospac/data/licenses/json/OSSP.json
@@ -28,39 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0",
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0",
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "OSSP is permissive and does not impose viral effects on combined works."

--- a/ospac/data/licenses/json/OpenMDW-1.0.json
+++ b/ospac/data/licenses/json/OpenMDW-1.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/OpenPBS-2.3.json
+++ b/ospac/data/licenses/json/OpenPBS-2.3.json
@@ -27,26 +27,18 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "GPL",
-          "AGPL"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "GPL",
-          "AGPL"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "contamination_effect": "none",
       "notes": "OpenPBS-2.3 is noncommercial and permissive, allowing use with permissive licenses without viral effects."

--- a/ospac/data/licenses/json/OpenSSL-standalone.json
+++ b/ospac/data/licenses/json/OpenSSL-standalone.json
@@ -28,38 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/OpenSSL.json
+++ b/ospac/data/licenses/json/OpenSSL.json
@@ -28,43 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0",
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0",
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "OpenSSL's permissive license allows for broad compatibility with other permissive licenses without imposing viral effects."

--- a/ospac/data/licenses/json/OpenVision.json
+++ b/ospac/data/licenses/json/OpenVision.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/PADL.json
+++ b/ospac/data/licenses/json/PADL.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "PADL is a permissive license, allowing for broad compatibility without viral effects."

--- a/ospac/data/licenses/json/PDDL-1.0.json
+++ b/ospac/data/licenses/json/PDDL-1.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/PHP-3.0.json
+++ b/ospac/data/licenses/json/PHP-3.0.json
@@ -28,43 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "PHP-3.0 is a permissive license with no viral effect on code that uses it."

--- a/ospac/data/licenses/json/PHP-3.01.json
+++ b/ospac/data/licenses/json/PHP-3.01.json
@@ -28,25 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/PPL.json
+++ b/ospac/data/licenses/json/PPL.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "PPL",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "PPL",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "Using PPL-licensed components in a project requires the entire combined work to be licensed under PPL."

--- a/ospac/data/licenses/json/PSF-2.0.json
+++ b/ospac/data/licenses/json/PSF-2.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/ParaType-Free-Font-1.3.json
+++ b/ospac/data/licenses/json/ParaType-Free-Font-1.3.json
@@ -28,25 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Parity-6.0.0.json
+++ b/ospac/data/licenses/json/Parity-6.0.0.json
@@ -28,22 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "Parity-6.0.0",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "Parity-6.0.0",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "All derivative works must be licensed under Parity-6.0.0 when using its components."

--- a/ospac/data/licenses/json/Parity-7.0.0.json
+++ b/ospac/data/licenses/json/Parity-7.0.0.json
@@ -28,22 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "Parity-7.0.0",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "Parity-7.0.0",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "Using Parity-7.0.0 in a project requires the entire combined work to be licensed under Parity-7.0.0 or a compatible license."

--- a/ospac/data/licenses/json/Pixar.json
+++ b/ospac/data/licenses/json/Pixar.json
@@ -28,25 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Plexus.json
+++ b/ospac/data/licenses/json/Plexus.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Plexus is a permissive license, allowing for broad compatibility with other permissive licenses."

--- a/ospac/data/licenses/json/PolyForm-Noncommercial-1.0.0.json
+++ b/ospac/data/licenses/json/PolyForm-Noncommercial-1.0.0.json
@@ -27,24 +27,18 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_weak"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_weak"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "contamination_effect": "none",
       "notes": "PolyForm-Noncommercial-1.0.0 allows use with permissive licenses but is incompatible with copyleft licenses."

--- a/ospac/data/licenses/json/PolyForm-Small-Business-1.0.0.json
+++ b/ospac/data/licenses/json/PolyForm-Small-Business-1.0.0.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "PolyForm-Small-Business-1.0.0 is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/PostgreSQL.json
+++ b/ospac/data/licenses/json/PostgreSQL.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Python-2.0.1.json
+++ b/ospac/data/licenses/json/Python-2.0.1.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Python-2.0.json
+++ b/ospac/data/licenses/json/Python-2.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/QPL-1.0-INRIA-2004.json
+++ b/ospac/data/licenses/json/QPL-1.0-INRIA-2004.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "QPL-1.0-INRIA-2004",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "QPL-1.0-INRIA-2004",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "QPL-1.0-INRIA-2004 allows linking with permissive and weak copyleft licenses, but modified files must remain under QPL."

--- a/ospac/data/licenses/json/QPL-1.0.json
+++ b/ospac/data/licenses/json/QPL-1.0.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "QPL-1.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "QPL-1.0",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "QPL-1.0 allows linking with permissive and weak copyleft licenses, but modified files must remain under QPL-1.0."

--- a/ospac/data/licenses/json/Qhull.json
+++ b/ospac/data/licenses/json/Qhull.json
@@ -28,41 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "Zlib",
-          "Public Domain",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "Zlib",
-          "Public Domain",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Qhull's permissive license allows for broad compatibility with other permissive licenses without imposing restrictions."

--- a/ospac/data/licenses/json/RHeCos-1.1.json
+++ b/ospac/data/licenses/json/RHeCos-1.1.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/RPL-1.1.json
+++ b/ospac/data/licenses/json/RPL-1.1.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "RPL-1.1",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "RPL-1.1",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "RPL-1.1 requires that any derivative works or combined works remain under the same license."

--- a/ospac/data/licenses/json/RPL-1.5.json
+++ b/ospac/data/licenses/json/RPL-1.5.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "RPL-1.5",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "RPL-1.5",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "RPL-1.5 has a strong copyleft nature, requiring the entire combined work to be licensed under RPL-1.5."

--- a/ospac/data/licenses/json/RPSL-1.0.json
+++ b/ospac/data/licenses/json/RPSL-1.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/RSA-MD.json
+++ b/ospac/data/licenses/json/RSA-MD.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/RSCPL.json
+++ b/ospac/data/licenses/json/RSCPL.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Rdisc.json
+++ b/ospac/data/licenses/json/Rdisc.json
@@ -28,39 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0",
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0",
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Rdisc is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/Ruby-pty.json
+++ b/ospac/data/licenses/json/Ruby-pty.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Ruby.json
+++ b/ospac/data/licenses/json/Ruby.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/SAX-PD-2.0.json
+++ b/ospac/data/licenses/json/SAX-PD-2.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strict"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strict"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/SAX-PD.json
+++ b/ospac/data/licenses/json/SAX-PD.json
@@ -28,24 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft",
-          "category:strong_copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft",
-          "category:strong_copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/SCEA.json
+++ b/ospac/data/licenses/json/SCEA.json
@@ -27,33 +27,20 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause"
-        ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause"
-        ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
-      "contamination_effect": "none",
+      "contamination_effect": "unknown",
       "notes": "SCEA-licensed components can be used with permissive licenses without imposing restrictions."
     },
     "obligations": [

--- a/ospac/data/licenses/json/SGI-B-1.0.json
+++ b/ospac/data/licenses/json/SGI-B-1.0.json
@@ -28,35 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "SGI-B-1.0 is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/SGI-B-1.1.json
+++ b/ospac/data/licenses/json/SGI-B-1.1.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "SGI-B-1.1 is a permissive license with no viral effect on linked code."

--- a/ospac/data/licenses/json/SGI-B-2.0.json
+++ b/ospac/data/licenses/json/SGI-B-2.0.json
@@ -28,35 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "SGI-B-2.0 is a permissive license, allowing for broad compatibility without viral effects."

--- a/ospac/data/licenses/json/SGI-OpenGL.json
+++ b/ospac/data/licenses/json/SGI-OpenGL.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "SGI-OpenGL is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/SGMLUG-PM.json
+++ b/ospac/data/licenses/json/SGMLUG-PM.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "SGMLUG-PM is a permissive license, allowing for broad compatibility without viral effects."

--- a/ospac/data/licenses/json/SGP4.json
+++ b/ospac/data/licenses/json/SGP4.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/SHL-0.5.json
+++ b/ospac/data/licenses/json/SHL-0.5.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/SHL-0.51.json
+++ b/ospac/data/licenses/json/SHL-0.51.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/SISSL-1.2.json
+++ b/ospac/data/licenses/json/SISSL-1.2.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/SISSL.json
+++ b/ospac/data/licenses/json/SISSL.json
@@ -28,36 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/SL.json
+++ b/ospac/data/licenses/json/SL.json
@@ -28,23 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft",
-          "category:strong_copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:strong_copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/SMAIL-GPL.json
+++ b/ospac/data/licenses/json/SMAIL-GPL.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "SMAIL-GPL",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "SMAIL-GPL",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "Any work using SMAIL-GPL components must be licensed under SMAIL-GPL."

--- a/ospac/data/licenses/json/SMLNJ.json
+++ b/ospac/data/licenses/json/SMLNJ.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/SMPPL.json
+++ b/ospac/data/licenses/json/SMPPL.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/SNIA.json
+++ b/ospac/data/licenses/json/SNIA.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/SOFA.json
+++ b/ospac/data/licenses/json/SOFA.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/SPL-1.0.json
+++ b/ospac/data/licenses/json/SPL-1.0.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/SSH-OpenSSH.json
+++ b/ospac/data/licenses/json/SSH-OpenSSH.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/SSH-short.json
+++ b/ospac/data/licenses/json/SSH-short.json
@@ -28,36 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/SSLeay-standalone.json
+++ b/ospac/data/licenses/json/SSLeay-standalone.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/SSPL-1.0.json
+++ b/ospac/data/licenses/json/SSPL-1.0.json
@@ -28,25 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "SSPL-1.0",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong",
-          "AGPL-3.0",
-          "GPL-3.0"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "SSPL-1.0",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "AGPL-3.0",
-          "GPL-3.0",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "Using SSPL-1.0 components in a project requires the entire project to be licensed under SSPL-1.0."

--- a/ospac/data/licenses/json/SUL-1.0.json
+++ b/ospac/data/licenses/json/SUL-1.0.json
@@ -27,28 +27,20 @@
     },
     "compatibility": {
       "static_linking": {
-        "compatible_with": [
-          "category:permissive"
-        ],
-        "incompatible_with": [
-          "category:copyleft",
-          "GPL",
-          "AGPL"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
       "dynamic_linking": {
-        "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
-        ],
-        "incompatible_with": [
-          "GPL",
-          "AGPL"
-        ],
-        "requires_review": []
+        "compatible_with": [],
+        "incompatible_with": [],
+        "requires_review": [
+          "category:any"
+        ]
       },
-      "contamination_effect": "module",
+      "contamination_effect": "none",
       "notes": "SUL-1.0 allows static linking with permissive licenses but requires modified files to remain under SUL-1.0."
     },
     "obligations": [

--- a/ospac/data/licenses/json/SWL.json
+++ b/ospac/data/licenses/json/SWL.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "SWL license is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/Saxpath.json
+++ b/ospac/data/licenses/json/Saxpath.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/SchemeReport.json
+++ b/ospac/data/licenses/json/SchemeReport.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Sendmail-8.23.json
+++ b/ospac/data/licenses/json/Sendmail-8.23.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Sendmail-Open-Source-1.1.json
+++ b/ospac/data/licenses/json/Sendmail-Open-Source-1.1.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Sendmail-Open-Source-1.1 is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/Sendmail.json
+++ b/ospac/data/licenses/json/Sendmail.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/SimPL-2.0.json
+++ b/ospac/data/licenses/json/SimPL-2.0.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "SimPL-2.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "SimPL-2.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "Using SimPL-2.0-licensed components in a project requires the entire combined work to be licensed under SimPL-2.0."

--- a/ospac/data/licenses/json/Sleepycat.json
+++ b/ospac/data/licenses/json/Sleepycat.json
@@ -28,25 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Soundex.json
+++ b/ospac/data/licenses/json/Soundex.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Spencer-86.json
+++ b/ospac/data/licenses/json/Spencer-86.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Spencer-94.json
+++ b/ospac/data/licenses/json/Spencer-94.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Spencer-99.json
+++ b/ospac/data/licenses/json/Spencer-99.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Spencer-99 is a permissive license with no viral effect on linked code."

--- a/ospac/data/licenses/json/StandardML-NJ.json
+++ b/ospac/data/licenses/json/StandardML-NJ.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "StandardML-NJ is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/SugarCRM-1.1.3.json
+++ b/ospac/data/licenses/json/SugarCRM-1.1.3.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "SugarCRM-1.1.3",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "SugarCRM-1.1.3",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "Static linking requires that only the modified module remains under the same license."

--- a/ospac/data/licenses/json/Sun-PPP-2000.json
+++ b/ospac/data/licenses/json/Sun-PPP-2000.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Sun-PPP.json
+++ b/ospac/data/licenses/json/Sun-PPP.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/SunPro.json
+++ b/ospac/data/licenses/json/SunPro.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "SunPro license is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/Symlinks.json
+++ b/ospac/data/licenses/json/Symlinks.json
@@ -28,25 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/TAPR-OHL-1.0.json
+++ b/ospac/data/licenses/json/TAPR-OHL-1.0.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "TAPR-OHL-1.0 is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/TCL.json
+++ b/ospac/data/licenses/json/TCL.json
@@ -28,38 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "Public Domain",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "Public Domain",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/TCP-wrappers.json
+++ b/ospac/data/licenses/json/TCP-wrappers.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/TGPPL-1.0.json
+++ b/ospac/data/licenses/json/TGPPL-1.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/TMate.json
+++ b/ospac/data/licenses/json/TMate.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "TMate is a permissive license, allowing for broad compatibility with other permissive licenses."

--- a/ospac/data/licenses/json/TORQUE-1.1.json
+++ b/ospac/data/licenses/json/TORQUE-1.1.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "TORQUE-1.1 is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/TOSL.json
+++ b/ospac/data/licenses/json/TOSL.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/TPDL.json
+++ b/ospac/data/licenses/json/TPDL.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "TPDL is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/TPL-1.0.json
+++ b/ospac/data/licenses/json/TPL-1.0.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "TPL-1.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "TPL-1.0",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "TPL-1.0 allows linking with permissive and weak copyleft licenses, but modified files must remain under TPL-1.0."

--- a/ospac/data/licenses/json/TTWL.json
+++ b/ospac/data/licenses/json/TTWL.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/TTYP0.json
+++ b/ospac/data/licenses/json/TTYP0.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "TTYP0 is a permissive license, allowing for broad compatibility without viral effects."

--- a/ospac/data/licenses/json/TU-Berlin-1.0.json
+++ b/ospac/data/licenses/json/TU-Berlin-1.0.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/TU-Berlin-2.0.json
+++ b/ospac/data/licenses/json/TU-Berlin-2.0.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/TekHVC.json
+++ b/ospac/data/licenses/json/TekHVC.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/TermReadKey.json
+++ b/ospac/data/licenses/json/TermReadKey.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "TermReadKey is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/ThirdEye.json
+++ b/ospac/data/licenses/json/ThirdEye.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/TrustedQSL.json
+++ b/ospac/data/licenses/json/TrustedQSL.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "TrustedQSL is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/UCAR.json
+++ b/ospac/data/licenses/json/UCAR.json
@@ -28,25 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/UCL-1.0.json
+++ b/ospac/data/licenses/json/UCL-1.0.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "UCL-1.0 is a permissive license, allowing for broad compatibility with other permissive licenses."

--- a/ospac/data/licenses/json/UMich-Merit.json
+++ b/ospac/data/licenses/json/UMich-Merit.json
@@ -28,20 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/UPL-1.0.json
+++ b/ospac/data/licenses/json/UPL-1.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/URT-RLE.json
+++ b/ospac/data/licenses/json/URT-RLE.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "URT-RLE is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/Ubuntu-font-1.0.json
+++ b/ospac/data/licenses/json/Ubuntu-font-1.0.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/UnRAR.json
+++ b/ospac/data/licenses/json/UnRAR.json
@@ -28,36 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "Zlib",
-          "Public Domain",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "Zlib",
-          "Public Domain",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Unicode-3.0.json
+++ b/ospac/data/licenses/json/Unicode-3.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Unicode-DFS-2015.json
+++ b/ospac/data/licenses/json/Unicode-DFS-2015.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Unicode-DFS-2016.json
+++ b/ospac/data/licenses/json/Unicode-DFS-2016.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Unicode-TOU.json
+++ b/ospac/data/licenses/json/Unicode-TOU.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/UnixCrypt.json
+++ b/ospac/data/licenses/json/UnixCrypt.json
@@ -28,41 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "UnixCrypt is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/Unlicense-libtelnet.json
+++ b/ospac/data/licenses/json/Unlicense-libtelnet.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Unlicense-libwhirlpool.json
+++ b/ospac/data/licenses/json/Unlicense-libwhirlpool.json
@@ -28,24 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Unlicense.json
+++ b/ospac/data/licenses/json/Unlicense.json
@@ -28,24 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strict",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strict",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/VOSTROM.json
+++ b/ospac/data/licenses/json/VOSTROM.json
@@ -28,20 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/VSL-1.0.json
+++ b/ospac/data/licenses/json/VSL-1.0.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Vim.json
+++ b/ospac/data/licenses/json/Vim.json
@@ -28,29 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "Vim",
+          "category:permissive",
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "Vim",
+          "category:permissive",
+          "category:public_domain",
+          "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "Vim license allows linking with permissive licenses but requires modifications to be under the same license."

--- a/ospac/data/licenses/json/Vixie-Cron.json
+++ b/ospac/data/licenses/json/Vixie-Cron.json
@@ -28,32 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/W3C-19980720.json
+++ b/ospac/data/licenses/json/W3C-19980720.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/W3C-20150513.json
+++ b/ospac/data/licenses/json/W3C-20150513.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/W3C.json
+++ b/ospac/data/licenses/json/W3C.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/WTFNMFPL.json
+++ b/ospac/data/licenses/json/WTFNMFPL.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/WTFPL.json
+++ b/ospac/data/licenses/json/WTFPL.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strict"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strict"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Watcom-1.0.json
+++ b/ospac/data/licenses/json/Watcom-1.0.json
@@ -28,36 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Widget-Workshop.json
+++ b/ospac/data/licenses/json/Widget-Workshop.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Widget-Workshop license is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/WordNet.json
+++ b/ospac/data/licenses/json/WordNet.json
@@ -28,20 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Wsuipa.json
+++ b/ospac/data/licenses/json/Wsuipa.json
@@ -28,24 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/X11-distribute-modifications-variant.json
+++ b/ospac/data/licenses/json/X11-distribute-modifications-variant.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/X11-no-permit-persons.json
+++ b/ospac/data/licenses/json/X11-no-permit-persons.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/X11-swapped.json
+++ b/ospac/data/licenses/json/X11-swapped.json
@@ -28,36 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/X11.json
+++ b/ospac/data/licenses/json/X11.json
@@ -28,43 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Apache-2.0",
-          "Zlib",
-          "Public Domain",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Apache-2.0",
-          "Zlib",
-          "Public Domain",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "X11 license is permissive and does not impose restrictions on the licensing of combined works."

--- a/ospac/data/licenses/json/XFree86-1.1.json
+++ b/ospac/data/licenses/json/XFree86-1.1.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/XSkat.json
+++ b/ospac/data/licenses/json/XSkat.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Xdebug-1.03.json
+++ b/ospac/data/licenses/json/Xdebug-1.03.json
@@ -28,33 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Xerox.json
+++ b/ospac/data/licenses/json/Xerox.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Xfig.json
+++ b/ospac/data/licenses/json/Xfig.json
@@ -28,39 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Xfig's permissive license allows for broad compatibility with other permissive licenses without imposing restrictions."

--- a/ospac/data/licenses/json/Xnet.json
+++ b/ospac/data/licenses/json/Xnet.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Xnet is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/YPL-1.0.json
+++ b/ospac/data/licenses/json/YPL-1.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/YPL-1.1.json
+++ b/ospac/data/licenses/json/YPL-1.1.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/ZPL-1.1.json
+++ b/ospac/data/licenses/json/ZPL-1.1.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/ZPL-2.0.json
+++ b/ospac/data/licenses/json/ZPL-2.0.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/ZPL-2.1.json
+++ b/ospac/data/licenses/json/ZPL-2.1.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Zed.json
+++ b/ospac/data/licenses/json/Zed.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Zeeff.json
+++ b/ospac/data/licenses/json/Zeeff.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Zend-2.0.json
+++ b/ospac/data/licenses/json/Zend-2.0.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Zend-2.0 is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/Zimbra-1.3.json
+++ b/ospac/data/licenses/json/Zimbra-1.3.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/Zimbra-1.4.json
+++ b/ospac/data/licenses/json/Zimbra-1.4.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "Zimbra-1.4",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "Zimbra-1.4",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "Zimbra-1.4 allows linking with permissive and weak copyleft licenses, but modifications must remain under the same license."

--- a/ospac/data/licenses/json/Zlib.json
+++ b/ospac/data/licenses/json/Zlib.json
@@ -28,38 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "LGPL-2.1",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "LGPL-2.1",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/any-OSI-perl-modules.json
+++ b/ospac/data/licenses/json/any-OSI-perl-modules.json
@@ -28,45 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "Public Domain",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "Public Domain",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "The any-OSI-perl-modules license is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/any-OSI.json
+++ b/ospac/data/licenses/json/any-OSI.json
@@ -28,24 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak",
           "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak",
           "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/atc-game.json
+++ b/ospac/data/licenses/json/atc-game.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "atc-game license is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/bcrypt-Solar-Designer.json
+++ b/ospac/data/licenses/json/bcrypt-Solar-Designer.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/blessing.json
+++ b/ospac/data/licenses/json/blessing.json
@@ -28,25 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft",
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/bzip2-1.0.5.json
+++ b/ospac/data/licenses/json/bzip2-1.0.5.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/bzip2-1.0.6.json
+++ b/ospac/data/licenses/json/bzip2-1.0.6.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/check-cvs.json
+++ b/ospac/data/licenses/json/check-cvs.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Check-CVS is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/checkmk.json
+++ b/ospac/data/licenses/json/checkmk.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Checkmk's permissive license allows for broad compatibility without imposing restrictions on the licensing of combined works."

--- a/ospac/data/licenses/json/copyleft-next-0.3.0.json
+++ b/ospac/data/licenses/json/copyleft-next-0.3.0.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "copyleft-next-0.3.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "copyleft-next-0.3.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "All combined works must be licensed under copyleft-next-0.3.0 if using components licensed under it."

--- a/ospac/data/licenses/json/copyleft-next-0.3.1.json
+++ b/ospac/data/licenses/json/copyleft-next-0.3.1.json
@@ -28,23 +28,39 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "copyleft-next-0.3.1",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive"
+          "copyleft-next-0.3.1",
+          "category:permissive",
+          "category:public_domain"
         ],
         "incompatible_with": [
-          "category:copyleft_weak",
-          "category:copyleft_strong"
+          "category:proprietary"
         ],
-        "requires_review": []
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft",
+          "category:noncommercial",
+          "category:no_derivatives",
+          "category:source_available"
+        ]
       },
       "contamination_effect": "full",
       "notes": "All derivative works must be licensed under copyleft-next-0.3.1 when using components licensed under this license."

--- a/ospac/data/licenses/json/curl.json
+++ b/ospac/data/licenses/json/curl.json
@@ -28,40 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "Public Domain",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "Public Domain",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/cve-tou.json
+++ b/ospac/data/licenses/json/cve-tou.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "CVE-TOU is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/diffmark.json
+++ b/ospac/data/licenses/json/diffmark.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/dtoa.json
+++ b/ospac/data/licenses/json/dtoa.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/dvipdfm.json
+++ b/ospac/data/licenses/json/dvipdfm.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "dvipdfm",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "dvipdfm",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "Static linking requires that only the modified module remains under the same license."

--- a/ospac/data/licenses/json/eCos-2.0.json
+++ b/ospac/data/licenses/json/eCos-2.0.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "eCos-2.0",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "eCos-2.0",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "eCos-2.0 allows linking with permissive and weak copyleft licenses, but modified files must remain under eCos-2.0."

--- a/ospac/data/licenses/json/eGenix.json
+++ b/ospac/data/licenses/json/eGenix.json
@@ -28,25 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/etalab-2.0.json
+++ b/ospac/data/licenses/json/etalab-2.0.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/fwlw.json
+++ b/ospac/data/licenses/json/fwlw.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/gSOAP-1.3b.json
+++ b/ospac/data/licenses/json/gSOAP-1.3b.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "gSOAP-1.3b is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/generic-xts.json
+++ b/ospac/data/licenses/json/generic-xts.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/gnuplot.json
+++ b/ospac/data/licenses/json/gnuplot.json
@@ -28,38 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "Public Domain",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "Public Domain",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/gtkbook.json
+++ b/ospac/data/licenses/json/gtkbook.json
@@ -28,36 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/hdparm.json
+++ b/ospac/data/licenses/json/hdparm.json
@@ -28,40 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "Public Domain",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "LGPL-2.1",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "Public Domain",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "LGPL-2.1",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/hyphen-bulgarian.json
+++ b/ospac/data/licenses/json/hyphen-bulgarian.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/iMatix.json
+++ b/ospac/data/licenses/json/iMatix.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/jove.json
+++ b/ospac/data/licenses/json/jove.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/libpng-1.6.35.json
+++ b/ospac/data/licenses/json/libpng-1.6.35.json
@@ -28,41 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "libpng-1.6.35 is permissive and does not impose a viral effect on linked code."

--- a/ospac/data/licenses/json/libpng-2.0.json
+++ b/ospac/data/licenses/json/libpng-2.0.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "libpng-2.0 is permissive and does not impose a viral effect on linked code."

--- a/ospac/data/licenses/json/libselinux-1.0.json
+++ b/ospac/data/licenses/json/libselinux-1.0.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/libtiff.json
+++ b/ospac/data/licenses/json/libtiff.json
@@ -28,41 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "libtiff's permissive license allows for broad compatibility without imposing restrictions on the licensing of combined works."

--- a/ospac/data/licenses/json/libutil-David-Nugent.json
+++ b/ospac/data/licenses/json/libutil-David-Nugent.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "libutil-David-Nugent is permissive, allowing for broad compatibility with other permissive licenses."

--- a/ospac/data/licenses/json/lsof.json
+++ b/ospac/data/licenses/json/lsof.json
@@ -28,40 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "Public Domain",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "Public Domain",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/magaz.json
+++ b/ospac/data/licenses/json/magaz.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Magaz license is permissive and does not impose viral effects on combined works."

--- a/ospac/data/licenses/json/mailprio.json
+++ b/ospac/data/licenses/json/mailprio.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Mailprio is a permissive license, allowing for broad compatibility without viral effects."

--- a/ospac/data/licenses/json/man2html.json
+++ b/ospac/data/licenses/json/man2html.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/metamail.json
+++ b/ospac/data/licenses/json/metamail.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/mpi-permissive.json
+++ b/ospac/data/licenses/json/mpi-permissive.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "mpi-permissive license allows for broad compatibility with other permissive licenses without imposing viral effects."

--- a/ospac/data/licenses/json/mpich2.json
+++ b/ospac/data/licenses/json/mpich2.json
@@ -28,41 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "MPICH2 is permissive, allowing for broad compatibility with other permissive licenses."

--- a/ospac/data/licenses/json/mplus.json
+++ b/ospac/data/licenses/json/mplus.json
@@ -28,26 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL",
-          "AGPL"
-        ],
-        "requires_review": [
-          "category:copyleft_weak"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/ngrep.json
+++ b/ospac/data/licenses/json/ngrep.json
@@ -28,43 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "Public Domain",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "Public Domain",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Ngrep's permissive license allows for broad compatibility with other permissive licenses without imposing viral effects."

--- a/ospac/data/licenses/json/pkgconf.json
+++ b/ospac/data/licenses/json/pkgconf.json
@@ -28,32 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/pnmstitch.json
+++ b/ospac/data/licenses/json/pnmstitch.json
@@ -28,22 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/psfrag.json
+++ b/ospac/data/licenses/json/psfrag.json
@@ -28,23 +28,29 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
+          "psfrag",
           "category:permissive",
-          "category:copyleft_weak"
+          "category:public_domain"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_weak",
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "dynamic_linking": {
         "compatible_with": [
+          "psfrag",
           "category:permissive",
+          "category:public_domain",
           "category:copyleft_weak"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
-        "requires_review": []
+        "incompatible_with": [],
+        "requires_review": [
+          "category:copyleft_strong",
+          "category:network_copyleft"
+        ]
       },
       "contamination_effect": "module",
       "notes": "psfrag-licensed components can be used in combination with other licenses, but modifications to psfrag components must remain under the same license."

--- a/ospac/data/licenses/json/psutils.json
+++ b/ospac/data/licenses/json/psutils.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "psutils is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/python-ldap.json
+++ b/ospac/data/licenses/json/python-ldap.json
@@ -28,41 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "ISC",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "ISC",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "The python-ldap license is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/radvd.json
+++ b/ospac/data/licenses/json/radvd.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "radvd is permissively licensed, allowing for broad compatibility with other permissive licenses."

--- a/ospac/data/licenses/json/snprintf.json
+++ b/ospac/data/licenses/json/snprintf.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/softSurfer.json
+++ b/ospac/data/licenses/json/softSurfer.json
@@ -28,25 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong",
-          "GPL",
-          "AGPL"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/ssh-keyscan.json
+++ b/ospac/data/licenses/json/ssh-keyscan.json
@@ -28,34 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/swrule.json
+++ b/ospac/data/licenses/json/swrule.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "swrule is a permissive license, allowing for broad compatibility without viral effects."

--- a/ospac/data/licenses/json/threeparttable.json
+++ b/ospac/data/licenses/json/threeparttable.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "Threeparttable is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/ulem.json
+++ b/ospac/data/licenses/json/ulem.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/w3m.json
+++ b/ospac/data/licenses/json/w3m.json
@@ -28,41 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "ISC",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "ISC",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "w3m's permissive license allows for broad compatibility with other permissive licenses without imposing restrictions."

--- a/ospac/data/licenses/json/wwl.json
+++ b/ospac/data/licenses/json/wwl.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/wxWindows.json
+++ b/ospac/data/licenses/json/wxWindows.json
@@ -28,38 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "LGPL-2.1",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-2-Clause",
-          "BSD-3-Clause",
-          "Zlib",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0",
-          "LGPL-2.1",
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/xinetd.json
+++ b/ospac/data/licenses/json/xinetd.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/xkeyboard-config-Zinoviev.json
+++ b/ospac/data/licenses/json/xkeyboard-config-Zinoviev.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/xlock.json
+++ b/ospac/data/licenses/json/xlock.json
@@ -28,37 +28,17 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "category:copyleft_strong"
-        ],
-        "requires_review": [
-          "LGPL-2.1",
-          "LGPL-3.0"
-        ]
+        "incompatible_with": [],
+        "requires_review": []
       },
       "contamination_effect": "none",
       "notes": "xlock is permissive and does not impose viral effects on linked code."

--- a/ospac/data/licenses/json/xpp.json
+++ b/ospac/data/licenses/json/xpp.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/xzoom.json
+++ b/ospac/data/licenses/json/xzoom.json
@@ -28,30 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "MIT",
-          "Apache-2.0",
-          "BSD-3-Clause",
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "GPL-3.0",
-          "AGPL-3.0",
-          "LGPL-3.0"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/data/licenses/json/zlib-acknowledgement.json
+++ b/ospac/data/licenses/json/zlib-acknowledgement.json
@@ -28,21 +28,16 @@
     "compatibility": {
       "static_linking": {
         "compatible_with": [
-          "category:permissive"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "dynamic_linking": {
         "compatible_with": [
-          "category:permissive",
-          "category:copyleft_weak"
+          "category:any"
         ],
-        "incompatible_with": [
-          "category:copyleft_strong"
-        ],
+        "incompatible_with": [],
         "requires_review": []
       },
       "contamination_effect": "none",

--- a/ospac/models/license.py
+++ b/ospac/models/license.py
@@ -24,22 +24,25 @@ class License:
         if context not in self.compatibility:
             context = "general"
 
+        def matches(entries: list) -> bool:
+            # Dataset entries are license ids or "category:<type>" specifiers. This
+            # previously compared other.type against the entries verbatim, so a
+            # "category:permissive" entry never matched anything and category rules
+            # were silently inert.
+            return (other.id in entries
+                    or f"category:{other.type}" in entries
+                    or "category:any" in entries)
+
         if context in self.compatibility:
             compat_rules = self.compatibility[context]
 
-            # Check explicit compatible list
-            if "compatible_with" in compat_rules:
-                if other.id in compat_rules["compatible_with"]:
-                    return True
-                if other.type in compat_rules["compatible_with"]:
-                    return True
-
-            # Check explicit incompatible list
-            if "incompatible_with" in compat_rules:
-                if other.id in compat_rules["incompatible_with"]:
-                    return False
-                if other.type in compat_rules["incompatible_with"]:
-                    return False
+            # Incompatibility is checked first: a known conflict outranks a category
+            # match, which is how the GPL-2.0 and Apache-2.0 records can both say
+            # category:permissive is fine while naming each other as exceptions.
+            if matches(compat_rules.get("incompatible_with", [])):
+                return False
+            if matches(compat_rules.get("compatible_with", [])):
+                return True
 
         # Default: permissive licenses are generally compatible
         if self.type == "permissive" and other.type == "permissive":

--- a/ospac/pipeline/data_generator.py
+++ b/ospac/pipeline/data_generator.py
@@ -128,6 +128,33 @@ _KNOWN_OVERRIDES: Dict[str, Dict] = {
 }
 
 
+# License-level compatibility exceptions that category reasoning cannot express. Each
+# pair lands in both records' incompatible_with, so the claims stay symmetric.
+_KNOWN_INCOMPATIBLE_PAIRS = [
+    # GPL-2.0's "no further restrictions" clause conflicts with Apache-2.0's patent
+    # termination. GPL-2.0-or-later escapes by upgrading, so it is not listed.
+    ({"GPL-2.0", "GPL-2.0-only"}, {"Apache-2.0"}),
+    # The GPL versions are mutually incompatible unless or-later allows upgrading.
+    ({"GPL-2.0", "GPL-2.0-only"}, {"GPL-3.0", "GPL-3.0-only"}),
+    # The 4-clause BSD advertising requirement is an additional restriction no GPL
+    # version permits.
+    ({"BSD-4-Clause", "BSD-4-Clause-UC", "BSD-4-Clause-Shortened"},
+     {"GPL-2.0", "GPL-2.0-only", "GPL-2.0-or-later",
+      "GPL-3.0", "GPL-3.0-only", "GPL-3.0-or-later"}),
+]
+
+
+def _known_incompatible_ids(license_id: str) -> list:
+    """Every license id the exception table declares incompatible with this one."""
+    ids = set()
+    for side_a, side_b in _KNOWN_INCOMPATIBLE_PAIRS:
+        if license_id in side_a:
+            ids.update(side_b)
+        elif license_id in side_b:
+            ids.update(side_a)
+    return sorted(ids)
+
+
 class PolicyDataGenerator:
     """
     Generate comprehensive policy data from SPDX licenses.
@@ -414,6 +441,93 @@ class PolicyDataGenerator:
 
         return restrictions
 
+    @staticmethod
+    def _derive_compatibility(license_id: str, category: str,
+                              notes: Optional[str] = None) -> Dict[str, Any]:
+        """
+        Build the record's compatibility block from its category plus the known
+        license-level exceptions.
+
+        The model was asked for these lists per license and got them systematically
+        wrong: 540 permissive records declared themselves incompatible with GPL, which
+        inverts how permissive licensing works, MPL-2.0 claimed incompatibility with the
+        GPL it is expressly designed to combine with, and pairs disagreed with each
+        other. Compatibility between categories is a derivable fact, so it is derived;
+        the model contributes only the prose notes.
+        """
+        known_incompatible = _known_incompatible_ids(license_id)
+
+        if category in ("permissive", "public_domain"):
+            static = {
+                "compatible_with": ["category:any"],
+                "incompatible_with": list(known_incompatible),
+                "requires_review": [],
+            }
+            dynamic = dict(static)
+            contamination = "none"
+            default_note = ("Permissive terms: can be incorporated into works under "
+                            "any license")
+        elif category == "copyleft_weak":
+            static = {
+                "compatible_with": [license_id, "category:permissive",
+                                    "category:public_domain"],
+                "incompatible_with": list(known_incompatible),
+                "requires_review": ["category:copyleft_weak", "category:copyleft_strong",
+                                    "category:network_copyleft"],
+            }
+            dynamic = {
+                "compatible_with": [license_id, "category:permissive",
+                                    "category:public_domain", "category:copyleft_weak"],
+                "incompatible_with": list(known_incompatible),
+                "requires_review": ["category:copyleft_strong",
+                                    "category:network_copyleft"],
+            }
+            contamination = "module"
+            default_note = ("Weak copyleft: changes to the covered component must stay "
+                            "under its license")
+        elif category in ("copyleft_strong", "network_copyleft"):
+            block = {
+                "compatible_with": [license_id, "category:permissive",
+                                    "category:public_domain"],
+                "incompatible_with": ["category:proprietary"] + list(known_incompatible),
+                "requires_review": ["category:copyleft_weak", "category:copyleft_strong",
+                                    "category:network_copyleft", "category:noncommercial",
+                                    "category:no_derivatives",
+                                    "category:source_available"],
+            }
+            static = block
+            dynamic = dict(block)
+            contamination = "full"
+            default_note = ("Strong copyleft: the combined work must be released under "
+                            "the same license")
+            if category == "network_copyleft":
+                default_note = ("Network copyleft: serving users over a network triggers "
+                                "source disclosure for the combined work")
+        else:
+            # noncommercial, no_derivatives, source_available, proprietary, unknown:
+            # nothing is asserted without a human looking at the terms.
+            block = {
+                "compatible_with": [],
+                "incompatible_with": [],
+                "requires_review": ["category:any"],
+            }
+            static = block
+            dynamic = dict(block)
+            contamination = "none" if category in ("noncommercial",
+                                                   "no_derivatives") else "unknown"
+            default_note = "Restricted license: combination requires review of the terms"
+
+        # ShareAlike-style reciprocity binds derivative works specifically.
+        if category == "copyleft_weak" and "SA" in license_id.split("-"):
+            contamination = "derivative"
+
+        return {
+            "static_linking": static,
+            "dynamic_linking": dynamic,
+            "contamination_effect": contamination,
+            "notes": notes or default_note,
+        }
+
     def _apply_identifier_restrictions(self, license_id: str, analysis: Dict) -> Dict:
         """
         Force the terms the identifier states outright, then coerce the category to be
@@ -449,6 +563,13 @@ class PolicyDataGenerator:
             result["category"] = "copyleft_weak"
         if permissions.get("modification") is False and result.get("category") == "permissive":
             result["category"] = "no_derivatives"
+
+        # The compatibility lists are derived from the final category, keeping whatever
+        # prose notes the analysis produced. This runs on every path that writes a
+        # record, so the lists cannot drift from the category they describe.
+        existing_notes = (result.get("compatibility_rules") or {}).get("notes")
+        result["compatibility_rules"] = PolicyDataGenerator._derive_compatibility(
+            license_id, result["category"], existing_notes)
 
         return result
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ospac"
-version = "1.4.1"
+version = "1.4.2"
 description = "Open Source Policy as Code - License compliance policy engine"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -483,3 +483,56 @@ class TestPolicyResult:
                                  message="restricted")
             assert PolicyResult.aggregate([approve, other]).action == stronger
             assert PolicyResult.aggregate([other, approve]).action == stronger
+
+class TestIsCompatibleWithCategoryEntries:
+    """
+    Dataset compatibility entries use "category:<type>" specifiers, but this method
+    compared other.type verbatim, so category entries never matched anything and the
+    lists were silently inert. It also read compatible_with before incompatible_with,
+    which would have let a category match hide a named exception.
+    """
+
+    def _license(self, lid, ltype, compatible, incompatible):
+        return License(
+            id=lid, name=lid, type=ltype,
+            compatibility={"general": {
+                "compatible_with": compatible,
+                "incompatible_with": incompatible,
+                "requires_review": [],
+            }},
+        )
+
+    def test_category_any_matches(self):
+        mit = self._license("MIT", "permissive", ["category:any"], [])
+        gpl = self._license("GPL-3.0-only", "copyleft_strong", [], [])
+        assert mit.is_compatible_with(gpl) is True
+
+    def test_category_specifier_matches_the_other_type(self):
+        gpl = self._license("GPL-3.0-only", "copyleft_strong",
+                            ["category:permissive"], [])
+        mit = self._license("MIT", "permissive", [], [])
+        assert gpl.is_compatible_with(mit) is True
+
+    def test_named_exception_outranks_category_match(self):
+        gpl2 = self._license("GPL-2.0-only", "copyleft_strong",
+                             ["category:permissive"], ["Apache-2.0"])
+        apache = self._license("Apache-2.0", "permissive", [], [])
+        assert gpl2.is_compatible_with(apache) is False
+
+    def test_shipped_records_answer_correctly_both_directions(self):
+        import json
+        from pathlib import Path
+
+        data_dir = Path(__file__).parent.parent / "ospac" / "data" / "licenses" / "json"
+
+        def load(lid):
+            record = json.loads((data_dir / f"{lid}.json").read_text())["license"]
+            return License.from_dict(record)
+
+        mit, gpl3 = load("MIT"), load("GPL-3.0-only")
+        assert mit.is_compatible_with(gpl3, "static_linking") is True
+        assert gpl3.is_compatible_with(mit, "static_linking") is True
+
+        gpl2, apache = load("GPL-2.0-only"), load("Apache-2.0")
+        assert gpl2.is_compatible_with(apache, "static_linking") is False
+        assert apache.is_compatible_with(gpl2, "static_linking") is False

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -570,6 +570,7 @@ class TestDatasetPipelineReproducibility:
                 "category": record["type"],
                 "permissions": dict(record["properties"]),
                 "conditions": dict(record["requirements"]),
+                "compatibility_rules": dict(record.get("compatibility", {})),
             }
             analysis = G._apply_known_corrections(G, record["id"], analysis)
             analysis = G._apply_identifier_restrictions(G, record["id"], analysis)
@@ -581,7 +582,8 @@ class TestDatasetPipelineReproducibility:
                     or analysis["permissions"] != record["properties"]
                     or analysis["conditions"] != record["requirements"]
                     or obligations != record["obligations"]
-                    or key_requirements != record["key_requirements"]):
+                    or key_requirements != record["key_requirements"]
+                    or analysis["compatibility_rules"] != record.get("compatibility")):
                 not_reproduced.append(record["id"])
 
         assert not_reproduced == [], (
@@ -612,3 +614,69 @@ class TestDatasetPipelineReproducibility:
         sa_copyleft = types.get("copyleft_weak", []) + types.get("copyleft_strong", [])
         assert "CC-BY-SA-4.0" in sa_copyleft
         assert "CC-BY-SA-4.0" not in types.get("permissive", [])
+
+
+class TestCompatibilityListSoundness:
+    """
+    The record-level compatibility lists were model-generated and systematically wrong:
+    540 permissive records declared themselves incompatible with GPL, which inverts how
+    permissive licensing works, and pairs disagreed with each other. The lists are now
+    derived from the category plus a known-exception table, so these invariants hold by
+    construction and this test keeps them held.
+    """
+
+    @staticmethod
+    def _records():
+        import json
+
+        data_dir = Path(__file__).parent.parent / "ospac" / "data" / "licenses" / "json"
+        records = {}
+        for path in data_dir.glob("*.json"):
+            record = json.loads(path.read_text())["license"]
+            records[record["id"]] = record
+        return records
+
+    @staticmethod
+    def _claims(record, other):
+        block = record["compatibility"]["static_linking"]
+        other_cat = f"category:{other['type']}"
+        if other["id"] in block["incompatible_with"] or other_cat in block["incompatible_with"]:
+            return "incompatible"
+        if (other["id"] in block["compatible_with"] or other_cat in block["compatible_with"]
+                or "category:any" in block["compatible_with"]):
+            return "compatible"
+        return None
+
+    def test_no_permissive_record_claims_copyleft_incompatibility(self):
+        from ospac.pipeline.data_generator import _known_incompatible_ids
+
+        offenders = []
+        for record in self._records().values():
+            if record["type"] not in ("permissive", "public_domain"):
+                continue
+            allowed = set(_known_incompatible_ids(record["id"]))
+            for entry in record["compatibility"]["static_linking"]["incompatible_with"]:
+                if entry not in allowed:
+                    offenders.append(f"{record['id']} -> {entry}")
+        assert offenders == [], offenders[:10]
+
+    def test_pairwise_claims_are_symmetric(self):
+        records = self._records()
+        sample = ["MIT", "Apache-2.0", "BSD-3-Clause", "BSD-4-Clause", "GPL-2.0-only",
+                  "GPL-3.0-only", "LGPL-2.1-only", "MPL-2.0", "AGPL-3.0-only",
+                  "CC-BY-NC-4.0", "EPL-2.0"]
+        conflicts = []
+        for i, a in enumerate(sample):
+            for b in sample[i + 1:]:
+                ca = self._claims(records[a], records[b])
+                cb = self._claims(records[b], records[a])
+                if {ca, cb} == {"compatible", "incompatible"}:
+                    conflicts.append(f"{a} says {ca} of {b}, {b} says {cb} of {a}")
+        assert conflicts == [], conflicts
+
+    def test_known_exception_pairs_are_mutually_incompatible(self):
+        records = self._records()
+        for a, b in [("GPL-2.0-only", "Apache-2.0"), ("GPL-2.0-only", "GPL-3.0-only"),
+                     ("BSD-4-Clause", "GPL-3.0-only")]:
+            assert self._claims(records[a], records[b]) == "incompatible"
+            assert self._claims(records[b], records[a]) == "incompatible"


### PR DESCRIPTION
540 of 733 records typed permissive or public domain declared themselves
incompatible with GPL or strong copyleft, which inverts how permissive licensing
works. MPL-2.0 claimed incompatibility with the GPL it is expressly designed to
combine with, and pairs disagreed with each other: BSD-3-Clause called GPL-3.0
incompatible while GPL-3.0 called BSD-3-Clause compatible. The policy engine was
unaffected, since check answers from rules, but the lists ship in every record and
License.is_compatible_with reads them.

Compatibility between categories is a derivable fact, so it is derived from the
record's final category plus a table of known license-level exceptions: GPL-2.0
with Apache-2.0, GPL-2.0 with GPL-3.0, and 4-clause BSD with any GPL, each landing
in both records of the pair so the claims stay symmetric. The derivation runs on
every path that writes a record and is pinned by the reproducibility test, which
now covers the compatibility block too. The model contributes only the prose
notes. All 733 blocks rebuilt with notes preserved.

License.is_compatible_with also never worked against these lists: entries use
category:<type> specifiers, and the method compared the other license's bare type
verbatim, so category entries never matched anything. It also consulted
compatible_with before incompatible_with, which would have let a category match
hide a named exception. Both fixed, with tests covering the shipped records in
both directions.

Property tests keep the invariants held: no permissive record may claim copyleft
incompatibility beyond the exception table, pairwise claims must never contradict
each other, and the known pairs must be mutually incompatible.
