### PR TITLE
fix: canonicalize GFDL invariant variants and reject malformed check input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to OSPAC (Open Source Policy as Code) will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2026-08-15
+
+An independent review of 1.5.0 found two defects, both verified by execution and both
+now pinned by tests.
+
+### Fixed
+
+**GFDL invariant variants did not canonicalize**
+- The alias map correctly sent `gfdl-1.3-no-invariants` to `GFDL-1.3-no-invariants-only`,
+  but `canonical_spdx_id` only handled the bare GFDL forms, so `is_compatible_with` still
+  answered false for two spellings of the same license. The invariants and no-invariants
+  variants now canonicalize exactly like the bare forms.
+
+**`check -l` silently repaired malformed input**
+- Empty comma fields were dropped before counting, so `-l "MIT,,GPL-3.0"` and a trailing
+  comma exited zero as a valid-looking two-license check. Malformed automation input now
+  gets a usage error naming what was received; padded but well-formed input still works.
+
 ## [1.5.0] - 2026-08-15
 
 ### Added

--- a/ospac/cli/commands.py
+++ b/ospac/cli/commands.py
@@ -163,9 +163,12 @@ def check(license1: Optional[str], license2: Optional[str], licenses_opt: Option
     if licenses_opt is not None:
         if license1 or license2:
             raise click.UsageError("Pass either -l \"A,B\" or two positional licenses, not both.")
-        parts = [part.strip() for part in licenses_opt.split(",") if part.strip()]
-        if len(parts) != 2:
-            raise click.UsageError(f"-l needs exactly two licenses, got {len(parts)}.")
+        parts = [part.strip() for part in licenses_opt.split(",")]
+        if len(parts) != 2 or not all(parts):
+            # Malformed automation input such as "MIT,,GPL-3.0" or a trailing comma
+            # must not be silently repaired into a valid-looking two-license check.
+            raise click.UsageError(
+                f'-l needs exactly two licenses, e.g. -l "MIT,GPL-3.0"; got {licenses_opt!r}.')
         license1, license2 = parts
     elif not (license1 and license2):
         raise click.UsageError('Provide two licenses: ospac check MIT GPL-3.0, or ospac check -l "MIT,GPL-3.0".')

--- a/ospac/utils/validation.py
+++ b/ospac/utils/validation.py
@@ -137,9 +137,10 @@ def canonical_spdx_id(license_id: str) -> str:
     """
     import re
 
-    if re.fullmatch(r"([AL]?GPL|GFDL)-\d+\.\d+\+", license_id):
+    base = r"(?:[AL]?GPL-\d+\.\d+|GFDL-\d+\.\d+(?:-no-invariants|-invariants)?)"
+    if re.fullmatch(base + r"\+", license_id):
         return license_id[:-1] + "-or-later"
-    if re.fullmatch(r"([AL]?GPL|GFDL)-\d+\.\d+", license_id):
+    if re.fullmatch(base, license_id):
         return license_id + "-only"
     return license_id
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ospac"
-version = "1.5.0"
+version = "1.5.1"
 description = "Open Source Policy as Code - License compliance policy engine"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -428,3 +428,20 @@ class TestCheckAcceptsStandardInput:
         payload = json.loads(result.output)
         assert payload["aliases"]["expat"] == "MIT"
         assert "gpl" in payload["never_resolve"]
+
+
+class TestCheckRejectsMalformedList:
+    """Empty comma fields were silently repaired into a valid-looking check."""
+
+    def test_empty_middle_field_is_rejected(self, runner):
+        result = runner.invoke(cli, ["check", "-l", "MIT,,GPL-3.0"])
+        assert result.exit_code != 0
+        assert "exactly two" in result.output
+
+    def test_trailing_comma_is_rejected(self, runner):
+        result = runner.invoke(cli, ["check", "-l", "MIT,GPL-3.0,"])
+        assert result.exit_code != 0
+
+    def test_padded_but_wellformed_input_still_works(self, runner):
+        result = runner.invoke(cli, ["check", "-l", " MIT , GPL-3.0 "])
+        assert result.exit_code == 0, result.output

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -891,3 +891,25 @@ class TestLicenseAliases:
         expected = {a: next(iter(ids)) for a, ids in owners.items()
                     if len(ids) == 1 and a not in NEVER_RESOLVE}
         assert ospac.license_aliases() == expected
+
+
+class TestGfdlInvariantsCanonicalize:
+    """
+    The invariants variants alias exactly like the bare forms: the flattener already
+    mapped gfdl-1.3-no-invariants forward, but canonical_spdx_id did not, so the same
+    license in two spellings still got a wrong incompatibility answer from
+    is_compatible_with.
+    """
+
+    def test_invariants_spellings_map_forward(self):
+        from ospac.utils.validation import canonical_spdx_id
+
+        assert canonical_spdx_id("GFDL-1.3-no-invariants") == "GFDL-1.3-no-invariants-only"
+        assert canonical_spdx_id("GFDL-1.2-invariants+") == "GFDL-1.2-invariants-or-later"
+
+    def test_alias_pair_is_compatible(self):
+        from ospac.models.license import License
+
+        bare = License(id="GFDL-1.3-no-invariants", name="", type="copyleft_strong")
+        only = License(id="GFDL-1.3-no-invariants-only", name="", type="copyleft_strong")
+        assert bare.is_compatible_with(only) is True


### PR DESCRIPTION
An independent review of 1.5.0 found two defects, both verified by execution.

The alias map correctly sent gfdl-1.3-no-invariants to
GFDL-1.3-no-invariants-only, but canonical_spdx_id only handled the bare GFDL
forms, so is_compatible_with still answered false for two spellings of the same
license. The invariants and no-invariants variants now canonicalize exactly like
the bare forms.

check -l dropped empty comma fields before counting, so -l "MIT,,GPL-3.0" and a
trailing comma exited zero as a valid-looking two-license check. Malformed
automation input now gets a usage error naming what was received; padded but
well-formed input still works.
