### PR TITLE
ci: limit the docs workflow token to contents read

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,10 @@ on:
     paths:
       - 'docs/**'
 
+# The job only builds and link-checks the site, so the token needs nothing but read.
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build the site


### PR DESCRIPTION
The job only builds and link-checks the site, and it was the one workflow without
an explicit permissions block, which code scanning flagged.
