### PR TITLE
fix: enforce the known-incompatible table at runtime and resolve alias spellings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to OSPAC (Open Source Policy as Code) will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.5] - 2026-08-15
+
+An independent review of the v1.4.1 to v1.4.4 diff found three defects in the
+compatibility work; all are fixed and each fix is pinned by tests.
+
+### Fixed
+
+**The known-incompatible table missed the deprecated + spellings**
+- `GPL-3.0+` is the deprecated alias of `GPL-3.0-or-later`, but only the modern
+  spellings sat in the 4-clause BSD exception, so the generated data called
+  `GPL-3.0+` with `BSD-4-Clause` compatible. Both + spellings are in the pair now.
+
+**The runtime never enforced the known-incompatible table**
+- `check` answered from policy rules alone, and the policy only enumerated some of
+  the pairs, so `GPL-2.0` with `BSD-4-Clause` reported compliant while the records
+  named each other incompatible: 30 of 48 pair directions passed. The dataset's
+  named incompatibilities now outrank category-level approvals in
+  `check_compatibility`, the same precedence named exceptions get in
+  `License.is_compatible_with`, and a test sweeps every table direction through the
+  runtime. All 60 directions now deny.
+
+**Alias spellings of one license were reported as a pair needing review**
+- `GPL-2.0` and `GPL-2.0-only` are the same license in two spellings, but the
+  relationships tree marked them `review_required` and `is_compatible_with`
+  returned false. A canonical-identifier helper resolves the deprecated bare and
+  `+` GPL-family spellings, and both consumers treat alias-equal identifiers as
+  identical. Five records and the tree rebuilt.
+
 ## [1.4.4] - 2026-08-15
 
 Clears the remaining known defects from the session ledger.

--- a/ospac/data/compatibility/metadata.json
+++ b/ospac/data/compatibility/metadata.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated": "2026-08-14T12:36:06.968913",
+  "generated": "2026-08-15T11:21:20.451440",
   "total_licenses": 733,
   "format": "sparse",
   "default_status": "unknown"

--- a/ospac/data/compatibility/relationships/agpl.json
+++ b/ospac/data/compatibility/relationships/agpl.json
@@ -56,9 +56,9 @@
       "distribution": "review_required"
     },
     "AGPL-1.0": {
-      "static_linking": "review_required",
-      "dynamic_linking": "review_required",
-      "distribution": "review_required"
+      "static_linking": "compatible",
+      "dynamic_linking": "compatible",
+      "distribution": "compatible"
     },
     "AGPL-3.0-only": {
       "static_linking": "review_required",
@@ -7380,9 +7380,9 @@
       "distribution": "compatible"
     },
     "AGPL-1.0-only": {
-      "static_linking": "review_required",
-      "dynamic_linking": "review_required",
-      "distribution": "review_required"
+      "static_linking": "compatible",
+      "dynamic_linking": "compatible",
+      "distribution": "compatible"
     },
     "AGPL-1.0-or-later": {
       "static_linking": "review_required",
@@ -11072,9 +11072,9 @@
       "distribution": "review_required"
     },
     "AGPL-3.0": {
-      "static_linking": "review_required",
-      "dynamic_linking": "review_required",
-      "distribution": "review_required"
+      "static_linking": "compatible",
+      "dynamic_linking": "compatible",
+      "distribution": "compatible"
     },
     "ALGLIB-Documentation": {
       "static_linking": "compatible",
@@ -18396,9 +18396,9 @@
       "distribution": "review_required"
     },
     "AGPL-3.0-only": {
-      "static_linking": "review_required",
-      "dynamic_linking": "review_required",
-      "distribution": "review_required"
+      "static_linking": "compatible",
+      "dynamic_linking": "compatible",
+      "distribution": "compatible"
     },
     "AGPL-3.0-or-later": {
       "static_linking": "review_required",

--- a/ospac/data/compatibility/relationships/bsd.json
+++ b/ospac/data/compatibility/relationships/bsd.json
@@ -93116,9 +93116,9 @@
       "distribution": "compatible"
     },
     "GPL-2.0+": {
-      "static_linking": "compatible",
-      "dynamic_linking": "compatible",
-      "distribution": "compatible"
+      "static_linking": "incompatible",
+      "dynamic_linking": "incompatible",
+      "distribution": "incompatible"
     },
     "GPL-2.0-only": {
       "static_linking": "incompatible",
@@ -93161,9 +93161,9 @@
       "distribution": "incompatible"
     },
     "GPL-3.0+": {
-      "static_linking": "compatible",
-      "dynamic_linking": "compatible",
-      "distribution": "compatible"
+      "static_linking": "incompatible",
+      "dynamic_linking": "incompatible",
+      "distribution": "incompatible"
     },
     "GPL-3.0-only": {
       "static_linking": "incompatible",
@@ -96783,9 +96783,9 @@
       "distribution": "compatible"
     },
     "GPL-2.0+": {
-      "static_linking": "compatible",
-      "dynamic_linking": "compatible",
-      "distribution": "compatible"
+      "static_linking": "incompatible",
+      "dynamic_linking": "incompatible",
+      "distribution": "incompatible"
     },
     "GPL-2.0-only": {
       "static_linking": "incompatible",
@@ -96828,9 +96828,9 @@
       "distribution": "incompatible"
     },
     "GPL-3.0+": {
-      "static_linking": "compatible",
-      "dynamic_linking": "compatible",
-      "distribution": "compatible"
+      "static_linking": "incompatible",
+      "dynamic_linking": "incompatible",
+      "distribution": "incompatible"
     },
     "GPL-3.0-only": {
       "static_linking": "incompatible",
@@ -100450,9 +100450,9 @@
       "distribution": "compatible"
     },
     "GPL-2.0+": {
-      "static_linking": "compatible",
-      "dynamic_linking": "compatible",
-      "distribution": "compatible"
+      "static_linking": "incompatible",
+      "dynamic_linking": "incompatible",
+      "distribution": "incompatible"
     },
     "GPL-2.0-only": {
       "static_linking": "incompatible",
@@ -100495,9 +100495,9 @@
       "distribution": "incompatible"
     },
     "GPL-3.0+": {
-      "static_linking": "compatible",
-      "dynamic_linking": "compatible",
-      "distribution": "compatible"
+      "static_linking": "incompatible",
+      "dynamic_linking": "incompatible",
+      "distribution": "incompatible"
     },
     "GPL-3.0-only": {
       "static_linking": "incompatible",

--- a/ospac/data/compatibility/relationships/gpl.json
+++ b/ospac/data/compatibility/relationships/gpl.json
@@ -5098,9 +5098,9 @@
       "distribution": "review_required"
     },
     "GPL-1.0-or-later": {
-      "static_linking": "review_required",
-      "dynamic_linking": "review_required",
-      "distribution": "review_required"
+      "static_linking": "compatible",
+      "dynamic_linking": "compatible",
+      "distribution": "compatible"
     },
     "GPL-1.0": {
       "static_linking": "review_required",
@@ -8770,9 +8770,9 @@
       "distribution": "review_required"
     },
     "GPL-1.0": {
-      "static_linking": "review_required",
-      "dynamic_linking": "review_required",
-      "distribution": "review_required"
+      "static_linking": "compatible",
+      "dynamic_linking": "compatible",
+      "distribution": "compatible"
     },
     "GPL-2.0+": {
       "static_linking": "review_required",
@@ -12422,9 +12422,9 @@
       "distribution": "compatible"
     },
     "GPL-1.0+": {
-      "static_linking": "review_required",
-      "dynamic_linking": "review_required",
-      "distribution": "review_required"
+      "static_linking": "compatible",
+      "dynamic_linking": "compatible",
+      "distribution": "compatible"
     },
     "GPL-1.0-only": {
       "static_linking": "review_required",
@@ -16094,9 +16094,9 @@
       "distribution": "review_required"
     },
     "GPL-1.0-only": {
-      "static_linking": "review_required",
-      "dynamic_linking": "review_required",
-      "distribution": "review_required"
+      "static_linking": "compatible",
+      "dynamic_linking": "compatible",
+      "distribution": "compatible"
     },
     "GPL-1.0-or-later": {
       "static_linking": "review_required",
@@ -18716,19 +18716,19 @@
       "distribution": "compatible"
     },
     "BSD-4-Clause-Shortened": {
-      "static_linking": "compatible",
-      "dynamic_linking": "compatible",
-      "distribution": "compatible"
+      "static_linking": "incompatible",
+      "dynamic_linking": "incompatible",
+      "distribution": "incompatible"
     },
     "BSD-4-Clause-UC": {
-      "static_linking": "compatible",
-      "dynamic_linking": "compatible",
-      "distribution": "compatible"
+      "static_linking": "incompatible",
+      "dynamic_linking": "incompatible",
+      "distribution": "incompatible"
     },
     "BSD-4-Clause": {
-      "static_linking": "compatible",
-      "dynamic_linking": "compatible",
-      "distribution": "compatible"
+      "static_linking": "incompatible",
+      "dynamic_linking": "incompatible",
+      "distribution": "incompatible"
     },
     "BSD-4.3RENO": {
       "static_linking": "compatible",
@@ -19786,9 +19786,9 @@
       "distribution": "review_required"
     },
     "GPL-2.0-or-later": {
-      "static_linking": "review_required",
-      "dynamic_linking": "review_required",
-      "distribution": "review_required"
+      "static_linking": "compatible",
+      "dynamic_linking": "compatible",
+      "distribution": "compatible"
     },
     "GPL-2.0-with-GCC-exception": {
       "static_linking": "review_required",
@@ -23483,9 +23483,9 @@
       "distribution": "review_required"
     },
     "GPL-2.0": {
-      "static_linking": "review_required",
-      "dynamic_linking": "review_required",
-      "distribution": "review_required"
+      "static_linking": "compatible",
+      "dynamic_linking": "compatible",
+      "distribution": "compatible"
     },
     "GPL-3.0+": {
       "static_linking": "review_required",
@@ -27110,9 +27110,9 @@
       "distribution": "review_required"
     },
     "GPL-2.0+": {
-      "static_linking": "review_required",
-      "dynamic_linking": "review_required",
-      "distribution": "review_required"
+      "static_linking": "compatible",
+      "dynamic_linking": "compatible",
+      "distribution": "compatible"
     },
     "GPL-2.0-only": {
       "static_linking": "review_required",
@@ -49117,9 +49117,9 @@
       "distribution": "review_required"
     },
     "GPL-2.0-only": {
-      "static_linking": "review_required",
-      "dynamic_linking": "review_required",
-      "distribution": "review_required"
+      "static_linking": "compatible",
+      "dynamic_linking": "compatible",
+      "distribution": "compatible"
     },
     "GPL-2.0-or-later": {
       "static_linking": "review_required",
@@ -51719,19 +51719,19 @@
       "distribution": "compatible"
     },
     "BSD-4-Clause-Shortened": {
-      "static_linking": "compatible",
-      "dynamic_linking": "compatible",
-      "distribution": "compatible"
+      "static_linking": "incompatible",
+      "dynamic_linking": "incompatible",
+      "distribution": "incompatible"
     },
     "BSD-4-Clause-UC": {
-      "static_linking": "compatible",
-      "dynamic_linking": "compatible",
-      "distribution": "compatible"
+      "static_linking": "incompatible",
+      "dynamic_linking": "incompatible",
+      "distribution": "incompatible"
     },
     "BSD-4-Clause": {
-      "static_linking": "compatible",
-      "dynamic_linking": "compatible",
-      "distribution": "compatible"
+      "static_linking": "incompatible",
+      "dynamic_linking": "incompatible",
+      "distribution": "incompatible"
     },
     "BSD-4.3RENO": {
       "static_linking": "compatible",
@@ -52834,9 +52834,9 @@
       "distribution": "review_required"
     },
     "GPL-3.0-or-later": {
-      "static_linking": "review_required",
-      "dynamic_linking": "review_required",
-      "distribution": "review_required"
+      "static_linking": "compatible",
+      "dynamic_linking": "compatible",
+      "distribution": "compatible"
     },
     "GPL-3.0-with-GCC-exception": {
       "static_linking": "review_required",
@@ -56516,9 +56516,9 @@
       "distribution": "review_required"
     },
     "GPL-3.0": {
-      "static_linking": "review_required",
-      "dynamic_linking": "review_required",
-      "distribution": "review_required"
+      "static_linking": "compatible",
+      "dynamic_linking": "compatible",
+      "distribution": "compatible"
     },
     "Game-Programming-Gems": {
       "static_linking": "compatible",
@@ -60158,9 +60158,9 @@
       "distribution": "review_required"
     },
     "GPL-3.0+": {
-      "static_linking": "review_required",
-      "dynamic_linking": "review_required",
-      "distribution": "review_required"
+      "static_linking": "compatible",
+      "dynamic_linking": "compatible",
+      "distribution": "compatible"
     },
     "GPL-3.0-only": {
       "static_linking": "review_required",
@@ -71164,9 +71164,9 @@
       "distribution": "review_required"
     },
     "GPL-3.0-only": {
-      "static_linking": "review_required",
-      "dynamic_linking": "review_required",
-      "distribution": "review_required"
+      "static_linking": "compatible",
+      "dynamic_linking": "compatible",
+      "distribution": "compatible"
     },
     "GPL-3.0-or-later": {
       "static_linking": "review_required",

--- a/ospac/data/compatibility/relationships/lgpl.json
+++ b/ospac/data/compatibility/relationships/lgpl.json
@@ -1866,9 +1866,9 @@
       "distribution": "review_required"
     },
     "LGPL-2.0-or-later": {
-      "static_linking": "review_required",
+      "static_linking": "compatible",
       "dynamic_linking": "compatible",
-      "distribution": "review_required"
+      "distribution": "compatible"
     },
     "LGPL-2.0": {
       "static_linking": "review_required",
@@ -5538,9 +5538,9 @@
       "distribution": "review_required"
     },
     "LGPL-2.0": {
-      "static_linking": "review_required",
+      "static_linking": "compatible",
       "dynamic_linking": "compatible",
-      "distribution": "review_required"
+      "distribution": "compatible"
     },
     "LGPL-2.1+": {
       "static_linking": "review_required",
@@ -9190,9 +9190,9 @@
       "distribution": "review_required"
     },
     "LGPL-2.0+": {
-      "static_linking": "review_required",
+      "static_linking": "compatible",
       "dynamic_linking": "compatible",
-      "distribution": "review_required"
+      "distribution": "compatible"
     },
     "LGPL-2.0-only": {
       "static_linking": "review_required",
@@ -12862,9 +12862,9 @@
       "distribution": "review_required"
     },
     "LGPL-2.0-only": {
-      "static_linking": "review_required",
+      "static_linking": "compatible",
       "dynamic_linking": "compatible",
-      "distribution": "review_required"
+      "distribution": "compatible"
     },
     "LGPL-2.0-or-later": {
       "static_linking": "review_required",
@@ -16554,9 +16554,9 @@
       "distribution": "review_required"
     },
     "LGPL-2.1-or-later": {
-      "static_linking": "review_required",
+      "static_linking": "compatible",
       "dynamic_linking": "compatible",
-      "distribution": "review_required"
+      "distribution": "compatible"
     },
     "LGPL-2.1": {
       "static_linking": "review_required",
@@ -20226,9 +20226,9 @@
       "distribution": "review_required"
     },
     "LGPL-2.1": {
-      "static_linking": "review_required",
+      "static_linking": "compatible",
       "dynamic_linking": "compatible",
-      "distribution": "review_required"
+      "distribution": "compatible"
     },
     "LGPL-3.0+": {
       "static_linking": "review_required",
@@ -23878,9 +23878,9 @@
       "distribution": "review_required"
     },
     "LGPL-2.1+": {
-      "static_linking": "review_required",
+      "static_linking": "compatible",
       "dynamic_linking": "compatible",
-      "distribution": "review_required"
+      "distribution": "compatible"
     },
     "LGPL-2.1-only": {
       "static_linking": "review_required",
@@ -27550,9 +27550,9 @@
       "distribution": "review_required"
     },
     "LGPL-2.1-only": {
-      "static_linking": "review_required",
+      "static_linking": "compatible",
       "dynamic_linking": "compatible",
-      "distribution": "review_required"
+      "distribution": "compatible"
     },
     "LGPL-2.1-or-later": {
       "static_linking": "review_required",
@@ -31242,9 +31242,9 @@
       "distribution": "review_required"
     },
     "LGPL-3.0-or-later": {
-      "static_linking": "review_required",
+      "static_linking": "compatible",
       "dynamic_linking": "compatible",
-      "distribution": "review_required"
+      "distribution": "compatible"
     },
     "LGPL-3.0": {
       "static_linking": "review_required",
@@ -34914,9 +34914,9 @@
       "distribution": "review_required"
     },
     "LGPL-3.0": {
-      "static_linking": "review_required",
+      "static_linking": "compatible",
       "dynamic_linking": "compatible",
-      "distribution": "review_required"
+      "distribution": "compatible"
     },
     "LGPLLR": {
       "static_linking": "review_required",
@@ -38566,9 +38566,9 @@
       "distribution": "review_required"
     },
     "LGPL-3.0+": {
-      "static_linking": "review_required",
+      "static_linking": "compatible",
       "dynamic_linking": "compatible",
-      "distribution": "review_required"
+      "distribution": "compatible"
     },
     "LGPL-3.0-only": {
       "static_linking": "review_required",
@@ -42238,9 +42238,9 @@
       "distribution": "review_required"
     },
     "LGPL-3.0-only": {
-      "static_linking": "review_required",
+      "static_linking": "compatible",
       "dynamic_linking": "compatible",
-      "distribution": "review_required"
+      "distribution": "compatible"
     },
     "LGPL-3.0-or-later": {
       "static_linking": "review_required",

--- a/ospac/data/compatibility/relationships/proprietary.json
+++ b/ospac/data/compatibility/relationships/proprietary.json
@@ -1191,9 +1191,9 @@
       "distribution": "review_required"
     },
     "Elastic-2.0": {
-      "static_linking": "review_required",
-      "dynamic_linking": "review_required",
-      "distribution": "review_required"
+      "static_linking": "compatible",
+      "dynamic_linking": "compatible",
+      "distribution": "compatible"
     },
     "Entessa": {
       "static_linking": "review_required",
@@ -6388,9 +6388,9 @@
       "distribution": "review_required"
     },
     "PolyForm-Noncommercial-1.0.0": {
-      "static_linking": "review_required",
-      "dynamic_linking": "review_required",
-      "distribution": "review_required"
+      "static_linking": "compatible",
+      "dynamic_linking": "compatible",
+      "distribution": "compatible"
     },
     "PolyForm-Small-Business-1.0.0": {
       "static_linking": "review_required",

--- a/ospac/data/licenses/json/BSD-4-Clause-Shortened.json
+++ b/ospac/data/licenses/json/BSD-4-Clause-Shortened.json
@@ -32,9 +32,11 @@
         ],
         "incompatible_with": [
           "GPL-2.0",
+          "GPL-2.0+",
           "GPL-2.0-only",
           "GPL-2.0-or-later",
           "GPL-3.0",
+          "GPL-3.0+",
           "GPL-3.0-only",
           "GPL-3.0-or-later"
         ],
@@ -46,9 +48,11 @@
         ],
         "incompatible_with": [
           "GPL-2.0",
+          "GPL-2.0+",
           "GPL-2.0-only",
           "GPL-2.0-or-later",
           "GPL-3.0",
+          "GPL-3.0+",
           "GPL-3.0-only",
           "GPL-3.0-or-later"
         ],

--- a/ospac/data/licenses/json/BSD-4-Clause-UC.json
+++ b/ospac/data/licenses/json/BSD-4-Clause-UC.json
@@ -32,9 +32,11 @@
         ],
         "incompatible_with": [
           "GPL-2.0",
+          "GPL-2.0+",
           "GPL-2.0-only",
           "GPL-2.0-or-later",
           "GPL-3.0",
+          "GPL-3.0+",
           "GPL-3.0-only",
           "GPL-3.0-or-later"
         ],
@@ -46,9 +48,11 @@
         ],
         "incompatible_with": [
           "GPL-2.0",
+          "GPL-2.0+",
           "GPL-2.0-only",
           "GPL-2.0-or-later",
           "GPL-3.0",
+          "GPL-3.0+",
           "GPL-3.0-only",
           "GPL-3.0-or-later"
         ],

--- a/ospac/data/licenses/json/BSD-4-Clause.json
+++ b/ospac/data/licenses/json/BSD-4-Clause.json
@@ -32,9 +32,11 @@
         ],
         "incompatible_with": [
           "GPL-2.0",
+          "GPL-2.0+",
           "GPL-2.0-only",
           "GPL-2.0-or-later",
           "GPL-3.0",
+          "GPL-3.0+",
           "GPL-3.0-only",
           "GPL-3.0-or-later"
         ],
@@ -46,9 +48,11 @@
         ],
         "incompatible_with": [
           "GPL-2.0",
+          "GPL-2.0+",
           "GPL-2.0-only",
           "GPL-2.0-or-later",
           "GPL-3.0",
+          "GPL-3.0+",
           "GPL-3.0-only",
           "GPL-3.0-or-later"
         ],

--- a/ospac/data/licenses/json/GPL-2.0+.json
+++ b/ospac/data/licenses/json/GPL-2.0+.json
@@ -33,7 +33,10 @@
           "category:public_domain"
         ],
         "incompatible_with": [
-          "category:proprietary"
+          "category:proprietary",
+          "BSD-4-Clause",
+          "BSD-4-Clause-Shortened",
+          "BSD-4-Clause-UC"
         ],
         "requires_review": [
           "category:copyleft_weak",
@@ -51,7 +54,10 @@
           "category:public_domain"
         ],
         "incompatible_with": [
-          "category:proprietary"
+          "category:proprietary",
+          "BSD-4-Clause",
+          "BSD-4-Clause-Shortened",
+          "BSD-4-Clause-UC"
         ],
         "requires_review": [
           "category:copyleft_weak",

--- a/ospac/data/licenses/json/GPL-3.0+.json
+++ b/ospac/data/licenses/json/GPL-3.0+.json
@@ -33,7 +33,10 @@
           "category:public_domain"
         ],
         "incompatible_with": [
-          "category:proprietary"
+          "category:proprietary",
+          "BSD-4-Clause",
+          "BSD-4-Clause-Shortened",
+          "BSD-4-Clause-UC"
         ],
         "requires_review": [
           "category:copyleft_weak",
@@ -51,7 +54,10 @@
           "category:public_domain"
         ],
         "incompatible_with": [
-          "category:proprietary"
+          "category:proprietary",
+          "BSD-4-Clause",
+          "BSD-4-Clause-Shortened",
+          "BSD-4-Clause-UC"
         ],
         "requires_review": [
           "category:copyleft_weak",

--- a/ospac/models/license.py
+++ b/ospac/models/license.py
@@ -21,6 +21,13 @@ class License:
 
     def is_compatible_with(self, other: "License", context: str = "general") -> bool:
         """Check if this license is compatible with another."""
+        from ospac.utils.validation import canonical_spdx_id
+
+        # Two spellings of the same license are the same license: GPL-2.0 is the
+        # deprecated alias of GPL-2.0-only.
+        if canonical_spdx_id(self.id) == canonical_spdx_id(other.id):
+            return True
+
         if context not in self.compatibility:
             context = "general"
 

--- a/ospac/pipeline/data_generator.py
+++ b/ospac/pipeline/data_generator.py
@@ -142,8 +142,8 @@ _KNOWN_INCOMPATIBLE_PAIRS = [
     # The 4-clause BSD advertising requirement is an additional restriction no GPL
     # version permits.
     ({"BSD-4-Clause", "BSD-4-Clause-UC", "BSD-4-Clause-Shortened"},
-     {"GPL-2.0", "GPL-2.0-only", "GPL-2.0-or-later",
-      "GPL-3.0", "GPL-3.0-only", "GPL-3.0-or-later"}),
+     {"GPL-2.0", "GPL-2.0-only", "GPL-2.0-or-later", "GPL-2.0+",
+      "GPL-3.0", "GPL-3.0-only", "GPL-3.0-or-later", "GPL-3.0+"}),
 ]
 
 
@@ -839,9 +839,18 @@ class PolicyDataGenerator:
         Uses the LLM-generated compatibility_rules from license1 when available,
         falling back to category-level inference only when the specific pair is unlisted.
         """
+        from ospac.utils.validation import canonical_spdx_id
+
         id2 = license2.get("license_id", "")
         cat2 = license2.get("category", "permissive")
         rules = license1.get("compatibility_rules", {})
+
+        # Two spellings of the same license are the same license. Without this,
+        # GPL-2.0 and GPL-2.0-only were reported as a pair needing review.
+        id1 = license1.get("license_id", "")
+        if id1 and id2 and canonical_spdx_id(id1) == canonical_spdx_id(id2):
+            return {"static_linking": "compatible", "dynamic_linking": "compatible",
+                    "distribution": "compatible"}
 
         def resolve(section_key: str) -> str:
             section = rules.get(section_key, {})

--- a/ospac/runtime/engine.py
+++ b/ospac/runtime/engine.py
@@ -11,7 +11,7 @@ import shutil
 
 from ospac.runtime.loader import PolicyLoader
 from ospac.runtime.evaluator import RuleEvaluator
-from ospac.models.compliance import ComplianceResult, PolicyResult, ActionType
+from ospac.models.compliance import ComplianceResult, ComplianceStatus, PolicyResult, ActionType
 from ospac.utils.validation import validate_license_id
 
 class PolicyRuntime:
@@ -259,7 +259,30 @@ class PolicyRuntime:
         # The result always reported an empty licenses_checked even though exactly two
         # licenses were checked.
         compliance.licenses_checked = [license1, license2]
+
+        # The dataset's known-incompatible pairs outrank a category-level approval,
+        # the same precedence named exceptions get in License.is_compatible_with.
+        # Policy rules only enumerated some of the pairs, so GPL-2.0 with BSD-4-Clause
+        # was reported compliant while the records named each other incompatible.
+        if compliance.is_compliant or compliance.needs_review:
+            if (self._dataset_names_incompatible(license1, license2)
+                    or self._dataset_names_incompatible(license2, license1)):
+                compliance.status = ComplianceStatus.NON_COMPLIANT
+                compliance.add_violation(
+                    "dataset_known_incompatibility",
+                    f"{license1} and {license2} are a known incompatible pair in the "
+                    f"license dataset")
         return compliance
+
+    def _dataset_names_incompatible(self, license_a: str, license_b: str) -> bool:
+        """True if license_a's record names license_b in its incompatible list."""
+        try:
+            record = self.lookup_license_data(license_a)
+        except ValueError:
+            return False
+        block = (((record or {}).get("license") or {}).get("compatibility") or {})
+        incompatible = (block.get("static_linking") or {}).get("incompatible_with", [])
+        return license_b in incompatible
 
     def get_obligations(self, licenses: List[str], data_dir: Optional[str] = None) -> Dict[str, Any]:
         """

--- a/ospac/utils/__init__.py
+++ b/ospac/utils/__init__.py
@@ -3,6 +3,6 @@ OSPAC utility functions.
 """
 
 from ospac.utils.data_validation import KNOWN_LICENSES, validate_license
-from ospac.utils.validation import validate_license_id, validate_license_path
+from ospac.utils.validation import canonical_spdx_id, validate_license_id, validate_license_path
 
 __all__ = ["KNOWN_LICENSES", "validate_license", "validate_license_id", "validate_license_path"]

--- a/ospac/utils/validation.py
+++ b/ospac/utils/validation.py
@@ -123,3 +123,22 @@ def validate_license_path(
         )
 
     return target_resolved
+
+
+def canonical_spdx_id(license_id: str) -> str:
+    """
+    Resolve a deprecated GPL-family spelling to its canonical SPDX identifier.
+
+    SPDX deprecated the bare and "+" spellings in favour of "-only" and "-or-later":
+    GPL-2.0 means GPL-2.0-only and GPL-3.0+ means GPL-3.0-or-later. Compatibility
+    logic that compares identifiers verbatim called two spellings of the same
+    license a pair needing review. Only the GPL, LGPL and AGPL families carry this
+    aliasing; every other identifier is returned unchanged.
+    """
+    import re
+
+    if re.fullmatch(r"[AL]?GPL-\d+\.\d+\+", license_id):
+        return license_id[:-1] + "-or-later"
+    if re.fullmatch(r"[AL]?GPL-\d+\.\d+", license_id):
+        return license_id + "-only"
+    return license_id

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ospac"
-version = "1.4.4"
+version = "1.4.5"
 description = "Open Source Policy as Code - License compliance policy engine"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -777,3 +777,53 @@ class TestZeroClauseLicensesAskNothing:
         assert record["obligations"] == []
         assert record["requirements"]["include_license"] is False
         assert record["requirements"]["include_copyright"] is False
+
+
+class TestKnownPairEnforcement:
+    """
+    A review of the v1.4.1 to v1.4.4 diff found the known-incompatible table missed
+    the deprecated + spellings, the runtime never enforced the table beyond the few
+    enumerated policy pairs, and alias spellings of one license were reported as a
+    pair needing review.
+    """
+
+    def test_plus_aliases_are_in_the_exception_table(self):
+        from ospac.pipeline.data_generator import _known_incompatible_ids
+
+        assert "BSD-4-Clause" in _known_incompatible_ids("GPL-3.0+")
+        assert "BSD-4-Clause" in _known_incompatible_ids("GPL-2.0+")
+
+    def test_runtime_check_enforces_every_known_pair(self):
+        from ospac.pipeline.data_generator import _KNOWN_INCOMPATIBLE_PAIRS
+        from ospac.runtime.engine import PolicyRuntime
+
+        runtime = PolicyRuntime()
+        compliant = []
+        for side_a, side_b in _KNOWN_INCOMPATIBLE_PAIRS:
+            for a in side_a:
+                for b in side_b:
+                    for x, y in ((a, b), (b, a)):
+                        if runtime.check_compatibility(x, y).is_compliant:
+                            compliant.append(f"{x} vs {y}")
+        assert compliant == [], (
+            "known incompatible pairs the runtime reports compliant: "
+            + "; ".join(compliant[:6]))
+
+    def test_alias_spellings_are_the_same_license(self):
+        import json
+
+        from ospac.models.license import License
+
+        data_dir = Path(__file__).parent.parent / "ospac" / "data" / "licenses" / "json"
+
+        def load(lid):
+            return License.from_dict(
+                json.loads((data_dir / f"{lid}.json").read_text())["license"])
+
+        assert load("GPL-2.0").is_compatible_with(load("GPL-2.0-only")) is True
+        assert load("GPL-3.0+").is_compatible_with(load("GPL-3.0-or-later")) is True
+
+        tree = json.loads((Path(__file__).parent.parent / "ospac" / "data"
+                           / "compatibility" / "relationships" / "gpl.json").read_text())
+        assert tree["GPL-2.0"]["GPL-2.0-only"]["static_linking"] == "compatible"
+        assert tree["GPL-3.0+"]["BSD-4-Clause"]["static_linking"] == "incompatible"


### PR DESCRIPTION
An independent review of the v1.4.1 to v1.4.4 diff found three defects in the
compatibility work, each verified by execution before fixing.

The known-incompatible table listed only the modern GPL spellings against
4-clause BSD, so GPL-3.0+, the deprecated alias of GPL-3.0-or-later, was
reported compatible with BSD-4-Clause in the generated data. Both + spellings
are in the pair now.

check answered from policy rules alone, and the policy only enumerated some of
the pairs, so GPL-2.0 with BSD-4-Clause reported compliant while the records
named each other incompatible: 30 of 48 pair directions passed. The dataset's
named incompatibilities now outrank category-level approvals in
check_compatibility, the same precedence named exceptions get in
License.is_compatible_with, and a test sweeps every table direction through the
runtime. All 60 directions deny.

GPL-2.0 and GPL-2.0-only are one license in two spellings, but the relationships
tree marked the pair review_required and is_compatible_with returned false. A
canonical-identifier helper resolves the deprecated bare and + GPL-family
spellings, and both consumers treat alias-equal identifiers as identical. Five
records and the tree rebuilt.
