### PR TITLE
fix: clear the remaining ledger defects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to OSPAC (Open Source Policy as Code) will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.4] - 2026-08-15
+
+Clears the remaining known defects from the session ledger.
+
+### Fixed
+
+**The bundled policy carried one more rule that could never execute**
+- `gpl_dev_tools` approved GPL for development-only use by matching on a `usage`
+  field that no evaluation path provides, the same never-executes shape as the
+  removed `decision_tree` and compatibility sections. Removed. A test now pins the
+  vocabulary: every `when` key in the bundled policy and in the generated templates
+  must be a field the CLI actually sets, so this class of dead rule cannot return.
+
+**`check` reported an empty `licenses_checked`**
+- `check_compatibility` always returned `licenses_checked: []` even though it
+  checked exactly two licenses. It now names them.
+
+**0BSD asked for attribution and license text**
+- The zero-clause BSD requires nothing at all; the analysis kept asking for
+  copyright retention and license inclusion anyway. Pinned in the correction table
+  and the record rebuilt: obligations are now empty, matching Unlicense and CC0.
+
+### Changed
+
+- The `generated` and `spdx_list_version` fields are documented as recording when
+  the analysis that produced a record ran, against which SPDX revision.
+  Deterministic repairs derived from a record's own fields do not re-stamp it,
+  deliberately: re-stamping would make the reproducibility check impossible, and
+  the stamp answers "when was this license analysed", not "when did this file last
+  change".
+
 ## [1.4.3] - 2026-08-14
 
 Recovers four review findings that were deferred during the 1.4.x work and lost:

--- a/docs/dataset.md
+++ b/docs/dataset.md
@@ -144,6 +144,7 @@ the file on disk has the extra nesting level.
 | `contamination_effect` | How far copyleft reaches: `none`, `file`, `library`, `project`. |
 | `obligations` | Human-readable duties, derived from `requirements`. |
 | `spdx_metadata` | Upstream flags, including `is_deprecated`. |
+| `generated`, `spdx_list_version` | When the analysis that produced this record ran, and against which SPDX revision. Deterministic repairs derived from the record's own fields do not re-stamp it, so the stamp answers "when was this license analysed", not "when did this file last change". |
 
 {: .note }
 > If you have seen older ospac documentation referring to a single

--- a/ospac/data/index.json
+++ b/ospac/data/index.json
@@ -9,7 +9,7 @@
       "category": "public_domain",
       "file": "licenses/json/0BSD.json",
       "is_deprecated": false,
-      "obligations_count": 2
+      "obligations_count": 0
     },
     "3D-Slicer-1.0": {
       "name": "3D Slicer License v1.0",

--- a/ospac/data/licenses/json/0BSD.json
+++ b/ospac/data/licenses/json/0BSD.json
@@ -13,8 +13,8 @@
     },
     "requirements": {
       "disclose_source": false,
-      "include_license": true,
-      "include_copyright": true,
+      "include_license": false,
+      "include_copyright": false,
       "include_notice": false,
       "state_changes": false,
       "same_license": false,
@@ -43,10 +43,7 @@
       "contamination_effect": "none",
       "notes": "0BSD is a permissive license, allowing for broad compatibility without imposing restrictions on linked code."
     },
-    "obligations": [
-      "Retain copyright notices",
-      "Include license text"
-    ],
+    "obligations": [],
     "key_requirements": [
       "No restrictions"
     ],

--- a/ospac/defaults/enterprise_policy.yaml
+++ b/ospac/defaults/enterprise_policy.yaml
@@ -206,20 +206,11 @@ rules:
       severity: info
       message: "Public domain dedication approved"
 
-  # Special Cases
-  - id: gpl_dev_tools
-    description: "Allow GPL for development tools"
-    priority: 2
-    when:
-      license: ["GPL-2.0", "GPL-3.0", "GPL-2.0-only", "GPL-3.0-only"]
-      usage: ["development", "testing", "build"]
-    then:
-      action: approve
-      severity: info
-      message: "GPL allowed for development-only tools"
-      requirements:
-        - "Ensure tool is not distributed with product"
-        - "Tool output must not contain GPL code"
+  # A gpl_dev_tools rule used to sit here, approving GPL for development-only use.
+  # It matched on a usage field that no evaluation path ever provides, so it never
+  # executed once: the same shape as the removed decision_tree and compatibility
+  # sections. If the development-use carve-out is wanted, evaluate needs a flag that
+  # populates the field first.
 
   - id: review_commercial
     description: "Review commercial/proprietary licenses"

--- a/ospac/pipeline/data_generator.py
+++ b/ospac/pipeline/data_generator.py
@@ -125,6 +125,9 @@ _KNOWN_OVERRIDES: Dict[str, Dict] = {
     "Apache-2.0": {"conditions": {"state_changes": True}},
     # CC0 is a full public domain waiver, with no copyright or license text requirements
     "CC0-1.0": {"conditions": {"include_copyright": False, "include_license": False}},
+    # 0BSD is the zero-clause BSD: it requires nothing at all, and the analysis kept
+    # asking for attribution anyway
+    "0BSD":    {"conditions": {"include_copyright": False, "include_license": False}},
 }
 
 

--- a/ospac/runtime/engine.py
+++ b/ospac/runtime/engine.py
@@ -255,7 +255,11 @@ class PolicyRuntime:
         # with itself, since this context carries no distribution_type and most rules
         # therefore cannot match.
         result = self.evaluate(eval_context, when_unmatched="allow")
-        return ComplianceResult.from_policy_result(result)
+        compliance = ComplianceResult.from_policy_result(result)
+        # The result always reported an empty licenses_checked even though exactly two
+        # licenses were checked.
+        compliance.licenses_checked = [license1, license2]
+        return compliance
 
     def get_obligations(self, licenses: List[str], data_dir: Optional[str] = None) -> Dict[str, Any]:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ospac"
-version = "1.4.3"
+version = "1.4.4"
 description = "Open Source Policy as Code - License compliance policy engine"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -344,3 +344,11 @@ class TestPolicyRuntime:
 
         result = runtime.check_compatibility("MIT", "GPL-3.0")
         assert result.is_compliant is True
+
+class TestCheckReportsLicensesChecked:
+    """check_compatibility always returned an empty licenses_checked."""
+
+    def test_licenses_checked_is_populated(self):
+        runtime = PolicyRuntime()
+        result = runtime.check_compatibility("MIT", "GPL-3.0")
+        assert result.licenses_checked == ["MIT", "GPL-3.0"]

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -711,3 +711,69 @@ class TestRelationshipsTreeSoundness:
     def test_noncommercial_rows_require_review(self):
         nc = self._family("cc")["CC-BY-NC-4.0"]
         assert nc["MIT"]["static_linking"] == "review_required"
+
+
+class TestPolicyRulesAreReachable:
+    """
+    Three sections of the bundled policy turned out to be dead config that never
+    executed: decision_tree, the compatibility matrix, and a gpl_dev_tools rule
+    matching on a usage field no evaluation path provides. A rule whose when clause
+    names a field the runtime never populates is silently inert, so this pins the
+    vocabulary: every when key in the bundled policy must be one the CLI actually
+    sets.
+    """
+
+    # The union of fields evaluate and check_compatibility place in their contexts.
+    PROVIDED_FIELDS = {
+        "license", "licenses", "licenses_found", "license_type",
+        "distribution", "distribution_type", "context", "linking_type",
+        "license1", "license2", "compatibility_context",
+    }
+
+    def test_every_bundled_rule_matches_on_provided_fields(self):
+        import yaml
+
+        policy_path = (Path(__file__).parent.parent / "ospac" / "defaults"
+                       / "enterprise_policy.yaml")
+        policy = yaml.safe_load(policy_path.read_text())
+        unreachable = []
+        for rule in policy["rules"]:
+            for key in rule.get("when", {}):
+                if key not in self.PROVIDED_FIELDS:
+                    unreachable.append(f"{rule['id']} matches on '{key}'")
+        assert unreachable == [], (
+            "these rules can never fire because no evaluation path provides the "
+            "field: " + "; ".join(unreachable))
+
+    def test_generated_templates_match_on_provided_fields(self):
+        import yaml
+        from click.testing import CliRunner
+
+        from ospac.cli.commands import cli
+
+        runner = CliRunner()
+        for template in ("mobile", "desktop", "web", "server", "embedded", "library"):
+            with runner.isolated_filesystem():
+                result = runner.invoke(
+                    cli, ["policy", "init", "-t", template, "-o", "t.yaml"])
+                assert result.exit_code == 0, result.output
+                policy = yaml.safe_load(Path("t.yaml").read_text())
+                for rule in policy["rules"]:
+                    for key in rule.get("when", {}):
+                        assert key in self.PROVIDED_FIELDS, (
+                            f"template {template}, rule {rule['id']} matches on "
+                            f"'{key}', which no evaluation path provides")
+
+
+class TestZeroClauseLicensesAskNothing:
+    """0BSD asked for attribution and license text, which zero-clause means it does not."""
+
+    def test_0bsd_has_no_obligations(self):
+        import json
+
+        record = json.loads(
+            (Path(__file__).parent.parent / "ospac" / "data" / "licenses" / "json"
+             / "0BSD.json").read_text())["license"]
+        assert record["obligations"] == []
+        assert record["requirements"]["include_license"] is False
+        assert record["requirements"]["include_copyright"] is False


### PR DESCRIPTION
gpl_dev_tools approved GPL for development-only use by matching on a usage field
that no evaluation path provides, the same never-executes shape as the removed
decision_tree and compatibility sections. Removed, and a test now pins the
vocabulary: every when key in the bundled policy and the generated templates must
be a field the CLI actually sets, so this class of dead rule cannot return.

check_compatibility always returned an empty licenses_checked even though it
checked exactly two licenses. It now names them.

0BSD asked for attribution and license text, which zero-clause means it does not
require. Pinned in the correction table alongside CC0 and the record rebuilt:
obligations are empty, matching Unlicense and CC0.

The generated and spdx_list_version fields are documented as recording when the
analysis that produced a record ran. Deterministic repairs derived from a record's
own fields do not re-stamp it, deliberately: re-stamping would make the
reproducibility check impossible, and the stamp answers when the license was
analysed, not when the file last changed.
