### PR TITLE
docs: document the data export contract and version policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to OSPAC (Open Source Policy as Code) will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+**The data export contract is documented** (#83)
+- `index.json` has carried a `version` field since the first release with no stated
+  meaning, so a downstream consumer had to infer whether it tracked the schema or the
+  data. [Data contract](https://semclone.github.io/ospac/data-contract/) now states which
+  files and fields are the published surface, what triggers a version bump, which of
+  `version`, `generated` and `spdx_list_version` answers staleness, and how a removal is
+  announced. Linked from the README and from The dataset.
+- `ospac.data_version()` returns the dataset's own metadata as a frozen `DataVersion`, so
+  a consumer can gate on `schema_version_info` at import instead of parsing `index.json`.
+  `ospac.DATA_SCHEMA_VERSION` is the same value as a constant for a build-time pin.
+- `version` is now a three-part string across `index.json`, `aliases.json` and
+  `compatibility/metadata.json`, and `aliases.json` carries it for the first time. The
+  old two-part `"1.0"` sorted below `"1.9"` at `"1.10"` under both float and string
+  comparison, which is a live hazard the first time the minor version reaches double
+  digits. The generator writes the constant rather than a literal per call site.
+- `tests/test_data_contract.py` pins every field the contract names, so a silent removal
+  fails CI.
+
+### Fixed
+
+**`schemas/license_schema.json` described data that no longer existed**
+- The schema was referenced by nothing, and had drifted far enough to reject all 733
+  records it describes: five of the ten license families were missing from its `type` enum,
+  which also listed a `restrictive` value that is not a valid family, its
+  `contamination_effect` enum listed three values the generator never emits and omitted
+  three it does, and `additionalProperties: false` rejected `aliases`, `alias_of`,
+  `spdx_metadata`, `generated` and `spdx_list_version`. A stale schema in a directory
+  called `schemas/` is worse than none, because it reads as authoritative. It now matches
+  the shipped data and is declared normative for consumers: its value domains are pinned
+  by test to the same constants the dataset validator uses, and all 733 records are
+  validated against it in CI.
+- `contamination_effect` was documented as taking `none`, `file`, `library` or `project`.
+  The real values are `none`, `module`, `derivative`, `full` and `unknown`, and the
+  documentation had never matched the generator.
+
 ## [1.5.1] - 2026-08-15
 
 An independent review of 1.5.0 found two defects, both verified by execution and both

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include README.md
 include LICENSE
 include ospac/data/LICENSE
+include schemas/license_schema.json
 recursive-include ospac/data *.json *.yaml *.yml *.txt
 recursive-include ospac/data/licenses *
 recursive-include ospac/data/compatibility *

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Full documentation is at **[semclone.github.io/ospac](https://semclone.github.io
 - [Commands](https://semclone.github.io/ospac/commands/): every CLI command and flag, with real output
 - [Policies](https://semclone.github.io/ospac/policies/): rule schema, how matching works, templates
 - [The dataset](https://semclone.github.io/ospac/dataset/): how license data is shaped, shipped, and regenerated
+- [Data contract](https://semclone.github.io/ospac/data-contract/): what a downstream consumer may rely on, what `version` means, how changes are announced
 - [Python API](https://semclone.github.io/ospac/api/): using OSPAC as a library
 - [Integration](https://semclone.github.io/ospac/integration/): CI, the SEMCL.ONE toolchain, MCP
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Python API
-nav_order: 5
+nav_order: 6
 description: Using ospac as a library, with the classes and methods it actually exposes.
 ---
 
@@ -14,8 +14,11 @@ and looks up license data.
 from ospac import PolicyRuntime, License, Policy, ComplianceResult
 ```
 
-Those four names are ospac's public surface. Anything under `ospac.pipeline` is
-dataset-generation machinery, not an API to build on.
+Those four names, plus `license_aliases`, `license_never_resolve` and `data_version`
+below, are ospac's public surface. `ospac.__all__` is the authoritative list and also
+carries `DataVersion`, the return type of `data_version()`, and the
+`DATA_SCHEMA_VERSION` constant. Anything under `ospac.pipeline` is dataset-generation
+machinery, not an API to build on.
 
 ## PolicyRuntime
 
@@ -183,6 +186,39 @@ your input lowercased. The never-resolve set is family names that must not map t
 one license, because resolving them fabricates a version the document never stated.
 Tools normalizing declared licenses should consume these instead of curating their own
 tables. See [The dataset]({{ site.baseurl }}/dataset/#aliases).
+
+## data_version
+
+What the bundled dataset says about itself, without parsing `index.json` by hand.
+
+```python
+import ospac
+
+info = ospac.data_version()
+info.schema_version        # '1.0.0'   shape of the shipped files
+info.schema_version_info   # (1, 0, 0) compare on this, not on the string
+info.spdx_list_version     # 'e4c1f27' upstream SPDX revision
+info.generated             # '2026-08-12T09:45:09.769222'
+info.total_licenses        # 733
+```
+
+The three version-ish fields answer different questions and are not interchangeable.
+`schema_version` says whether the shape is one you understand, `generated` says how stale
+your copy is, and `spdx_list_version` says which upstream produced it. A monthly refresh
+moves the second and third and leaves the first alone.
+
+Gate on the major version at import, so an incompatible dataset fails loudly instead of
+normalizing quietly wrong:
+
+```python
+major, _, _ = ospac.data_version().schema_version_info
+if major != 1:
+    raise RuntimeError(f"ospac data schema v{major} is not supported here")
+```
+
+`ospac.DATA_SCHEMA_VERSION` is the same string as a module constant, for a build-time pin.
+What a bump means, and which files and fields carry a promise at all, is on
+[Data contract]({{ site.baseurl }}/data-contract/).
 
 ## License
 

--- a/docs/data-contract.md
+++ b/docs/data-contract.md
@@ -1,0 +1,287 @@
+---
+layout: default
+title: Data contract
+nav_order: 5
+description: What a downstream consumer of the ospac dataset may rely on, what the version field means, and how changes are announced.
+---
+
+# Data contract
+
+[The dataset]({{ site.baseurl }}/dataset/) describes how the license data is shaped and
+where it comes from. This page is narrower and more boring: it is the promise. If you are
+reading `ospac/data/` from another tool, these are the files and fields you may build on,
+and this is what happens when one of them changes.
+
+The reason to write it down is that the alternative is inference. `index.json` has carried
+a `version` field since the first release, with no stated meaning, so a consumer had to
+guess whether it tracked the schema or the data. Three consumers guessing produce three
+different answers, which is the same failure that moved the alias table into the dataset in
+the first place. Guessing is cheap to prevent now and expensive to unwind later.
+
+## The published surface
+
+Four things are published. Everything else in the package is an implementation detail that
+may move or vanish in any release.
+
+| Path | What it is |
+|:--|:--|
+| `ospac/data/index.json` | Lookup index over every license: id, name, family, file path, deprecation flag, obligation count |
+| `ospac/data/aliases.json` | Flattened alias map and the never-resolve list |
+| `ospac/data/licenses/json/<id>.json` | One record per license, the full analysis |
+| `ospac/data/compatibility/` | `metadata.json`, `categories.json`, and `relationships/*.json` |
+
+### index.json
+
+```json
+{
+  "version": "1.0.0",
+  "generated": "2026-08-12T09:45:09.769222",
+  "spdx_list_version": "e4c1f27",
+  "total_licenses": 733,
+  "licenses": {
+    "MIT": {
+      "name": "MIT License",
+      "category": "permissive",
+      "file": "licenses/json/MIT.json",
+      "is_deprecated": false,
+      "obligations_count": 2
+    }
+  }
+}
+```
+
+Five top-level keys, five keys per record, and no others. `total_licenses` always equals
+the size of `licenses`. Every `file` path is relative to `ospac/data/` and always resolves.
+
+Worth knowing: ospac barely reads this file. Evaluation reads the per-license records,
+`aliases.json`, and `compatibility/`. The only internal reader is `data_version()`, which
+touches the four metadata keys and never opens the `licenses` map. So the whole per-record
+half of the index exists purely for consumers, and breaking it would fail no code path of
+ours. That is exactly why it is pinned by test rather than left to be noticed.
+
+The record field is called `category` here and `type` in the license record. They hold the
+same value from the same domain. The two names are historical, both are published, and
+neither will be renamed inside a major version.
+
+### aliases.json
+
+```json
+{
+  "version": "1.0.0",
+  "spdx_list_version": "e4c1f27",
+  "aliases": { "expat": "MIT", "gpl-3.0+": "GPL-3.0-or-later" },
+  "never_resolve": ["agpl", "apache", "bsd", "gpl", "lgpl", "public domain"]
+}
+```
+
+Keys in `aliases` are lowercased, so lowercase your input before looking it up. Every value
+is an id present in `index.json`. An alias claimed by more than one license is absent
+rather than resolved, because a confidently wrong answer is worse than none.
+
+`never_resolve` is not a subset of `aliases`, it is the complement: text that must not
+resolve to anything. `bsd` is 2-clause or 3-clause and the choice changes obligations. Treat
+these as unresolved rather than inventing a guess. Read both through
+[`license_aliases()` and `license_never_resolve()`]({{ site.baseurl }}/api/#license_aliases-and-license_never_resolve)
+rather than parsing the file, if you are in Python.
+
+### licenses/json/&lt;id&gt;.json
+
+The per-license record. Its shape is defined normatively by
+[`schemas/license_schema.json`](https://github.com/SemClone/ospac/blob/main/schemas/license_schema.json),
+and the field-by-field meanings are in
+[The dataset]({{ site.baseurl }}/dataset/#what-a-license-record-contains).
+
+Yes, normative. That schema used to be an unused internal artifact that had drifted so far
+out of date it rejected all 733 records it claimed to describe: five of the ten license
+families were absent from its `type` enum, three of the five real `contamination_effect`
+values were absent while three values the generator never emits were listed, and it was
+closed against five fields the records had carried for releases. It now matches the shipped
+data, its value domains are pinned by test to the same constants the dataset validator uses,
+and every shipped record is validated against it in CI. You can point a validator at it and
+trust the result.
+
+One deliberate looseness: the schema does not forbid unknown fields. The compatibility
+promise below permits new fields in a minor release, so a schema that rejected them would
+break every consumer on an additive change. Absence of a field is what the schema catches;
+addition of one is caught by our own test, not by yours.
+
+The schema lives in the repository and the source distribution, not in the wheel, because
+validating records is a consumer's CI activity rather than something the installed tool
+does. Vendor a copy at the major version you support rather than fetching it at runtime;
+ospac makes no network calls and neither should a compliance check.
+
+### compatibility/
+
+`metadata.json` publishes `version`, `generated`, `total_licenses`, `format`, and
+`default_status`. `categories.json` maps a family name to the license ids in it.
+`relationships/<family>.json` holds the pair rules.
+
+A relationship file is keyed by source license id, then by target license id, then by
+linking context:
+
+```json
+{
+  "Apache-1.0": {
+    "0BSD": {
+      "static_linking": "compatible",
+      "dynamic_linking": "compatible",
+      "distribution": "compatible"
+    }
+  }
+}
+```
+
+The family in the filename groups the *source* license only. Targets are every license, so
+`apache.json` contains rows for the three Apache sources against all 733 targets. Note that
+the pair rules carry a third context, `distribution`, which the per-license record's
+`compatibility` block does not have.
+
+**Budget for the size.** `relationships/` is currently about 73 MB across ten files, and
+`other.json` alone is 59 MB. Stream it or index it; do not plan on holding it in memory
+next to everything else you are doing.
+
+That size is the thing to know about `"format": "sparse"`, because the label promises more
+than the data delivers. The intent of the format is that pairs resolving to `unknown` are
+omitted. In the shipped data there are no `unknown` statuses, so nothing is omitted and the
+store is a full enumeration: all 733 by 733 pairs, 537,289 of them, are present. Treat
+`sparse` as a statement about the writer's rule, not as a promise that the file is small.
+
+`"default_status": "unknown"` is still the rule you must implement for a pair you cannot
+find: **unknown, not compatible**. Absence of a recorded conflict is not evidence of its
+absence. A consumer that treats a missing pair as approval will ship a violation and blame
+the dataset. Today no pair is missing, but that is a property of the current data and not a
+promise, so code the default anyway.
+
+Note also that the family names in `categories.json` (`gpl`, `bsd`, `cc`, `apache` and so
+on) are a different taxonomy from the `type`/`category` field on a license (`permissive`,
+`copyleft_strong` and so on). They are not interchangeable and one does not map onto the
+other.
+
+## What is not published
+
+These exist, and reading them is not a supported thing to do:
+
+- `obligation_database.json`, `ospac_license_database.json`, and `compatibility_matrix.json`.
+  Generation-time intermediates. They are deleted by the generator's own cleanup step, so
+  they are not in the wheel at all, and their `version` field is unrelated to this contract.
+- Everything under `ospac.pipeline`. Dataset-generation machinery. It calls an LLM; the
+  installed tool does not.
+- `ospac/defaults/` and `ospac/data/LICENSE`. The bundled default policy is documented as
+  behaviour, not as a data format, and it is opinionated on purpose. Copy it, do not parse it.
+- Any file added under `ospac/data/` that this page does not name. If you find something
+  useful there and want to depend on it, open an issue and it can be published deliberately.
+
+## What `version` means
+
+`version` is the version of the **data layout**, not of the ospac package and not of the
+license data. It is a three-part string, `MAJOR.MINOR.PATCH`, and it is the same value in
+`index.json`, `aliases.json`, and `compatibility/metadata.json`.
+
+| Change | Bump |
+|:--|:--|
+| A published field is removed or renamed, a type changes, or a documented meaning changes | MAJOR |
+| A published field is added, or a new file joins the published surface | MINOR |
+| The contract text is corrected without the shape changing | PATCH |
+| A monthly SPDX refresh: new licenses, changed classifications, updated deprecation flags | none |
+
+That last row is the important one. A dataset refresh changes hundreds of values and does
+not touch `version`, because the shape did not change. If you want to know whether your copy
+of the data is stale, `version` is the wrong field.
+
+Three parts rather than two, and a string rather than a number, for one reason: `1.10` sorts
+below `1.9` under both float and lexicographic comparison. Compare on integers.
+
+### version, generated, spdx_list_version
+
+Three fields, three questions, no overlap:
+
+| Field | Answers | Use it for |
+|:--|:--|:--|
+| `version` | Is the shape one I understand? | Compatibility gates |
+| `spdx_list_version` | Which upstream SPDX revision is this? | Provenance, reproducing a decision |
+| `generated` | When did the build that produced this run? | Staleness |
+
+For a staleness check, use `generated`. The dataset is rebuilt monthly, so data older than
+about six weeks means releases stopped arriving. `spdx_list_version` also moves on a refresh
+but it is a commit hash, so it tells you *which* upstream you have and not *how old* it is.
+
+### Checking compatibility from Python
+
+Rather than opening `index.json` yourself:
+
+```python
+import ospac
+
+info = ospac.data_version()
+info.schema_version        # "1.0.0"
+info.schema_version_info   # (1, 0, 0)
+info.spdx_list_version     # "e4c1f27"
+info.generated             # "2026-08-12T09:45:09.769222"
+info.total_licenses        # 733
+```
+
+Assert once, at import, so an incompatible dataset fails loudly instead of producing quietly
+wrong normalization:
+
+```python
+import ospac
+
+major, _, _ = ospac.data_version().schema_version_info
+if major != 1:
+    raise RuntimeError(f"ospac data schema v{major} is not supported by this consumer")
+```
+
+`ospac.DATA_SCHEMA_VERSION` is the same value as a module constant, for a build-time pin.
+
+## The compatibility promise
+
+Within a major version:
+
+- No published field is removed, renamed, or retyped.
+- No published field's meaning changes. If the meaning has to change, that is a new field
+  and the old one is deprecated, not a redefinition of the existing one.
+- Fields may be added. Tolerate unknown keys.
+- Values may change freely. A license may be reclassified, gain obligations, or flip its
+  deprecation flag on any monthly refresh. The contract is about shape, never about
+  verdicts. If a reclassification would change your output, pin `spdx_list_version` in
+  whatever you store, so you can explain a decision later.
+- License ids may appear and disappear, following SPDX. A deprecated id is kept, with
+  `is_deprecated: true`, so a removal from upstream does not orphan an id you already
+  recorded.
+
+  `alias_of` is **not** guaranteed on a deprecated record. It is populated for the GPL,
+  LGPL, AGPL and GFDL spellings, where the deprecated form maps onto an unambiguous
+  `-only` or `-or-later` identifier. Fifteen other deprecated ids carry `alias_of: null`,
+  including `wxWindows`, `eCos-2.0`, `Net-SNMP`, the two `BSD-2-Clause-*BSD` spellings and
+  the seven `GPL-*-with-*-exception` ids, because SPDX replaced them with something other
+  than a single plain identifier. To migrate a stored id, read `alias_of` and fall back to
+  the alias map rather than assuming a non-null value.
+
+### How a removal is announced
+
+Nothing in the published surface is removed without all of:
+
+1. A minor release that documents the deprecation on this page and in the
+   [CHANGELOG](https://github.com/SemClone/ospac/blob/main/CHANGELOG.md), while the field
+   keeps working.
+2. At least one further minor release in which it still works.
+3. A major bump of `version` that removes it, called out in the changelog under a
+   `Breaking` heading.
+
+There is no in-band notice mechanism, no deprecation flag inside the JSON. The changelog
+and this page are the channel. If you consume the dataset in automation, watch releases.
+
+## How this is enforced
+
+`tests/test_data_contract.py` asserts every field named on this page, that the schema's
+value domains still match the dataset validator's constants, and that all 733 shipped
+records validate against the normative schema. A silent removal fails CI.
+
+The field lists in that test are typed out by hand rather than read from the data, on
+purpose. A test that derives its expectations from the file it is checking asserts only that
+the data equals itself, which is how a contract test passes through the exact change it was
+written to catch.
+
+The test does not pin values, only shape. It has to stay green across a monthly refresh that
+reclassifies licenses, and a test that pinned verdicts would fail on correct data and get
+weakened until it stopped meaning anything.

--- a/docs/dataset.md
+++ b/docs/dataset.md
@@ -45,7 +45,7 @@ every license file:
 
 ```json
 {
-  "version": "1.0",
+  "version": "1.0.0",
   "generated": "2026-08-01T03:04:52.358635",
   "spdx_list_version": "e4c1f27",
   "total_licenses": 733,
@@ -63,6 +63,10 @@ every license file:
 
 Note `spdx_list_version` in both the index and every license record. Every value in the
 dataset is traceable to a specific upstream SPDX commit and a generation timestamp.
+
+If you are reading these files from another tool, `version` and the field list are a
+promise, not an accident. What that promise covers is on
+[Data contract]({{ site.baseurl }}/data-contract/).
 
 ### The dataset is licensed separately from the code
 
@@ -141,7 +145,7 @@ the file on disk has the extra nesting level.
 | `requirements` | Conditions you must satisfy. The booleans here drive `obligations`. |
 | `limitations` | Disclaimer analysis: `liability: true` means the license disclaims liability, which is standard for OSS. `trademark_use: true` means trademark use is restricted. |
 | `compatibility` | Per-linking-context rules, derived from the record's category plus a table of known license-level exceptions such as GPL-2.0 with Apache-2.0. Entries are license ids or `category:<type>` specifiers; `category:any` means compatible with every family. Only the prose `notes` come from the analysis. |
-| `contamination_effect` | How far copyleft reaches: `none`, `file`, `library`, `project`. |
+| `contamination_effect` | How far copyleft reaches: `none`, `module` (the linked module only), `derivative` (derivative works only, which is what share-alike licenses such as CC-BY-SA require), `full` (the whole combined work), `unknown`. |
 | `obligations` | Human-readable duties, derived from `requirements`. |
 | `aliases` | Lowercased spellings that mean this license: its own id and name, the deprecated SPDX spellings mapped forward, and curated ecosystem spellings such as `expat` for MIT. Deprecated records carry an empty list; their strings live on the canonical record. |
 | `alias_of` | On a deprecated GPL, LGPL, AGPL or GFDL spelling: the canonical id it means. `null` elsewhere. |
@@ -159,10 +163,14 @@ the file on disk has the extra nesting level.
 ### Compatibility is stored sparsely
 
 `compatibility/metadata.json` records `"format": "sparse"` and
-`"default_status": "unknown"`. Pairs are not enumerated, since the full list would mean over
-250,000 pairs. Instead, licenses are grouped into families in `categories.json`, and only
-the rules *between* families are stored, in `relationships/`. A lookup resolves each
-license to its family and consults that rule.
+`"default_status": "unknown"`. The writer's rule is that a pair resolving to `unknown` is
+not written, and licenses are grouped into families in `categories.json` so that
+`relationships/` can be split into one file per source family.
+
+In practice the current data has no `unknown` statuses, so nothing is omitted and all 733
+by 733 pairs are on disk: 537,289 of them, about 73 MB. "Sparse" describes the intent, not
+today's file sizes. If you are consuming `relationships/` directly, read
+[Data contract]({{ site.baseurl }}/data-contract/) first, which documents the pair shape.
 
 The consequence worth internalising: a pair with no stored rule resolves to `unknown`, not
 to compatible. Absence of a recorded conflict is not evidence of compatibility.

--- a/docs/index.md
+++ b/docs/index.md
@@ -108,5 +108,6 @@ Decisions are reproducible, so the same inputs give byte-identical output run to
 | [Commands]({{ site.baseurl }}/commands/) | Every CLI command and flag, with real output |
 | [Policies]({{ site.baseurl }}/policies/) | Rule schema, matching, and the build-target templates |
 | [The dataset]({{ site.baseurl }}/dataset/) | How the license data is shaped, shipped, and regenerated |
+| [Data contract]({{ site.baseurl }}/data-contract/) | What a downstream consumer may rely on, and how changes are announced |
 | [Python API]({{ site.baseurl }}/api/) | Using ospac as a library |
 | [Integration]({{ site.baseurl }}/integration/) | CI, the SEMCL.ONE toolchain, and MCP |

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Integration
-nav_order: 6
+nav_order: 7
 description: Wiring ospac into CI, the SEMCL.ONE toolchain, and MCP.
 ---
 

--- a/ospac/__init__.py
+++ b/ospac/__init__.py
@@ -15,6 +15,7 @@ except PackageNotFoundError:  # running from a source tree that was never instal
     __version__ = "0.0.0.dev0"
 
 from ospac.aliases import license_aliases, license_never_resolve
+from ospac.dataset import DATA_SCHEMA_VERSION, DataVersion, data_version
 from ospac.runtime.engine import PolicyRuntime
 from ospac.models.license import License
 from ospac.models.policy import Policy
@@ -24,6 +25,9 @@ __all__ = [
     "PolicyRuntime",
     "license_aliases",
     "license_never_resolve",
+    "data_version",
+    "DataVersion",
+    "DATA_SCHEMA_VERSION",
     "License",
     "Policy",
     "ComplianceResult",

--- a/ospac/core/compatibility_matrix.py
+++ b/ospac/core/compatibility_matrix.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Set
 from enum import Enum
 
+from ospac.dataset import DATA_SCHEMA_VERSION
+
 
 class CompatibilityStatus(Enum):
     """License compatibility status."""
@@ -57,7 +59,7 @@ class CompatibilityMatrix:
 
         # Extract metadata
         self._metadata = {
-            "version": data.get("version", "1.0"),
+            "version": data.get("version", DATA_SCHEMA_VERSION),
             "generated": data.get("generated"),
             "total_licenses": len(compatibility),
             "format": "sparse",
@@ -324,7 +326,7 @@ class CompatibilityMatrix:
 
         # Save full matrix
         output_data = {
-            "version": self._metadata.get("version", "1.0"),
+            "version": self._metadata.get("version", DATA_SCHEMA_VERSION),
             "generated": self._metadata.get("generated"),
             "total_licenses": len(all_licenses),
             "compatibility": complete_matrix

--- a/ospac/data/aliases.json
+++ b/ospac/data/aliases.json
@@ -1,4 +1,5 @@
 {
+  "version": "1.0.0",
   "spdx_list_version": "e4c1f27",
   "aliases": {
     "0bsd": "0BSD",

--- a/ospac/data/compatibility/metadata.json
+++ b/ospac/data/compatibility/metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0",
+  "version": "1.0.0",
   "generated": "2026-08-15T11:21:20.451440",
   "total_licenses": 733,
   "format": "sparse",

--- a/ospac/data/index.json
+++ b/ospac/data/index.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0",
+  "version": "1.0.0",
   "generated": "2026-08-12T09:45:09.769222",
   "spdx_list_version": "e4c1f27",
   "total_licenses": 733,

--- a/ospac/dataset.py
+++ b/ospac/dataset.py
@@ -1,0 +1,75 @@
+"""
+Dataset version metadata.
+
+The shipped JSON carries its own schema version, and a consumer pinning against
+that shape needs one place to read it from and one place that says what a bump
+means. Left undocumented, every consumer parses `index.json` by hand and invents
+its own idea of what `version` promised, which is the same divergence the alias
+table was moved into the dataset to avoid.
+
+The contract itself is written down in docs/data-contract.md. This module is the
+programmatic half of it.
+"""
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Tuple
+
+# Version of the shipped data layout, not of the ospac package. MAJOR.MINOR.PATCH:
+# MAJOR for a removal or an incompatible change to a documented field, MINOR for a
+# purely additive field, PATCH for a correction to the contract that does not change
+# the shape. A monthly SPDX refresh changes `generated` and `spdx_list_version` and
+# leaves this alone.
+DATA_SCHEMA_VERSION = "1.0.0"
+
+_INDEX_FILE = Path(__file__).parent / "data" / "index.json"
+
+
+@dataclass(frozen=True)
+class DataVersion:
+    """
+    What the bundled dataset says about itself.
+
+    `schema_version` is the shape of the files. `spdx_list_version` is the upstream
+    SPDX commit the records were built from, and `generated` is when that build ran,
+    so the two provenance fields answer staleness and the schema field answers
+    compatibility. They move independently and conflating them is the mistake this
+    type exists to prevent.
+    """
+
+    schema_version: str
+    generated: str
+    spdx_list_version: str
+    total_licenses: int
+
+    @property
+    def schema_version_info(self) -> Tuple[int, ...]:
+        """
+        `schema_version` as integers, for comparison.
+
+        Compare on this rather than on the string. Lexicographic ordering puts
+        "1.10.0" below "1.9.0", which is wrong the first time the minor version
+        reaches double digits.
+        """
+        return tuple(int(part) for part in self.schema_version.split("."))
+
+
+def data_version() -> DataVersion:
+    """
+    Read the bundled dataset's version metadata.
+
+    Assert compatibility once at import rather than hoping the shape held:
+
+        import ospac
+        assert ospac.data_version().schema_version_info[0] == 1, "ospac data schema changed"
+    """
+    with open(_INDEX_FILE) as f:
+        index = json.load(f)
+
+    return DataVersion(
+        schema_version=index["version"],
+        generated=index["generated"],
+        spdx_list_version=index["spdx_list_version"],
+        total_licenses=index["total_licenses"],
+    )

--- a/ospac/pipeline/data_generator.py
+++ b/ospac/pipeline/data_generator.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Dict, List, Any, Optional
 from datetime import datetime
 
+from ospac.dataset import DATA_SCHEMA_VERSION
 from ospac.pipeline.spdx_processor import SPDXProcessor
 from ospac.pipeline.llm_analyzer import LicenseAnalyzer
 
@@ -849,9 +850,10 @@ class PolicyDataGenerator:
         # Initialize the matrix handler
         matrix_handler = CompatibilityMatrix(str(self.output_dir / "compatibility"))
 
-        # Build full matrix for conversion
+        # Build full matrix for conversion. The version travels through into
+        # compatibility/metadata.json, which is part of the published surface.
         full_matrix = {
-            "version": "1.0",
+            "version": DATA_SCHEMA_VERSION,
             "generated": datetime.now().isoformat(),
             "total_licenses": len(licenses),
             "compatibility": {}
@@ -985,6 +987,8 @@ class PolicyDataGenerator:
 
     def _generate_obligation_database(self, licenses: List[Dict[str, Any]]) -> Dict[str, Any]:
         """Generate obligation database."""
+        # Intermediate, deleted by _cleanup_temporary_files. Its version is local to this
+        # file and is not DATA_SCHEMA_VERSION, which covers the published surface only.
         obligations = {
             "version": "1.0",
             "generated": datetime.now().isoformat(),
@@ -1017,6 +1021,8 @@ class PolicyDataGenerator:
                                  compatibility_matrix: Dict[str, Any],
                                  obligation_database: Dict[str, Any]) -> None:
         """Generate master database with all license information."""
+        # Also an intermediate, cleaned up after generation. See the note above on why its
+        # version is not DATA_SCHEMA_VERSION.
         master_db = {
             "version": "1.0",
             "generated": datetime.now().isoformat(),
@@ -1271,6 +1277,7 @@ class PolicyDataGenerator:
             logger.warning(f"Ambiguous aliases resolve to nothing: {dropped}")
 
         payload = {
+            "version": DATA_SCHEMA_VERSION,
             "spdx_list_version": spdx_version,
             "aliases": aliases,
             "never_resolve": sorted(NEVER_RESOLVE),
@@ -1283,7 +1290,7 @@ class PolicyDataGenerator:
         """Build index.json from ALL license JSON files on disk, not just the current batch."""
         licenses_json_dir = self.output_dir / "licenses" / "json"
         index = {
-            "version": "1.0",
+            "version": DATA_SCHEMA_VERSION,
             "generated": datetime.now().isoformat(),
             "spdx_list_version": spdx_version,
             "total_licenses": 0,

--- a/schemas/license_schema.json
+++ b/schemas/license_schema.json
@@ -1,7 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "SPDX License Schema",
-  "description": "Schema for SPDX license data in OSPAC",
+  "$id": "https://raw.githubusercontent.com/SemClone/ospac/main/schemas/license_schema.json",
+  "title": "ospac license record",
+  "description": "Normative shape of a single record in ospac/data/licenses/json/. See docs/data-contract.md for the versioning and compatibility policy. Value domains here are pinned to VALID_TYPES and VALID_CONTAMINATION in ospac/utils/data_validation.py by tests/test_data_contract.py, so a change to the dataset rules cannot silently leave this file stale. Objects are deliberately open: the contract permits new fields in a minor version, so validation must not fail on a field it has not heard of.",
   "type": "object",
   "required": ["license"],
   "properties": {
@@ -10,34 +11,28 @@
       "required": [
         "id", "name", "type", "spdx_id", "properties",
         "requirements", "limitations", "compatibility",
-        "obligations", "key_requirements"
+        "obligations", "key_requirements", "aliases", "alias_of",
+        "spdx_metadata", "generated", "spdx_list_version"
       ],
       "properties": {
         "id": {
           "type": "string",
           "pattern": "^[A-Za-z0-9._+-]+$",
-          "description": "SPDX license identifier"
+          "description": "SPDX license identifier, and the filename stem"
         },
         "name": {
           "type": "string",
           "minLength": 1,
-          "description": "Full license name"
+          "description": "Full license name as SPDX publishes it"
         },
         "type": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": [
-                "permissive", "copyleft_weak", "copyleft_strong",
-                "proprietary", "public_domain", "restrictive"
-              ]
-            },
-            {
-              "type": "string",
-              "pattern": "^(permissive|copyleft_weak|copyleft_strong|proprietary|public_domain|restrictive)(\\|(permissive|copyleft_weak|copyleft_strong|proprietary|public_domain|restrictive))*$"
-            }
+          "type": "string",
+          "enum": [
+            "permissive", "copyleft_weak", "copyleft_strong", "network_copyleft",
+            "noncommercial", "no_derivatives", "source_available", "proprietary",
+            "public_domain", "unknown"
           ],
-          "description": "License type or combination of types separated by |"
+          "description": "License family. Policy rules match on this via license_type."
         },
         "spdx_id": {
           "type": "string",
@@ -70,8 +65,7 @@
               "type": "boolean",
               "description": "Allows private use"
             }
-          },
-          "additionalProperties": false
+          }
         },
         "requirements": {
           "type": "object",
@@ -109,8 +103,7 @@
               "type": "boolean",
               "description": "Must disclose source for network use"
             }
-          },
-          "additionalProperties": false
+          }
         },
         "limitations": {
           "type": "object",
@@ -118,18 +111,17 @@
           "properties": {
             "liability": {
               "type": "boolean",
-              "description": "Limits liability"
+              "description": "License disclaims liability"
             },
             "warranty": {
               "type": "boolean",
-              "description": "Excludes warranty"
+              "description": "License excludes warranty"
             },
             "trademark_use": {
               "type": "boolean",
-              "description": "Limits trademark use"
+              "description": "License restricts trademark use"
             }
-          },
-          "additionalProperties": false
+          }
         },
         "compatibility": {
           "type": "object",
@@ -146,15 +138,14 @@
             },
             "contamination_effect": {
               "type": "string",
-              "enum": ["none", "module", "file", "project", "network"],
-              "description": "Scope of license contamination"
+              "enum": ["none", "module", "derivative", "full", "unknown"],
+              "description": "How far copyleft reaches: none, the linked module, derivative works only, the whole combined work, or not determined"
             },
             "notes": {
               "type": "string",
-              "description": "Additional compatibility notes"
+              "description": "Prose compatibility notes, the only field here that comes from the license analysis"
             }
-          },
-          "additionalProperties": false
+          }
         },
         "obligations": {
           "type": "array",
@@ -162,7 +153,7 @@
             "type": "string",
             "minLength": 1
           },
-          "description": "License obligations and requirements"
+          "description": "Human-readable duties, derived mechanically from requirements and properties"
         },
         "key_requirements": {
           "type": "array",
@@ -170,10 +161,47 @@
             "type": "string",
             "minLength": 1
           },
-          "description": "Key license requirements summary"
+          "description": "Key license requirements summary, also derived"
+        },
+        "aliases": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Lowercased spellings that mean this license. Empty on a deprecated record, whose spellings live on the canonical record."
+        },
+        "alias_of": {
+          "type": ["string", "null"],
+          "description": "On a deprecated spelling, the canonical id it means. Null elsewhere."
+        },
+        "spdx_metadata": {
+          "type": "object",
+          "required": ["is_osi_approved", "is_fsf_libre", "is_deprecated"],
+          "properties": {
+            "is_osi_approved": {
+              "type": "boolean",
+              "description": "Upstream OSI approval flag"
+            },
+            "is_fsf_libre": {
+              "type": "boolean",
+              "description": "Upstream FSF libre flag"
+            },
+            "is_deprecated": {
+              "type": "boolean",
+              "description": "Upstream deprecation flag"
+            }
+          }
+        },
+        "generated": {
+          "type": "string",
+          "description": "ISO 8601 timestamp of the analysis that produced this record. Deterministic repairs do not re-stamp it."
+        },
+        "spdx_list_version": {
+          "type": "string",
+          "description": "Upstream SPDX revision this record was built from"
         }
-      },
-      "additionalProperties": false
+      }
     }
   },
   "definitions": {
@@ -186,24 +214,23 @@
           "items": {
             "type": "string"
           },
-          "description": "Licenses compatible with this one"
+          "description": "License ids or category:<type> specifiers compatible in this linking context"
         },
         "incompatible_with": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Licenses incompatible with this one"
+          "description": "License ids or category:<type> specifiers that conflict in this linking context"
         },
         "requires_review": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Licenses requiring manual review"
+          "description": "License ids or category:<type> specifiers needing manual review"
         }
-      },
-      "additionalProperties": false
+      }
     }
   }
 }

--- a/tests/test_data_contract.py
+++ b/tests/test_data_contract.py
@@ -1,0 +1,283 @@
+"""
+Pins the published data export contract.
+
+docs/data-contract.md tells consumers which files and fields they may rely on and
+promises that nothing there disappears without a major version bump. A promise with
+no test behind it is a comment, so every field named in that document is asserted
+here. If one of these fails, either the removal is intentional and the contract needs
+a major bump and a documented deprecation, or it is the accident this file exists to
+catch.
+
+Field lists are duplicated from the doc on purpose. Deriving them from the data would
+assert only that the data equals itself.
+"""
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+import ospac
+from ospac.dataset import DATA_SCHEMA_VERSION
+from ospac.utils.data_validation import VALID_CONTAMINATION, VALID_TYPES
+
+DATA_DIR = Path(ospac.__file__).parent / "data"
+SCHEMA_FILE = Path(__file__).parent.parent / "schemas" / "license_schema.json"
+
+INDEX_KEYS = {"version", "generated", "spdx_list_version", "total_licenses", "licenses"}
+INDEX_RECORD_KEYS = {"name", "category", "file", "is_deprecated", "obligations_count"}
+ALIASES_KEYS = {"version", "spdx_list_version", "aliases", "never_resolve"}
+COMPAT_METADATA_KEYS = {"version", "generated", "total_licenses", "format", "default_status"}
+LICENSE_RECORD_KEYS = {
+    "id", "name", "type", "spdx_id", "properties", "requirements", "limitations",
+    "compatibility", "obligations", "key_requirements", "aliases", "alias_of",
+    "spdx_metadata", "generated", "spdx_list_version",
+}
+
+
+def _load(*parts):
+    with open(DATA_DIR.joinpath(*parts)) as f:
+        return json.load(f)
+
+
+@pytest.fixture(scope="module")
+def index():
+    return _load("index.json")
+
+
+@pytest.fixture(scope="module")
+def aliases_payload():
+    return _load("aliases.json")
+
+
+@pytest.fixture(scope="module")
+def license_schema():
+    with open(SCHEMA_FILE) as f:
+        return json.load(f)
+
+
+class TestPublicFiles:
+    """The four published files exist where the contract says they do."""
+
+    @pytest.mark.parametrize("relative", [
+        "index.json",
+        "aliases.json",
+        "compatibility/metadata.json",
+        "compatibility/categories.json",
+    ])
+    def test_file_is_present(self, relative):
+        assert (DATA_DIR / relative).is_file(), f"published file missing: {relative}"
+
+    def test_relationships_directory_is_populated(self):
+        relationships = sorted((DATA_DIR / "compatibility" / "relationships").glob("*.json"))
+        assert relationships, "compatibility/relationships is empty"
+
+    def test_every_family_in_categories_has_a_relationship_file(self):
+        categories = _load("compatibility", "categories.json")
+        relationships = {p.stem for p in
+                         (DATA_DIR / "compatibility" / "relationships").glob("*.json")}
+        assert set(categories) <= relationships, (
+            f"families with no relationship file: {sorted(set(categories) - relationships)}")
+
+
+class TestIndex:
+    def test_top_level_keys(self, index):
+        assert set(index) == INDEX_KEYS
+
+    def test_record_keys(self, index):
+        # Sampled across the alphabet rather than every record; the schema test below
+        # covers all 733 license files exhaustively.
+        for license_id in ("MIT", "Apache-2.0", "GPL-3.0-only", "CC-BY-NC-4.0"):
+            assert set(index["licenses"][license_id]) == INDEX_RECORD_KEYS, license_id
+
+    def test_total_licenses_matches_the_map(self, index):
+        assert index["total_licenses"] == len(index["licenses"])
+
+    def test_every_indexed_file_exists(self, index):
+        missing = [entry["file"] for entry in index["licenses"].values()
+                   if not (DATA_DIR / entry["file"]).is_file()]
+        assert not missing, f"index points at absent files: {missing[:5]}"
+
+    def test_category_is_the_documented_domain(self, index):
+        categories = {entry["category"] for entry in index["licenses"].values()}
+        assert categories <= VALID_TYPES, f"undocumented categories: {categories - VALID_TYPES}"
+
+
+class TestAliases:
+    def test_top_level_keys(self, aliases_payload):
+        assert set(aliases_payload) == ALIASES_KEYS
+
+    def test_accessors_read_the_published_keys(self, aliases_payload):
+        assert ospac.license_aliases() == aliases_payload["aliases"]
+        assert ospac.license_never_resolve() == set(aliases_payload["never_resolve"])
+
+    def test_aliases_resolve_to_indexed_ids(self, aliases_payload, index):
+        unknown = sorted({v for v in aliases_payload["aliases"].values()
+                          if v not in index["licenses"]})
+        assert not unknown, f"aliases resolve to ids absent from the index: {unknown[:5]}"
+
+
+class TestCompatibilityMetadata:
+    def test_top_level_keys(self):
+        assert set(_load("compatibility", "metadata.json")) == COMPAT_METADATA_KEYS
+
+    def test_sparse_format_and_unknown_default_are_still_the_contract(self):
+        metadata = _load("compatibility", "metadata.json")
+        # A consumer that treats an absent pair as compatible is wrong, and the doc
+        # says so. If either value ever changes, that reasoning changes with it.
+        assert metadata["format"] == "sparse"
+        assert metadata["default_status"] == "unknown"
+
+
+class TestCompatibilityRelationships:
+    """
+    The contract describes the pair store's shape, so the shape is pinned.
+
+    Not its size. `relationships/` is a full 733x733 enumeration today because no pair
+    resolves to `unknown`, and asserting the pair count would fail on the first monthly
+    refresh that adds a license. The doc says as much and quotes the number as an
+    observation rather than a promise.
+    """
+
+    @pytest.fixture(scope="class")
+    def relationships(self):
+        loaded = {}
+        for path in sorted((DATA_DIR / "compatibility" / "relationships").glob("*.json")):
+            with open(path) as f:
+                loaded[path.stem] = json.load(f)
+        return loaded
+
+    def test_pairs_use_the_three_documented_contexts(self, relationships):
+        found = set()
+        for family in relationships.values():
+            for targets in family.values():
+                for pair in targets.values():
+                    found.add(frozenset(pair))
+        expected = {frozenset({"static_linking", "dynamic_linking", "distribution"})}
+        assert found == expected, f"pair context keys changed: {[sorted(k) for k in found]}"
+
+    def test_distribution_context_is_unique_to_the_pair_store(self):
+        # The doc warns that the pair rules carry a third context the per-license record
+        # does not. If a record ever grows one, that warning becomes misleading.
+        with open(DATA_DIR / "licenses" / "json" / "MIT.json") as f:
+            compatibility = json.load(f)["license"]["compatibility"]
+        assert "distribution" not in compatibility
+
+    def test_sources_and_targets_are_indexed_ids(self, relationships, index):
+        referenced = set()
+        for family in relationships.values():
+            referenced |= set(family)
+            for targets in family.values():
+                referenced |= set(targets)
+        unknown = sorted(referenced - set(index["licenses"]))
+        assert not unknown, f"pair store references unindexed ids: {unknown[:5]}"
+
+
+class TestDeprecationPointers:
+    def test_non_null_alias_of_always_resolves(self, index):
+        # The contract promises that `alias_of`, when present, resolves. It deliberately
+        # does not promise `alias_of` is non-null on a deprecated record, because 15 of
+        # them are null: SPDX replaced those ids with something other than one plain id.
+        dangling = []
+        for path in sorted((DATA_DIR / "licenses" / "json").glob("*.json")):
+            with open(path) as f:
+                record = json.load(f)["license"]
+            target = record["alias_of"]
+            if target is not None and target not in index["licenses"]:
+                dangling.append(f"{record['id']} -> {target}")
+        assert not dangling, f"alias_of points at unindexed ids: {dangling[:5]}"
+
+    def test_alias_of_is_null_or_a_string(self):
+        for path in sorted((DATA_DIR / "licenses" / "json").glob("*.json")):
+            with open(path) as f:
+                record = json.load(f)["license"]
+            assert record["alias_of"] is None or isinstance(record["alias_of"], str), path.name
+
+
+class TestSchemaVersion:
+    def test_all_published_files_carry_the_same_schema_version(self, index, aliases_payload):
+        metadata = _load("compatibility", "metadata.json")
+        assert index["version"] == DATA_SCHEMA_VERSION
+        assert aliases_payload["version"] == DATA_SCHEMA_VERSION
+        assert metadata["version"] == DATA_SCHEMA_VERSION
+
+    def test_version_is_a_three_part_string(self):
+        # Not a float, and not a two-part string: "1.10" sorts below "1.9" under both,
+        # which is the hazard the documented scheme exists to remove.
+        assert isinstance(DATA_SCHEMA_VERSION, str)
+        parts = DATA_SCHEMA_VERSION.split(".")
+        assert len(parts) == 3 and all(p.isdigit() for p in parts)
+
+    def test_data_version_reports_the_index_metadata(self, index):
+        reported = ospac.data_version()
+        assert reported.schema_version == index["version"]
+        assert reported.generated == index["generated"]
+        assert reported.spdx_list_version == index["spdx_list_version"]
+        assert reported.total_licenses == index["total_licenses"]
+
+    def test_schema_version_info_compares_numerically(self):
+        assert ospac.data_version().schema_version_info == (1, 0, 0)
+        assert (1, 9, 0) < (1, 10, 0)  # the ordering the string form gets wrong
+
+
+class TestLicenseRecordSchema:
+    """`schemas/license_schema.json` is normative, so it has to match the data."""
+
+    def test_schema_type_enum_tracks_the_validation_rules(self, license_schema):
+        enum = license_schema["properties"]["license"]["properties"]["type"]["enum"]
+        assert set(enum) == VALID_TYPES, "schema type enum drifted from VALID_TYPES"
+
+    def test_schema_contamination_enum_tracks_the_validation_rules(self, license_schema):
+        compatibility = license_schema["properties"]["license"]["properties"]["compatibility"]
+        enum = compatibility["properties"]["contamination_effect"]["enum"]
+        assert set(enum) == VALID_CONTAMINATION, "schema drifted from VALID_CONTAMINATION"
+
+    def test_schema_requires_every_documented_field(self, license_schema):
+        required = license_schema["properties"]["license"]["required"]
+        assert set(required) == LICENSE_RECORD_KEYS
+
+    def test_schema_itself_is_valid_draft_07(self, license_schema):
+        jsonschema.Draft7Validator.check_schema(license_schema)
+
+    def test_every_shipped_record_validates(self, license_schema):
+        validator = jsonschema.Draft7Validator(license_schema)
+        failures = []
+        for path in sorted((DATA_DIR / "licenses" / "json").glob("*.json")):
+            with open(path) as f:
+                record = json.load(f)
+            for error in validator.iter_errors(record):
+                failures.append(f"{path.name}: {error.message}")
+        assert not failures, "records violate the normative schema:\n" + "\n".join(failures[:10])
+
+    def test_every_record_has_exactly_the_documented_keys(self):
+        # The schema deliberately allows extra fields so an additive minor release does
+        # not break consumer validation. This asserts the actual surface, so a silent
+        # addition or removal still fails here and forces a contract decision.
+        offenders = []
+        for path in sorted((DATA_DIR / "licenses" / "json").glob("*.json")):
+            with open(path) as f:
+                wrapper = json.load(f)
+            if set(wrapper) != {"license"}:
+                offenders.append(f"{path.name}: wrapper keys {sorted(wrapper)}")
+                continue
+            keys = set(wrapper["license"])
+            if keys != LICENSE_RECORD_KEYS:
+                added = sorted(keys - LICENSE_RECORD_KEYS)
+                removed = sorted(LICENSE_RECORD_KEYS - keys)
+                offenders.append(f"{path.name}: added={added} removed={removed}")
+        assert not offenders, "record surface changed:\n" + "\n".join(offenders[:10])
+
+
+class TestPythonSurface:
+    def test_documented_names_are_exported(self):
+        for name in ("PolicyRuntime", "License", "Policy", "ComplianceResult",
+                     "license_aliases", "license_never_resolve", "data_version",
+                     "DataVersion", "DATA_SCHEMA_VERSION"):
+            assert name in ospac.__all__, f"{name} dropped from ospac.__all__"
+            assert hasattr(ospac, name)
+
+    def test_data_version_is_immutable(self):
+        reported = ospac.data_version()
+        with pytest.raises(Exception):
+            reported.schema_version = "9.9.9"


### PR DESCRIPTION
Closes #83.

## Why

`index.json` has carried a `version` field since the first release with no stated meaning, so a downstream consumer had to infer whether it tracked the schema or the data. Three consumers inferring separately is how one dataset gets read three different ways, which is the divergence the alias table was moved into the dataset to avoid, applied one level up.

## What is in here

**The contract.** New `docs/data-contract.md`, linked from `README.md` and the docs index. It names the four published files and their fields, defines `version` semantics and what triggers a bump, separates `version` from `generated` and `spdx_list_version` (only one of the three answers staleness), states what may change inside a major version, and defines how a removal is announced.

**`version` becomes a three-part string.** `"1.0"` to `"1.0.0"` in `index.json` and `compatibility/metadata.json`, and `aliases.json` gains the field for the first time. `"1.10"` sorts below `"1.9"` under both float and lexicographic comparison, which is live the first time the minor version reaches double digits. The generator now writes one shared `DATA_SCHEMA_VERSION` constant instead of a literal at each call site.

**A programmatic accessor.** `ospac.data_version()` returns a frozen `DataVersion`, so a consumer gates on `schema_version_info` at import rather than parsing `index.json` by hand:

```python
major, _, _ = ospac.data_version().schema_version_info
if major != 1:
    raise RuntimeError(f"ospac data schema v{major} is not supported here")
```

**`schemas/license_schema.json` is repaired and declared normative.** It was referenced by nothing and had rotted badly enough to reject **all 733** records it claimed to describe: its `oneOf` on `type` matched both branches for every single-value type, five of the ten families were missing from the enum while an invalid `restrictive` was listed, three of the five real `contamination_effect` values were missing, and `additionalProperties: false` rejected `aliases`, `alias_of`, `spdx_metadata`, `generated` and `spdx_list_version`. A stale schema in a directory called `schemas/` is worse than no schema, because it reads as authoritative. Its value domains are now pinned by test to the same constants the dataset validator uses, and every record is validated against it in CI. It deliberately does not close the object, because the contract permits additive fields in a minor release and a schema that rejected them would break every consumer on an additive change.

## Two documentation claims were wrong

**`contamination_effect`** was documented as `none`/`file`/`library`/`project`. The real values are `none`/`module`/`derivative`/`full`/`unknown`. The docs had never matched the generator.

**The compatibility store is not sparse.** `docs/dataset.md` said pairs are not enumerated and only inter-family rules are stored. It is a full dense enumeration: 537,289 pairs, 733 squared exactly, 73 MB, keyed by individual license id rather than by family. Both pages now describe what actually ships, and state the sizes and pair shape as observations rather than promises so the store can be compacted without contradicting the contract. Filed separately as #84, since it is a data problem and not a docs problem.

## Tests

`tests/test_data_contract.py`, 33 tests. Every field the contract names is pinned, so a silent removal fails CI.

The field lists are hand-typed rather than read from the data, because a test that derives its expectations from the file it is checking asserts only that the data equals itself, which is how a contract test passes through the exact change it was written to catch. The tests pin shape and never verdicts, so they stay green across a monthly refresh that reclassifies licenses.

Each load-bearing assertion was verified to actually go red by mutating its target and confirming the failure: dropping `obligations_count` from an index record, removing `network_copyleft` from the schema enum, deleting `version` from `aliases.json`, regressing `index.json` to `"1.0"`, dropping a documented linking context from a pair, and pointing a deprecated record's `alias_of` at a nonexistent id.

## Verification

- `219 passed`
- `python scripts/validate_data.py --data-dir ospac/data`: 0 errors across 733 records
- All 733 records validate against the repaired schema
- Nothing in the repo, tests or workflows string-compares or float-parses the dataset `version`; `spdx-sync.yml` regeneration reproduces `"1.0.0"` in all three files
- `aliases.json` remains byte-identical to a fresh generator run with the new key, so the determinism property in its writer's docstring still holds

## Notes

`alias_of` is documented as **not** guaranteed on a deprecated record. Fifteen deprecated ids carry `null` because SPDX replaced them with something other than a single plain identifier, so the contract promises only that a non-null value resolves, and a test pins that.
